### PR TITLE
fix(tup-cms): full-height edit plugin inside text

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:4008682
+FROM taccwma/core-cms:f1ba69f
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Fix CMS bug adding plugin within a Text plugin.

## Related

- [FP-1949](https://jira.tacc.utexas.edu/browse/FP-1949)
- relies on https://github.com/TACC/Core-CMS/pull/573

## Changes

- changed CMS image

## Testing & UI

Deployed to https://dev.tup.tacc.utexas.edu/ (2022-12-09).

For details, see https://github.com/TACC/Core-CMS/pull/573.

My tup-cms local test:
![tup-cms fp-1949](https://user-images.githubusercontent.com/62723358/206765538-7318576a-1934-4fcb-9e2e-d51f1c8b92c9.png)
