### PR TITLE
fix(core-styles): drop ineffectual prettierignore

### DIFF
--- a/libs/core-styles/.prettierignore
+++ b/libs/core-styles/.prettierignore
@@ -1,5 +1,0 @@
-# Add files here to ignore them from prettier formatting WHEN CWD IS THIS FOLDER
-
-# do not format stylesheets until `nx format` ignores multiple blank lines
-# https://prettier.io/docs/en/rationale.html#empty-lines
-*.css


### PR DESCRIPTION
## Overview

Remove a `.prettierignore` (in core-styles) because it has no effect.

_The root `.prettierignore` does the job._

## Related

N/A

## Changes

- delete `libs/core-styles/.prettierignore`

## Testing / UI

N/A