### PR TITLE
feat(core-styles): tup-308, new global color

### DIFF
--- a/libs/core-styles/src/lib/_imports/settings/color.css
+++ b/libs/core-styles/src/lib/_imports/settings/color.css
@@ -50,6 +50,7 @@
   --global-color-warning--weak: #c7ce1d20;
   --global-color-warning--alt: var(--global-color-accent--dark);
   --global-color-warning--alt-weak: var(--global-color-accent--weak);
+  --global-color-danger--dark: #ab1717;
   --global-color-danger--normal: #eb6e6e;
   --global-color-danger--weak: #eb6e6e20;
 


### PR DESCRIPTION
## Overview / Changes

Add new color that:
- CMS forms will use
- fits among existing global colors

## Related

- [TUP-308](https://jira.tacc.utexas.edu/browse/TUP-308)
- required by https://github.com/TACC/Core-CMS/pull/498

## Testing / UI

https://github.com/TACC/Core-CMS/pull/498

## Notes

The original plan to make this change came from [TACC/Core-CMS#501](https://github.com/TACC/Core-CMS/pull/501/files#diff-e9414234ff809b486ac95af5c2c1b4fd1cf2dd7618564c667529baa52133d99fR68-R69), and it will be used in https://github.com/TACC/Core-CMS/pull/498.

Released in [@tacc/core-styles@0.7.0-beta](https://www.npmjs.com/package/@tacc/core-styles/v/0.7.0-beta) via [core-styles/v0.7.0-beta](https://github.com/TACC/tup-ui/compare/core-styles/v0.7.0-beta).