### PR TITLE
hotfix/TUP Update Value types in System_Monitor hook

### DIFF
--- a/libs/tup-hooks/src/index.ts
+++ b/libs/tup-hooks/src/index.ts
@@ -77,7 +77,7 @@ export type SystemMonitorRawSystem = {
   running?: number;
   waiting?: number;
   in_maintenance?: boolean;
-  next_maintenance?: boolean;
+  next_maintenance?: string;
   reservations?: [Reservation];
 };
 

--- a/libs/tup-testing/src/mocks/fixtures/system_monitor.ts
+++ b/libs/tup-testing/src/mocks/fixtures/system_monitor.ts
@@ -72,7 +72,7 @@ export const rawSystemMonitorOutput = [
     running: 243,
     waiting: 0,
     in_maintenance: false,
-    next_maintenance: null,
+    next_maintenance: "2022-12-06T08:00:00-06:00",
     reservations: [
       {
         name: 'additional_gpus_testing',


### PR DESCRIPTION
## Overview:

Change value type for next_maintenance for system_monitor hook

## Related:
[TUP-360](https://jira.tacc.utexas.edu/browse/TUP-360)

## Changes:
Update next_maintenance in hook index and added a date to the system_monitor fixture for later testing.

## Testing:

1. Go to cep.test and make sure the system_monitor table renders matching this response https://tap.tacc.utexas.edu/status/ 

** You may have to refresh cep.test and the endpoint at the same time to get the most accurate results.

## UI:
<img width="1508" alt="Screen Shot 2022-11-29 at 3 01 08 PM" src="https://user-images.githubusercontent.com/96220951/204646769-b311d3f8-c2c9-4e2c-ab2e-5675d9d1917c.png">


## Notes:
