### PR TITLE
hotfix/TUP-Remove-Longhorn-From-Sys-Mon

### DIFF
--- a/libs/tup-components/src/system_monitor/SystemMonitor.test.tsx
+++ b/libs/tup-components/src/system_monitor/SystemMonitor.test.tsx
@@ -31,4 +31,8 @@ describe('System Monitor Component', () => {
     const { getByText } = testRender(<SystemMonitor />);
     await waitFor(() => expect(getByText('Frontera')).toBeDefined());
   });
+  it('should not display the Longhorn system name', async () => {
+    const { getByText } = testRender(<SystemMonitor />);
+    await waitFor(() => expect(!getByText('Longhorn')).toBeDefined());
+  });
 });

--- a/libs/tup-components/src/system_monitor/SystemMonitor.tsx
+++ b/libs/tup-components/src/system_monitor/SystemMonitor.tsx
@@ -8,6 +8,7 @@ import {
 import { Display, Operational, Load } from './SystemMonitorCells';
 import { SystemMonitorRawSystem, useSystemMonitor } from '@tacc/tup-hooks';
 import styles from './SystemMonitor.module.css';
+import { debug } from 'console';
 
 export const isSystemDown = (rawSystem: SystemMonitorRawSystem): boolean => {
   if (
@@ -76,7 +77,7 @@ export const SystemMonitor: React.FC<{ display_name?: Array<string> }> = () => {
         {...getTableProps()}
         // Emulate <InfiniteScrollTable> and its use of `o-fixed-header-table`
         // TODO: Create global table styles & Make <InfiniteScrollTable> use them
-        className={`multi-system InfiniteScrollTable o-fixed-header-table ${styles['root']}`}
+        className={`multi-system o-fixed-header-table ${styles['root']}`}
       >
         <thead>
           {headerGroups.map((headerGroup) => (
@@ -93,6 +94,8 @@ export const SystemMonitor: React.FC<{ display_name?: Array<string> }> = () => {
         <tbody {...getTableBodyProps()} className={styles['rows']}>
           {rows.length ? (
             rows.map((row, idx) => {
+              // removes Longhorn system now that it's retired. Can remove when it's taken off TAP system endpoint
+              rows.filter((rows) => !{ rows: { display_name: 'Longhorn' } });
               prepareRow(row);
               return (
                 <tr {...row.getRowProps()}>

--- a/libs/tup-components/src/system_monitor/SystemMonitor.tsx
+++ b/libs/tup-components/src/system_monitor/SystemMonitor.tsx
@@ -93,18 +93,19 @@ export const SystemMonitor: React.FC<{ display_name?: Array<string> }> = () => {
         </thead>
         <tbody {...getTableBodyProps()} className={styles['rows']}>
           {rows.length ? (
-            rows.map((row, idx) => {
+            rows
               // removes Longhorn system now that it's retired. Can remove when it's taken off TAP system endpoint
-              rows.filter((rows) => !{ rows: { display_name: 'Longhorn' } });
-              prepareRow(row);
-              return (
-                <tr {...row.getRowProps()}>
-                  {row.cells.map((cell) => (
-                    <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
-                  ))}
-                </tr>
-              );
-            })
+              .filter((rows) => rows.display_name !== 'Longhorn')
+              .map((row, idx) => {
+                prepareRow(row);
+                return (
+                  <tr {...row.getRowProps()}>
+                    {row.cells.map((cell) => (
+                      <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+                    ))}
+                  </tr>
+                );
+              })
           ) : (
             <tr>
               <td colSpan={5}>No systems being monitored</td>


### PR DESCRIPTION
## Overview:
Remove Longhorn from system monitor list on the front end. Added unit test to make sure it does not display.

## Related:

- [TUP-360](https://jira.tacc.utexas.edu/browse/TUP-360)

## Changes:

- Added filter to map of rows in the system monitor component. 
- Added unit test to make sure Longhorn does not display.
- Removed infinite scroll table class

## Testing:

1. Go to [http://localhost:8000/dashboard/](http://localhost:8000/dashboard/) and go to dashboard
2. Check that Longhorn is no longer listed in the system monitor table. 

## UI:
<img width="1335" alt="Screen Shot 2022-12-01 at 12 51 04 PM" src="https://user-images.githubusercontent.com/96220951/205135796-69d94c48-c7ca-43c9-b378-cc0132709d80.png">

## Notes:
