### PR TITLE
chore(core-styles/cms): three small fixes/features

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:c938c60
+FROM taccwma/core-cms:407fb21
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:19defb5
+FROM taccwma/core-cms:c938c60
 
 WORKDIR /code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@nrwl/react": "15.0.6",
         "@nrwl/web": "15.0.6",
         "@nrwl/workspace": "15.0.6",
-        "@tacc/core-styles": "github:TACC/Core-Styles#9cf8a60",
+        "@tacc/core-styles": "github:TACC/Core-Styles#382ab54",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@types/jest": "28.1.8",
@@ -5599,7 +5599,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9cf8a6048bc02f9140a9d2b96a7215deca84d53e",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#382ab54045db5112fa7270388e494f4d7e19d136",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -29288,9 +29288,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9cf8a6048bc02f9140a9d2b96a7215deca84d53e",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#382ab54045db5112fa7270388e494f4d7e19d136",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#9cf8a60",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#382ab54",
       "requires": {}
     },
     "@testing-library/dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@nrwl/react": "15.0.6",
         "@nrwl/web": "15.0.6",
         "@nrwl/workspace": "15.0.6",
-        "@tacc/core-styles": "github:TACC/Core-Styles",
+        "@tacc/core-styles": "github:TACC/Core-Styles#9cf8a60",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@types/jest": "28.1.8",
@@ -29290,7 +29290,7 @@
     "@tacc/core-styles": {
       "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9cf8a6048bc02f9140a9d2b96a7215deca84d53e",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#9cf8a60",
       "requires": {}
     },
     "@testing-library/dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@nrwl/react": "15.0.6",
         "@nrwl/web": "15.0.6",
         "@nrwl/workspace": "15.0.6",
-        "@tacc/core-styles": "github:TACC/Core-Styles#07a98ab",
+        "@tacc/core-styles": "github:TACC/Core-Styles",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@types/jest": "28.1.8",
@@ -5599,7 +5599,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#07a98ab53b2314b38e5977141880d970131704dd",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9cf8a6048bc02f9140a9d2b96a7215deca84d53e",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5615,7 +5615,6 @@
         "js-yaml": "^4.1.0",
         "merge-lite": "^1.0.2",
         "node-cmd": "^5.0.0",
-        "npm-watch": "^0.11.0",
         "postcss": "^8.4.18",
         "postcss-banner": "^4.0.1",
         "postcss-cli": "^10.0.0",
@@ -7032,13 +7031,6 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -13221,13 +13213,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -18410,84 +18395,6 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
-    "node_modules/nodemon": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
-      "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/nodemon/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -18558,20 +18465,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/npm-watch": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/npm-watch/-/npm-watch-0.11.0.tgz",
-      "integrity": "sha512-wAOd0moNX2kSA2FNvt8+7ORwYaJpQ1ZoWjUYdb1bBCxq4nkWuU0IiJa9VpVxrj5Ks+FGXQd62OC/Bjk0aSr+dg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "nodemon": "^2.0.7",
-        "through2": "^4.0.2"
-      },
-      "bin": {
-        "npm-watch": "cli.js"
       }
     },
     "node_modules/nth-check": {
@@ -21206,13 +21099,6 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -22740,29 +22626,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simple-update-notifier": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
-      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "~7.0.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -23818,16 +23681,6 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
-    "node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "readable-stream": "3"
-      }
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -23896,19 +23749,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
-    },
-    "node_modules/touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
@@ -24395,13 +24235,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -29455,9 +29288,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#07a98ab53b2314b38e5977141880d970131704dd",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9cf8a6048bc02f9140a9d2b96a7215deca84d53e",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#07a98ab",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles",
       "requires": {}
     },
     "@testing-library/dom": {
@@ -30672,13 +30505,6 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
-      "peer": true
     },
     "accepts": {
       "version": "1.3.8",
@@ -35183,13 +35009,6 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
-    "ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true,
-      "peer": true
-    },
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -39071,64 +38890,6 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
-    "nodemon": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
-      "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "abbrev": "1"
-      }
-    },
     "normalize-package-data": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -39177,17 +38938,6 @@
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
-      }
-    },
-    "npm-watch": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/npm-watch/-/npm-watch-0.11.0.tgz",
-      "integrity": "sha512-wAOd0moNX2kSA2FNvt8+7ORwYaJpQ1ZoWjUYdb1bBCxq4nkWuU0IiJa9VpVxrj5Ks+FGXQd62OC/Bjk0aSr+dg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "nodemon": "^2.0.7",
-        "through2": "^4.0.2"
       }
     },
     "nth-check": {
@@ -40993,13 +40743,6 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
-    "pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true,
-      "peer": true
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -42152,25 +41895,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "simple-update-notifier": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
-      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "semver": "~7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -42996,16 +42720,6 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
-    "through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "readable-stream": "3"
-      }
-    },
     "thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -43062,16 +42776,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
-    },
-    "touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "nopt": "~1.0.10"
-      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -43406,13 +43110,6 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "dev": true,
-      "peer": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nrwl/react": "15.0.6",
     "@nrwl/web": "15.0.6",
     "@nrwl/workspace": "15.0.6",
-    "@tacc/core-styles": "github:TACC/Core-Styles#9cf8a60",
+    "@tacc/core-styles": "github:TACC/Core-Styles#382ab54",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@types/jest": "28.1.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nrwl/react": "15.0.6",
     "@nrwl/web": "15.0.6",
     "@nrwl/workspace": "15.0.6",
-    "@tacc/core-styles": "github:TACC/Core-Styles#07a98ab",
+    "@tacc/core-styles": "github:TACC/Core-Styles",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@types/jest": "28.1.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nrwl/react": "15.0.6",
     "@nrwl/web": "15.0.6",
     "@nrwl/workspace": "15.0.6",
-    "@tacc/core-styles": "github:TACC/Core-Styles",
+    "@tacc/core-styles": "github:TACC/Core-Styles#9cf8a60",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@types/jest": "28.1.8",


### PR DESCRIPTION
## Overview & Related & Changes

**1.** Hide text inside an `<i class="icon…">accessible text</i>`.
<sup>Also lets us prevent CMS from stripping empty tag from WYSIWYG.</sup>
- TACC/Core-Styles#86
- TACC/Core-Styles#88

**2.** Add an alias `.icon-collapse` for `.icon-contract`.
<sup>Because devs and I always expect the name to be `.icon-collapse`.</sup>
- TACC/Core-Styles#85

**3.** Fix a side effect from https://github.com/TACC/Core-CMS/pull/573.
<sup>Another editor window had become illegible.</sup>
- TACC/Core-CMS#575

## Testing & UI

### 1. Hide Icon Text

| Source | Render |
| - | - |
| ![icon overflow - source](https://user-images.githubusercontent.com/62723358/207415701-675de200-0a71-4d1b-9438-dd26543ab7dd.png) | ![icon overflow - render](https://user-images.githubusercontent.com/62723358/207415700-6881c620-7837-4752-92ec-fa128af2981b.png)

### 2. Icon Alias

| Source | Render |
| - | - |
| ![icon alias - source](https://user-images.githubusercontent.com/62723358/207415698-e83d4909-617c-45ed-8d0a-eaa9adf06a2a.png) | ![icon alias - render](https://user-images.githubusercontent.com/62723358/207415696-1a84911e-ff69-4495-97b1-3ec65a7a352c.png) |

### WYSIWIG Mini-Edit Window Viewport Size Hotfix

Both viewports within the Text editor mini-windows stretch to fill **and** do not have overlapping text nor fields.

https://user-images.githubusercontent.com/62723358/207415704-061d1e0d-e49d-4140-99aa-acb9f2ff206a.mov

### 1. & 2. Icon Tests on Portal

I added an icon—using the alias and long text inside—on the fly in the live markup.

![portal test](https://user-images.githubusercontent.com/62723358/207416760-413eaa39-8470-41e4-89ae-1db3cb7a8e4c.png)