### PR TITLE
task/TUP-377: Add project user list/detail view

### DIFF
--- a/apps/tup-ui/src/pages/ProjectView/ProjectMember/ProjectMember.tsx
+++ b/apps/tup-ui/src/pages/ProjectView/ProjectMember/ProjectMember.tsx
@@ -1,18 +1,17 @@
-import { Section } from '@tacc/core-components';
-import { PageLayout } from '@tacc/tup-components';
+import { UserDetail } from '@tacc/tup-components';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
 const ProjectMember: React.FC = () => {
-  const { username } = useParams<{
+  const { username, projectId } = useParams<{
     projectId: string;
     username: string;
   }>();
   return (
-    <Section
-      header={`Project member: ${username}`}
-      content={<PageLayout />}
-    ></Section>
+    <UserDetail
+      projectId={parseInt(projectId ?? '')}
+      username={username ?? ''}
+    />
   );
 };
 

--- a/apps/tup-ui/src/pages/ProjectView/ProjectView.tsx
+++ b/apps/tup-ui/src/pages/ProjectView/ProjectView.tsx
@@ -1,21 +1,20 @@
-import { Section } from '@tacc/core-components';
-import { PageLayout } from '@tacc/tup-components';
+import { PageLayout, RequireAuth } from '@tacc/tup-components';
 import React from 'react';
 import { Outlet, useParams } from 'react-router-dom';
+import { UserList } from '@tacc/tup-components';
 
 const ProjectView: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>();
+  if (!projectId) return <div>No project selected.</div>;
+
   return (
-    <Section
-      header={`Project View: ${projectId}`}
-      content={
-        <PageLayout
-          top={<div>header placeholder</div>}
-          left={<div>user list placeholder</div>}
-          right={<Outlet />}
-        />
-      }
-    ></Section>
+    <RequireAuth>
+      <PageLayout
+        top={<div>header placeholder</div>}
+        left={<UserList projectId={parseInt(projectId)} />}
+        right={<Outlet />}
+      ></PageLayout>
+    </RequireAuth>
   );
 };
 

--- a/libs/core-wrappers/src/lib/Navbar/Navbar.module.css
+++ b/libs/core-wrappers/src/lib/Navbar/Navbar.module.css
@@ -25,10 +25,13 @@
 }
 
 .nav-text {
-  padding-left: 10px;
   font-size: 1.2rem;
   font-weight: 500;
   pointer-events: none;
   color: var(--global-color-primary--x-dark);
   text-decoration: none;
+}
+
+.nav-icon {
+  margin-right: 1rem;
 }

--- a/libs/core-wrappers/src/lib/Navbar/Navbar.tsx
+++ b/libs/core-wrappers/src/lib/Navbar/Navbar.tsx
@@ -4,16 +4,21 @@ import { Icon } from '@tacc/core-components';
 import styles from './Navbar.module.css';
 
 export const NavItem: React.FC<
