### PR TITLE
Task/fp 1721 image captions and offsets

### DIFF
--- a/libs/core-styles/src/.postcssrc.base.yml
+++ b/libs/core-styles/src/.postcssrc.base.yml
@@ -3,8 +3,6 @@ plugins:
     path:
       - 'src/lib'
 
-  postcss-extend: {}
-
   # https://github.com/TACC/Core-CMS/blob/70a1ca3/conf/css/.postcssrc.yml#L6-L12
   postcss-env-function:
     importFrom:
@@ -31,6 +29,8 @@ plugins:
           exclude: true
         mergeRules:
           exclude: true
+
+  postcss-extend: {}
 
   postcss-banner:
     banner: 'no build id'

--- a/libs/core-styles/src/lib/_imports/components/bootstrap.figure.css
+++ b/libs/core-styles/src/lib/_imports/components/bootstrap.figure.css
@@ -1,22 +1,19 @@
 /*
 Figure (Bootstrap)
 
-Add to Bootstrap styles. See:
+Add to Bootstrap styles.
 
+Reference:
 - [Bootstrap Figures](https://getbootstrap.com/docs/4.0/content/figures/)
-- [HTML: Figure | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)
-- [HTML: Figcaption | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption)
 
 Styleguide Components.Bootstrap.Figure
 */
+@import url("_imports/tools/x-figure.css");
 
 .figure > a > img,
 .figure > img {
-  margin-bottom: 20px;
+  @extend %x-figure-img;
 }
 .figure-caption {
-  color: var(--global-color-primary--dark);
-  font-size: var(--global-font-size--medium);
-  border-top: var(--global-border-width--normal) solid var(--global-color-primary--normal);
-  padding-top: 12px;
+  @extend %x-figcaption;
 }

--- a/libs/core-styles/src/lib/_imports/objects/o-section.css
+++ b/libs/core-styles/src/lib/_imports/objects/o-section.css
@@ -48,6 +48,12 @@ Styleguide Objects.Section
 
   padding-block: var(--padding-block); /* ~avg. from design docs */
 }
+/* To clear section floats */
+.o-section::after {
+  display: block;
+  content: '';
+  clear: both;
+}
 /* To distinguish nested sections */
 .o-section .o-section {
   padding-block: 1em;

--- a/libs/core-styles/src/lib/_imports/tools/x-figure.css
+++ b/libs/core-styles/src/lib/_imports/tools/x-figure.css
@@ -14,7 +14,7 @@ Styleguide Tools.ExtendsAndMixins.Figure
   margin-bottom: 20px;
 }
 %x-figcaption {
-  color: var(--global-color-primary--dark);
+  opacity: 0.75;
   font-size: var(--global-font-size--medium);
   border-top: var(--global-border-width--normal) solid var(--global-color-primary--normal);
   padding-top: 12px;

--- a/libs/core-styles/src/lib/_imports/tools/x-figure.css
+++ b/libs/core-styles/src/lib/_imports/tools/x-figure.css
@@ -1,0 +1,21 @@
+/*
+Figure (Bootstrap)
+
+Provide reusable Figure styles.
+
+Reference:
+- [HTML: Figure | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)
+- [HTML: Figcaption | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption)
+
+Styleguide Tools.ExtendsAndMixins.Figure
+*/
+
+%x-figure-img {
+  margin-bottom: 20px;
+}
+%x-figcaption {
+  color: var(--global-color-primary--dark);
+  font-size: var(--global-font-size--medium);
+  border-top: var(--global-border-width--normal) solid var(--global-color-primary--normal);
+  padding-top: 12px;
+}


### PR DESCRIPTION
## Overview

Create and use mixins of styles for figure images and captions.

## Related

- [FP-1721](https://jira.tacc.utexas.edu/browse/FP-1721)
- required by https://github.com/TACC/Core-CMS/pull/510
- mimicked and superseded by https://github.com/TACC/Core-Styles/pull/33

## Changes

- change config to extend styles **after** parsing them﹡
- extend bootstrap figures with new mixins
- allow sections to clear floated children
    - this helps with testing, and fixes an unreported bug
- add new figure mixin
    - use opacity to change color of text, so it is legible on all backgrounds

<sup>﹡ Required to build/use new mixins properly and does not seem foul.</sup>

## Testing / UI

https://github.com/TACC/Core-CMS/pull/510

## Notes

Figure styles were re-usable before (via https://github.com/TACC/Core-Styles/pull/16/), but that solution assumed these styles for **all** figures, thus resulting in a bug (fixed by https://github.com/TACC/tup-ui/pull/17). This new solution does not make that assumption.