### PR TITLE
fix(.github): action error, missing params

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Check linting/formatting of workspace files
       - run: npx nx workspace-lint
-      - run: npx nx format:check
+      - run: npx nx format:check --base=main --head=HEAD
 
       # Lint/test/build any apps and libs that have been impacted by the diff.
       - run: npx nx affected --target=lint --parallel=3


### PR DESCRIPTION
## Overview

Fix job run error: https://github.com/TACC/tup-ui/actions/runs/3244072147/jobs/5319717716

**⚠️ The fix did NOT succeed. A new build has error with my code.**

## Related

N/A

## Changes

- add missing parameters (that were complained about in error)

## Testing

Unsure. Easiest solution is to merge (another maybe make another change to `main`).

## UI

N/A

## Notes

I followed the paper trail for the warnings at the bottom of [the action fail](https://github.com/TACC/tup-ui/actions/runs/3244072147), but I did not find relevant configuration to change to resolve the errors. We do not seem to set `node12` nor use the `set output` commands.