### PR TITLE
fix(tup-cms): wysiwyg to not force <p> tag

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:f1ba69f
+FROM taccwma/core-cms:19defb5
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Change CMS editor limitation so that we can create markup with _inline_ elements **not** wrapped by a `<p>` tag.

## Related

- most pattern markup work on CMS that started last week and will continue for weeks
- relies on https://github.com/TACC/Core-CMS/pull/574

## Changes

- changed CMS image

## Testing & UI

See https://github.com/TACC/Core-CMS/pull/574.

Of the screenshots below, the WYSIWYG edit ones show the current tag at the bottom left e.g. "body > p":

| Manual Test | Screenshot |
| - | - |
| 1. **no** `<p>` added initially | <img width="983" alt="no p on initial entry" src="https://user-images.githubusercontent.com/62723358/207157603-a01f4d03-382d-4625-aaee-c6798eb5a515.png">
| 2. `<p>` added **after** pressing enter | <img width="983" alt="add p on press enter" src="https://user-images.githubusercontent.com/62723358/207157602-cb6ed338-a123-47fa-b07f-af240fa4bf86.png">
| 3. edit source to **not** have `<p>` | <img width="983" alt="edit source to not have p" src="https://user-images.githubusercontent.com/62723358/207157599-eb799998-8a33-4257-81c0-1c42e9098ca4.png">
| 4. `<p>` **not** added after editing source | <img width="983" alt="source edit maintained" src="https://user-images.githubusercontent.com/62723358/207157601-54bd0129-fabf-4878-b0d2-41af2bc22cc3.png">
| 5. rendered markup has **no** `<p>` | ![rendered markup no p](https://user-images.githubusercontent.com/62723358/207157597-98acf73c-f9bb-445f-a036-e25147aa669e.png)