### PR TITLE
feat(tup-cms): cmd news

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -78,6 +78,10 @@ LOGO = [
     "True"
 ]
 
+########################
+# DJANGO
+########################
+
 AUTHENTICATION_BACKENDS = ['django.contrib.auth.backends.ModelBackend', 'apps.dashboard.backend.TupServicesBackend']
 TUP_SERVICES_URL = "https://dev.tup-services.tacc.utexas.edu"
 LOGIN_URL = "/dashboard/login"


### PR DESCRIPTION
## Overview

- Install News plugin.
- Add CMD News.
- Draft styles for Multimedia articles.

## Related

- [**TUP-118**](https://jira.tacc.utexas.edu/browse/TUP-118) ([TUP-258](https://jira.tacc.utexas.edu/browse/TUP-258))
- requires https://github.com/TACC/Core-CMS/pull/572

## Changes

ⓘ Ignore the diff, because it became minimal as the base branch and this branch were synced.

- changed CMS image to one with newer News styles and fixes
- added settings to install News
- added URLs to support News

## Testing

1. Open https://dev.tup.tacc.utexas.edu/news/latest-news/.
2. Play around.*

<sup>* [user guide](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=182911007), [admin guide](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=276662476)</sup>

## UI

See:
- https://github.com/TACC/Core-CMS/pull/572
- https://dev.tup.tacc.utexas.edu/news/latest-news/2020/11/07/final-dance-unequal-black-hole-partners/