-  React.PropsWithChildren<{ to: string; icon?: string; end?: boolean }>
-> = ({ to, icon, end, children }) => (
-  <NavLink to={to} end={end} className={styles['nav-link']}>
+  React.PropsWithChildren<{
+    to: string;
+    icon?: string;
+    end?: boolean;
+    className?: string;
+  }>
+> = ({ to, icon, end, className, children }) => (
+  <NavLink to={to} end={end} className={`${styles['nav-link']} ${className}`}>
     {({ isActive }) => (
       <div
         className={`${styles['nav-content']} ${
           isActive ? styles['nav-active'] : ''
         }`}
       >
-        {icon && <Icon name={icon} />}
+        {icon && <Icon name={icon} className={styles['nav-icon']} />}
         {/* we'll want to set name based on the app */}
         <span className={styles['nav-text']}>{children}</span>
       </div>

--- a/libs/tup-components/src/projects/index.ts
+++ b/libs/tup-components/src/projects/index.ts
@@ -1,3 +1,5 @@
 export { default as ProjectsTable } from './ProjectsTable';
 export { default as ProjectsDashboard } from './ProjectsDashboard';
 export { default as ProjectsLayout } from './ProjectsLayout';
+export { default as UserList } from './users/UserList/UserList';
+export { default as UserDetail } from './users/UserDetail/UserDetail';

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
@@ -1,0 +1,36 @@
+.user-detail-container {
+    width: 50%;
+}
+
+.user-info-banner {
+    display: flex;
+    padding: 2rem;
+    background: #F4F4F4;
+    align-items: center;
+    gap: 2rem;
+}
+
+.user-fullname {
+    font-size: 21px;
+    font-weight: bold;
+}
+
+.user-details {
+    font-size: 1.2rem;
+    font-weight: bold;
+}
+
+.user-details > .user-details-light {
+    color: #707070;
+}
+
+.manage-user-container {
+    display: flex;
+    padding: 2rem;
+    justify-content: space-between;
+}
+
+.usage-table {
+    width: 100%;
+    padding: 2rem;
+}

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
@@ -34,3 +34,8 @@
     width: 100%;
     padding: 2rem;
 }
+
+.usage-table--loading {
+    width: 100%;
+    height: 200px;
+}

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
@@ -4,14 +4,14 @@
 
 .user-info-banner {
     display: flex;
-    padding: 2rem;
+    padding: 20px;
     background: #F4F4F4;
     align-items: center;
-    gap: 2rem;
+    gap: 20px;
 }
 
 .user-fullname {
-    font-size: 21px;
+    font-size: 2.1rem;
     font-weight: bold;
 }
 
@@ -26,13 +26,13 @@
 
 .manage-user-container {
     display: flex;
-    padding: 2rem;
+    padding: 20px;
     justify-content: space-between;
 }
 
 .usage-table {
     width: 100%;
-    padding: 2rem;
+    padding: 20px;
 }
 
 .usage-table--loading {

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner } from '@tacc/core-components';
 import {
   useProjectUsers,
   useProjectUsage,
@@ -11,13 +12,10 @@ const UserRoleSelector: React.FC = () => (
 
 const RemoveUser: React.FC = () => <div>(User removal placeholder)</div>;
 
-const UserDetail: React.FC<{ projectId: number; username: string }> = ({
+const UsageTable: React.FC<{ projectId: number; username: string }> = ({
   projectId,
   username,
 }) => {
-  const projectUsers = useProjectUsers(projectId);
-  const data = projectUsers.data ?? [];
-  const user = data.find((user) => user.username === username);
   const usage = useProjectUsage(projectId, username);
   const usageData = usage.data;
 
@@ -34,6 +32,43 @@ const UserDetail: React.FC<{ projectId: number; username: string }> = ({
         return `${Math.floor(percentage)}%`;
     }
   };
+
+  if (usage.isLoading || !usageData)
+    return (
+      <div className={styles['usage-table--loading']}>
+        <LoadingSpinner />
+      </div>
+    );
+
+  return (
+    <table className={styles['usage-table']}>
+      <thead>
+        <tr>
+          <th>System</th>
+          <th>Individual Usage</th>
+          <th>% of Allocation</th>
+        </tr>
+      </thead>
+      <tbody>
+        {usageData?.map((resource) => (
+          <tr key={resource.resource}>
+            <th>{resource.resource}</th>
+            <th>{resource.used}</th>
+            <th>{getPercentUsage(resource)}</th>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+const UserDetail: React.FC<{ projectId: number; username: string }> = ({
+  projectId,
+  username,
+}) => {
+  const projectUsers = useProjectUsers(projectId);
+  const data = projectUsers.data ?? [];
+  const user = data.find((user) => user.username === username);
 
   return user ? (
     <div className={styles['user-detail-container']}>
@@ -56,25 +91,7 @@ const UserDetail: React.FC<{ projectId: number; username: string }> = ({
           <RemoveUser />
         </div>
       </div>
-
-      <table className={styles['usage-table']}>
-        <thead>
-          <tr>
-            <th>System</th>
-            <th>Individual Usage</th>
-            <th>% of Allocation</th>
-          </tr>
-        </thead>
-        <tbody>
-          {usageData?.map((resource) => (
-            <tr key={resource.resource}>
-              <th>{resource.resource}</th>
-              <th>{resource.used}</th>
-              <th>{getPercentUsage(resource)}</th>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <UsageTable username={username} projectId={projectId} />
     </div>
   ) : null;
 };

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -1,0 +1,93 @@
+import {
+  useProjectUsers,
+  useProjectUsage,
+  UsagePerResource,
+} from '@tacc/tup-hooks';
+
+const UserRoleSelector: React.FC = () => (
+  <div>(User role selector placeholder)</div>
+);
+
+const RemoveUser: React.FC = () => <div>(User removal placeholder)</div>;
+
+const UserDetail: React.FC<{ projectId: number; username: string }> = ({
+  projectId,
+  username,
+}) => {
+  const projectUsers = useProjectUsers(projectId);
+  const data = projectUsers.data ?? [];
+  const user = data.find((user) => user.username === username);
+  const usage = useProjectUsage(projectId, username);
+  const usageData = usage.data;
+
+  const getPercentUsage = (resource: UsagePerResource): string => {
+    const percentage = (resource.used / resource.total) * 100;
+    switch (true) {
+      case percentage === 0:
+        return '0%';
+      case percentage < 1:
+        return '<1%';
+      case isNaN(percentage):
+        return '0%';
+      default:
+        return `${Math.floor(percentage)}%`;
+    }
+  };
+
+  return user ? (
+    <div style={{ width: '50%' }}>
+      <div
+        style={{
+          display: 'flex',
+          padding: '2rem',
+          background: '#F4F4F4',
+          alignItems: 'center',
+          gap: '2rem',
+        }}
+      >
+        <span style={{ fontSize: '21px', fontWeight: 'bold' }}>
+          {user.firstName} {user.lastName}
+        </span>
+        <span style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+          <span style={{ color: '#707070' }}>Username:</span> {user.username} |{' '}
+          <span style={{ color: '#707070' }}>Email</span>: {user.email}
+        </span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          padding: '2rem',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div>
+          <UserRoleSelector />
+        </div>
+        <div>
+          <RemoveUser />
+        </div>
+      </div>
+
+      <table className=" " style={{ width: '100%', padding: '2rem' }}>
+        <thead>
+          <tr>
+            <th>System</th>
+            <th>Individual Usage</th>
+            <th>% of Allocation</th>
+          </tr>
+        </thead>
+        <tbody>
+          {usageData?.map((resource) => (
+            <tr key={resource.resource}>
+              <th>{resource.resource}</th>
+              <th>{resource.used}</th>
+              <th>{getPercentUsage(resource)}</th>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ) : null;
+};
+
+export default UserDetail;

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -53,7 +53,7 @@ const UsageTable: React.FC<{ projectId: number; username: string }> = ({
         {usageData?.map((resource) => (
           <tr key={resource.resource}>
             <th>{resource.resource}</th>
-            <th>{resource.used}</th>
+            <th>{resource.used} SU</th>
             <th>{getPercentUsage(resource)}</th>
           </tr>
         ))}

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -3,6 +3,7 @@ import {
   useProjectUsage,
   UsagePerResource,
 } from '@tacc/tup-hooks';
+import styles from './UserDetail.module.css';
 
 const UserRoleSelector: React.FC = () => (
   <div>(User role selector placeholder)</div>
@@ -35,31 +36,19 @@ const UserDetail: React.FC<{ projectId: number; username: string }> = ({
   };
 
   return user ? (
-    <div style={{ width: '50%' }}>
-      <div
-        style={{
-          display: 'flex',
-          padding: '2rem',
-          background: '#F4F4F4',
-          alignItems: 'center',
-          gap: '2rem',
-        }}
-      >
-        <span style={{ fontSize: '21px', fontWeight: 'bold' }}>
+    <div className={styles['user-detail-container']}>
+      <div className={styles['user-info-banner']}>
+        <span className={styles['user-fullname']}>
           {user.firstName} {user.lastName}
         </span>
-        <span style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
-          <span style={{ color: '#707070' }}>Username:</span> {user.username} |{' '}
-          <span style={{ color: '#707070' }}>Email</span>: {user.email}
+        <span className={styles['user-details']}>
+          <span className={styles['user-details-light']}>Username:</span>{' '}
+          {user.username} |{' '}
+          <span className={styles['user-details-light']}>Email</span>:{' '}
+          {user.email}
         </span>
       </div>
-      <div
-        style={{
-          display: 'flex',
-          padding: '2rem',
-          justifyContent: 'space-between',
-        }}
-      >
+      <div className={styles['manage-user-container']}>
         <div>
           <UserRoleSelector />
         </div>
@@ -68,7 +57,7 @@ const UserDetail: React.FC<{ projectId: number; username: string }> = ({
         </div>
       </div>
 
-      <table className=" " style={{ width: '100%', padding: '2rem' }}>
+      <table className={styles['usage-table']}>
         <thead>
           <tr>
             <th>System</th>

--- a/libs/tup-components/src/projects/users/UserDetail/index.ts
+++ b/libs/tup-components/src/projects/users/UserDetail/index.ts
@@ -1,0 +1,1 @@
+export { default as userDetail } from './UserDetail';

--- a/libs/tup-components/src/projects/users/UserDetail/userDetail.spec.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/userDetail.spec.tsx
@@ -1,0 +1,38 @@
+import UserDetail from './UserDetail';
+import { testRender } from '@tacc/tup-testing';
+import { screen, within } from '@testing-library/react';
+
+describe('UserDetailComponent', () => {
+  it('should render user details with >1% usage', async () => {
+    testRender(<UserDetail projectId={59184} username="jarosenb" />);
+    const dataQuery = await screen.findByText('Lonestar6');
+    const row = dataQuery.closest('tr') as HTMLElement;
+    const rowQuery = within(row);
+
+    expect(rowQuery.getByText('Lonestar6')).toBeDefined();
+    expect(rowQuery.getByText('5')).toBeDefined();
+    expect(rowQuery.getByText('50%')).toBeDefined();
+  });
+
+  it('should render user details with <1% usage', async () => {
+    testRender(<UserDetail projectId={59184} username="smassie" />);
+    const dataQuery = await screen.findByText('Lonestar6');
+    const row = dataQuery.closest('tr') as HTMLElement;
+    const rowQuery = within(row);
+
+    expect(rowQuery.getByText('Lonestar6')).toBeDefined();
+    expect(rowQuery.getByText('0.01')).toBeDefined();
+    expect(rowQuery.getByText('<1%')).toBeDefined();
+  });
+
+  it('should render user details with 0% usage', async () => {
+    testRender(<UserDetail projectId={59184} username="vg5726" />);
+    const dataQuery = await screen.findByText('Lonestar6');
+    const row = dataQuery.closest('tr') as HTMLElement;
+    const rowQuery = within(row);
+
+    expect(rowQuery.getByText('Lonestar6')).toBeDefined();
+    expect(rowQuery.getByText('0')).toBeDefined();
+    expect(rowQuery.getByText('0%')).toBeDefined();
+  });
+});

--- a/libs/tup-components/src/projects/users/UserDetail/userDetail.spec.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/userDetail.spec.tsx
@@ -10,7 +10,7 @@ describe('UserDetailComponent', () => {
     const rowQuery = within(row);
 
     expect(rowQuery.getByText('Lonestar6')).toBeDefined();
-    expect(rowQuery.getByText('5')).toBeDefined();
+    expect(rowQuery.getByText('5 SU')).toBeDefined();
     expect(rowQuery.getByText('50%')).toBeDefined();
   });
 
@@ -21,7 +21,7 @@ describe('UserDetailComponent', () => {
     const rowQuery = within(row);
 
     expect(rowQuery.getByText('Lonestar6')).toBeDefined();
-    expect(rowQuery.getByText('0.01')).toBeDefined();
+    expect(rowQuery.getByText('0.01 SU')).toBeDefined();
     expect(rowQuery.getByText('<1%')).toBeDefined();
   });
 
@@ -32,7 +32,7 @@ describe('UserDetailComponent', () => {
     const rowQuery = within(row);
 
     expect(rowQuery.getByText('Lonestar6')).toBeDefined();
-    expect(rowQuery.getByText('0')).toBeDefined();
+    expect(rowQuery.getByText('0 SU')).toBeDefined();
     expect(rowQuery.getByText('0%')).toBeDefined();
   });
 });

--- a/libs/tup-components/src/projects/users/UserList/UserList.module.css
+++ b/libs/tup-components/src/projects/users/UserList/UserList.module.css
@@ -1,0 +1,8 @@
+.user-navitem > div {
+    height: 25px;
+}
+
+.separator {
+    border: 1px solid  #C7C7C7;
+    margin-left: 20px;
+}

--- a/libs/tup-components/src/projects/users/UserList/UserList.module.css
+++ b/libs/tup-components/src/projects/users/UserList/UserList.module.css
@@ -6,3 +6,8 @@
     border: 1px solid  #C7C7C7;
     margin-left: 20px;
 }
+
+.loading-placeholder {
+    height: 100%;
+    width: 175px;
+}

--- a/libs/tup-components/src/projects/users/UserList/UserList.spec.tsx
+++ b/libs/tup-components/src/projects/users/UserList/UserList.spec.tsx
@@ -1,0 +1,12 @@
+import UserList from './UserList';
+import { testRender } from '@tacc/tup-testing';
+import { screen } from '@testing-library/react';
+
+describe('userListComponent', () => {
+  it('should render user list with all members plus delegate/PI', async () => {
+    testRender(<UserList projectId={59184} />);
+    const dataQuery = await screen.findAllByText(/Rosenberg/);
+    expect(dataQuery.length).toBe(2);
+    expect(screen.getAllByRole('link').length).toBe(5);
+  });
+});

--- a/libs/tup-components/src/projects/users/UserList/UserList.tsx
+++ b/libs/tup-components/src/projects/users/UserList/UserList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useProjectUsers } from '@tacc/tup-hooks';
 import { Navbar, NavItem } from '@tacc/core-wrappers';
+import styles from './UserList.module.css';
 
 const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
   const projectUsers = useProjectUsers(projectId);
@@ -10,25 +11,34 @@ const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
 
   return (
     <Navbar>
-      <div style={{ borderBottom: '1px solid black' }}>
-        {pi && (
-          <NavItem to={`/projects/${projectId}/${pi?.username}`} end>
-            PI: {pi.firstName} {pi.lastName}
-          </NavItem>
-        )}
-        {delegate && (
-          <NavItem to={`/projects/${projectId}/${delegate?.username}`} end>
-            Delegate: {delegate?.firstName} {delegate?.lastName}
-          </NavItem>
-        )}
-      </div>
+      {pi && (
+        <NavItem
+          to={`/projects/${projectId}/${pi?.username}`}
+          end
+          className={styles['user-navitem']}
+        >
+          PI: {pi.firstName} {pi.lastName} ({pi.username})
+        </NavItem>
+      )}
+      {delegate && (
+        <NavItem
+          to={`/projects/${projectId}/${delegate?.username}`}
+          end
+          className={styles['user-navitem']}
+        >
+          Delegate: {delegate?.firstName} {delegate?.lastName} (
+          {delegate.username})
+        </NavItem>
+      )}
+      <div className={styles['separator']}></div>
       {data.map((user) => (
         <NavItem
           to={`/projects/${projectId}/${user.username}`}
           end
+          className={styles['user-navitem']}
           key={user.username}
         >
-          {user.firstName} {user.lastName}
+          {user.firstName} {user.lastName} ({user.username})
         </NavItem>
       ))}
     </Navbar>

--- a/libs/tup-components/src/projects/users/UserList/UserList.tsx
+++ b/libs/tup-components/src/projects/users/UserList/UserList.tsx
@@ -2,12 +2,20 @@ import React from 'react';
 import { useProjectUsers } from '@tacc/tup-hooks';
 import { Navbar, NavItem } from '@tacc/core-wrappers';
 import styles from './UserList.module.css';
+import { LoadingSpinner } from '@tacc/core-components';
 
 const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
   const projectUsers = useProjectUsers(projectId);
   const data = projectUsers.data ?? [];
   const pi = data.find((user) => user.role === 'PI');
   const delegate = data.find((user) => user.role === 'Delegate');
+
+  if (projectUsers.isLoading)
+    return (
+      <div className={styles['loading-placeholder']}>
+        <LoadingSpinner />
+      </div>
+    );
 
   return (
     <Navbar>

--- a/libs/tup-components/src/projects/users/UserList/UserList.tsx
+++ b/libs/tup-components/src/projects/users/UserList/UserList.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useProjectUsers } from '@tacc/tup-hooks';
+import { Navbar, NavItem } from '@tacc/core-wrappers';
+
+const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
+  const projectUsers = useProjectUsers(projectId);
+  const data = projectUsers.data ?? [];
+  const pi = data.find((user) => user.role === 'PI');
+  const delegate = data.find((user) => user.role === 'Delegate');
+
+  return (
+    <Navbar>
+      <div style={{ borderBottom: '1px solid black' }}>
+        {pi && (
+          <NavItem to={`/projects/${projectId}/${pi?.username}`} end>
+            PI: {pi.firstName} {pi.lastName}
+          </NavItem>
+        )}
+        {delegate && (
+          <NavItem to={`/projects/${projectId}/${delegate?.username}`} end>
+            Delegate: {delegate?.firstName} {delegate?.lastName}
+          </NavItem>
+        )}
+      </div>
+      {data.map((user) => (
+        <NavItem
+          to={`/projects/${projectId}/${user.username}`}
+          end
+          key={user.username}
+        >
+          {user.firstName} {user.lastName}
+        </NavItem>
+      ))}
+    </Navbar>
+  );
+};
+
+export default UserList;

--- a/libs/tup-components/src/projects/users/UserList/index.ts
+++ b/libs/tup-components/src/projects/users/UserList/index.ts
@@ -1,0 +1,1 @@
+export { default as UserList } from './UserList';

--- a/libs/tup-hooks/src/index.ts
+++ b/libs/tup-hooks/src/index.ts
@@ -169,9 +169,34 @@ export type Ticket = {
   numerical_id: string;
 };
 
+export type ProjectUser = {
+  id: number;
+  username: string;
+  role?: string;
+  firstName: string;
+  middleInitial?: string;
+  lastName: string;
+  email: string;
+  vislabTrained?: boolean;
+  staff?: boolean;
+};
+
+export type AllocationUsage = {
+  allocationId: number;
+  usage: { username: string; usage: number }[];
+};
+
+export type UsagePerResource = {
+  resource: string;
+  total: number;
+  used: number;
+};
+
 export { default as useAuth } from './useAuth';
 export { default as useProfile } from './useProfile';
 export { default as useJwt } from './useJwt';
 export { default as useSystemMonitor } from './useSystemMonitor';
 export { default as useProjects } from './useProjects';
 export { default as useTickets } from './useTickets';
+export { default as useProjectUsers } from './useProjectUsers';
+export { default as useProjectUsage } from './useProjectUsage';

--- a/libs/tup-hooks/src/useProjectUsage.ts
+++ b/libs/tup-hooks/src/useProjectUsage.ts
@@ -1,0 +1,77 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import useConfig from './useConfig';
+import useJwt from './useJwt';
+import useProjects from './useProjects';
+import axios from 'axios';
+import { ProjectsAllocations, AllocationUsage, UsagePerResource } from '.';
+
+const useProjectUsage = (
+  projectId: number
+): UseQueryResult<AllocationUsage[], Error> => {
+  const { baseUrl } = useConfig();
+  const { jwt } = useJwt();
+  const { data } = useProjects();
+  const getUtil = async (projectId: number, allocationId: number) => {
+    const request = await axios.get<AllocationUsage>(
+      `${baseUrl}/projects/${projectId}/allocations/${allocationId}/usage`,
+      {
+        headers: { 'x-tup-token': jwt ?? '' },
+      }
+    );
+    return request.data;
+  };
+
+  const allocations: ProjectsAllocations[] =
+    (data ?? [])
+      .find((project) => project.id === projectId)
+      ?.allocations?.filter((a) => a.status === 'Active') ?? [];
+
+  const usage_req = async () =>
+    axios.all(
+      allocations.map((allocation) => getUtil(projectId, allocation.id))
+    );
+
+  return useQuery({
+    queryKey: ['usage', projectId],
+    queryFn: usage_req,
+    enabled: !!data,
+    refetchOnMount: false,
+  });
+};
+
+const useProjectUsageForUser = (projectId: number, username: string) => {
+  const { data: projectData } = useProjects();
+  const allocations: ProjectsAllocations[] =
+    (projectData ?? [])
+      .find((project) => project.id === projectId)
+      ?.allocations?.filter((a) => a.status === 'Active') ?? [];
+
+  const { data: usageData, ...rest } = useProjectUsage(projectId);
+  if (!usageData) return { data: usageData, ...rest };
+
+  //Keep a hash map of resource IDs for deduplication.
+  const usageHash: Record<string, UsagePerResource> = {};
+
+  usageHash &&
+    allocations.forEach((allocation) => {
+      const usage = usageData?.find((u) => u.allocationId === allocation.id);
+      const usageByUser =
+        usage?.usage.find((u) => u.username === username)?.usage ?? 0;
+      usageHash[allocation.resource] = usageHash[allocation.resource]
+        ? {
+            resource: allocation.resource,
+            total: usageHash[allocation.resource].total + allocation.total,
+            used: usageHash[allocation.resource].used + usageByUser,
+          }
+        : {
+            resource: allocation.resource,
+            total: allocation.total,
+            used: usageByUser,
+          };
+    });
+
+  const usageMap = usageHash && Object.keys(usageHash).map((k) => usageHash[k]);
+  return { data: usageMap, ...rest };
+};
+
+export default useProjectUsageForUser;

--- a/libs/tup-hooks/src/useProjectUsers.ts
+++ b/libs/tup-hooks/src/useProjectUsers.ts
@@ -1,0 +1,14 @@
+import { UseQueryResult } from 'react-query';
+import { ProjectUser } from '.';
+import { useGet } from './requests';
+
+// Query to retrieve the user's active projects.
+const useProjectUsers = (id: number): UseQueryResult<ProjectUser[]> => {
+  const query = useGet<ProjectUser[]>({
+    endpoint: `/projects/${id}/users`,
+    key: 'projectUsers',
+  });
+  return query;
+};
+
+export default useProjectUsers;

--- a/libs/tup-testing/src/mocks/fixtures/index.ts
+++ b/libs/tup-testing/src/mocks/fixtures/index.ts
@@ -1,5 +1,9 @@
 export { default as mockProfile } from './profile';
 export { default as mockJwt } from './auth';
-export { mockProjectsOutput } from './projects';
+export {
+  mockProjectsOutput,
+  mockProjectUsage,
+  MockProjectUsers,
+} from './projects';
 export { rawSystemMonitorOutput } from './system_monitor';
 export { mockTickets } from './tickets';

--- a/libs/tup-testing/src/mocks/fixtures/projects.ts
+++ b/libs/tup-testing/src/mocks/fixtures/projects.ts
@@ -45,3 +45,48 @@ export const mockProjectsOutput = [
     users: null,
   },
 ];
+
+export const MockProjectUsers = [
+  {
+    id: 1418897,
+    username: 'jarosenb',
+    role: 'PI',
+    firstName: 'Jake',
+    middleInitial: null,
+    lastName: 'Rosenberg',
+    email: 'jrosenberg@tacc.utexas.edu',
+    vislabTrained: null,
+    staff: null,
+  },
+  {
+    id: 1418898,
+    username: 'vg5726',
+    role: 'Standard',
+    firstName: 'Vanessa',
+    middleInitial: null,
+    lastName: 'Gonzalez',
+    email: 'vgonzalez@tacc.utexas.edu',
+    vislabTrained: null,
+    staff: null,
+  },
+  {
+    id: 1419485,
+    username: 'smassie',
+    role: 'Delegate',
+    firstName: 'Sophia',
+    middleInitial: null,
+    lastName: 'Massie',
+    email: 'sophia.massie@austin.utexas.edu',
+    vislabTrained: null,
+    staff: null,
+  },
+];
+
+export const mockProjectUsage = {
+  allocationId: 90474,
+  usage: [
+    { username: 'jarosenb', usage: 5 },
+    { username: 'smassie', usage: 0.01 },
+    { username: 'vg5726', usage: 0 },
+  ],
+};

--- a/libs/tup-testing/src/mocks/handlers.ts
+++ b/libs/tup-testing/src/mocks/handlers.ts
@@ -4,6 +4,8 @@ import {
   mockJwt,
   rawSystemMonitorOutput,
   mockProjectsOutput,
+  mockProjectUsage,
+  MockProjectUsers,
   mockTickets,
 } from './fixtures';
 
@@ -24,6 +26,24 @@ export const handlers = [
     // Respond with mock active projects output
     return res(ctx.json(mockProjectsOutput));
   }),
+  rest.get('http://localhost:8001/projects', (req, res, ctx) => {
+    // Respond with mock active projects output
+    return res(ctx.json(mockProjectsOutput));
+  }),
+  rest.get(
+    'http://localhost:8001/projects/:projectId/users',
+    (req, res, ctx) => {
+      // Respond with mock users output
+      return res(ctx.json(MockProjectUsers));
+    }
+  ),
+  rest.get(
+    'http://localhost:8001/projects/:projectId/allocations/:allocationId/usage',
+    (req, res, ctx) => {
+      // Respond with mock usage output
+      return res(ctx.json(mockProjectUsage));
+    }
+  ),
   rest.get('http://localhost:8001/tickets', (req, res, ctx) => {
     // Respond with mock tickets output
     return res(ctx.json(mockTickets));


### PR DESCRIPTION
## Overview:
Add user list sidebar and user detail view (read-only for now, role selection and user removal will be implemented in separate PRs).
## Related:

- [TUP-377](https://jira.tacc.utexas.edu/browse/TUP-377)

## Changes:
- Add a user list sidebar as part of the project view layout (visible in both project and user detail views).
- Add a user detail view with name/username/email and usage per allocation.

## Testing:
1. Navigate to `http://localhost:8000/dashboard/projects/{projectId}` where `projectId` is a project you have access to. check that the user sidebar displays and doesn't overflow beyond the page boundary.
2. Click on a username in the sidebar. Confirm that the detail view displays with the correct name/username/email. Confirm that the usage numbers in the table look reasonable.
## UI:
![image](https://user-images.githubusercontent.com/12601812/207411140-adf211f5-1e67-4d2f-9338-f6542677dd59.png)



## Notes:
