### PR TITLE
fix(tup-ui): load CSS from correct path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,5 @@ jobs:
       # Lint/test/build any apps and libs that have been impacted by the diff.
       - run: npx nx affected --target=lint --parallel=3
       - run: npx nx affected --target=test --parallel=3 --ci --code-coverage
+      - run: npx nx build core-components
       - run: npx nx affected --target=build --parallel=3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,5 @@ jobs:
       # Lint/test/build any apps and libs that have been impacted by the diff.
       - run: npx nx affected --target=lint --parallel=3
       - run: npx nx affected --target=test --parallel=3 --ci --code-coverage
-      - run: npx nx build core-components
+      - run: npx nx build core-styles
       - run: npx nx affected --target=build --parallel=3

--- a/apps/tup-ui/src/index.css
+++ b/apps/tup-ui/src/index.css
@@ -1,23 +1,23 @@
 /* SETTINGS */
-@import url('@tacc/core-styles/lib/_imports/settings/border.css');
+@import url('@tacc/core-styles/dist/settings/border.css');
 /* below, import local styles (if any) */
 
 /* GENERIC */
-/* @import url('@tacc/core-styles/lib/_imports/generics/*.css'); */
+/* @import url('@tacc/core-styles/dist/generics/*.css'); */
 /* below, import local styles (if any) */
 
 /* ELEMENTS */
-/* @import url('@tacc/core-styles/lib/_imports/elements/*.css'); */
+/* @import url('@tacc/core-styles/dist/elements/*.css'); */
 /* below, import local styles (if any) */
 
 /* OBJECTS */
-@import url('@tacc/core-styles/lib/_imports/objects/o-flex-item-table-wrap.css');
+@import url('@tacc/core-styles/dist/objects/o-flex-item-table-wrap.css');
 /* below, import local styles (if any) */
 
 /* COMPONENTS */
-/* @import url('@tacc/core-styles/lib/_imports/components/*.css'); */
+/* @import url('@tacc/core-styles/dist/components/*.css'); */
 /* below, import local styles (if any) */
 
 /* TRUMPS */
-/* @import url('@tacc/core-styles/lib/_imports/trumps/*.css'); */
+/* @import url('@tacc/core-styles/dist/trumps/*.css'); */
 /* below, import local styles (if any) */

--- a/apps/tup-ui/vite.config.ts
+++ b/apps/tup-ui/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       ),
       '@tacc/core-styles': path.resolve(
         __dirname,
-        '../../libs/core-styles/src/'
+        '../../libs/core-styles/'
       ),
     },
   },

--- a/apps/tup-ui/vite.config.ts
+++ b/apps/tup-ui/vite.config.ts
@@ -11,10 +11,7 @@ export default defineConfig({
         __dirname,
         '../../libs/core-components/src/index.ts'
       ),
-      '@tacc/core-styles': path.resolve(
-        __dirname,
-        '../../libs/core-styles/'
-      ),
+      '@tacc/core-styles': path.resolve(__dirname, '../../libs/core-styles/'),
     },
   },
   build: {


### PR DESCRIPTION
## Overview:

Configure tup-ui to load styles from the correct path.

## Related:

- caused by https://github.com/TACC/tup-ui/pull/2

## Changes:

- changed root path for `@tacc/core-styles` import
- changed bad paths for tup-ui CSS imports

## Testing:

1. Build core-styles i.e. `npx nx build core-styles`.
2. Serve tup-ui i.e. `npx nx serve tup-ui`.
3. Verify app loads without error.
4. Pipeline should have zero errors.

## UI:

![Screen Shot 2022-06-10 at 10 36 08](https://user-images.githubusercontent.com/62723358/173100906-fd7e655d-992a-48a0-8427-24e35961d540.png)

## Notes:

This was committed directly to branch [task/tup-272-core-components](https://github.com/TACC/tup-ui/tree/task/tup-272-core-components) to fix the problem so we could make progress on that branch.