### PR TITLE
Task/tup 373 project summary listing

### DIFF
--- a/libs/tup-components/src/projects/ProjectsCells.tsx
+++ b/libs/tup-components/src/projects/ProjectsCells.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Cell } from 'react-table';
-import { ProjectsRawSystem, ProjectsAllocations } from '@tacc/tup-hooks';
-import { Pill } from '@tacc/core-components';
+import { ProjectsRawSystem } from '@tacc/tup-hooks';
+import { Pill, SectionTableWrapper } from '@tacc/core-components';
 
 export const ProjectTitle: React.FC<{
   cell: Cell<ProjectsRawSystem, string>;
@@ -14,29 +14,28 @@ export const PrinInv: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
   cell: { value },
 }) => <div>{value}</div>;
 
-export const Allocations: React.FC<{
-  cell: Cell<ProjectsRawSystem, number>;
-}> = ({ cell: { value, row } }) => (
-  <tr>
-    <td>{'Compute: ' + row.original.allocations}</td>
-  </tr>
-);
+/*Refactor ProjectSummary Cell to have Storage and Compute in their own export const StorageAllocations: React.FC<{
+  cell: Cell<ProjectsRawSystem>;
+}> = ({ cell: { value, row } }) => (<SectionTableWrapper content={row.original.id}>{value}{'Compute: ' + row.original.allocations?.reduce((acc, e) => acc + e.computeRequested, 0) + ' SUs'},
+{'Storage: ' + row.original.allocations?.reduce((acc, e) => acc + e.storageRequested, 0) + ' SUs'}
+</SectionTableWrapper>);*/
 
 export const ProjectSummary: React.FC<{
   cell: Cell<ProjectsRawSystem>;
 }> = ({ cell: { value, row } }) => (
-  <div>
-    <h6>
-      <b>
-        <Link to={`/projects/${row.original.id}`}>{value}</Link>
-      </b>
-    </h6>
-    {'Project Charge Code: '} <b>{row.original.chargeCode}</b>
-    <p>
-      <Pill type="success">
-        {'Principle Investigator: '}
-        <b>{row.original.pi.firstName + ' ' + row.original.pi.lastName}</b>
+  <>
+    <Link to={`/projects/${row.original.id}`}>{value}</Link>
+      <div>{'Project Charge Code: '} {row.original.chargeCode}</div>
+      <Pill type='success'>{"Principle Investigator: " + row.original.pi.firstName + ' ' + row.original.pi.lastName}
       </Pill>
-    </p>
-  </div>
+    <SectionTableWrapper>
+      <td colSpan={2 }>{'Compute: '} 
+        <b>{row.original.allocations?.reduce((acc, e) => acc + e.computeRequested, 0) + ' SUs'}</b>
+        {" ( % Used)"}</td>
+      <td>{'Storage: '} 
+        <b>{row.original.allocations?.reduce((acc, e) => acc + e.storageRequested, 0) + ' SUs'}</b>
+        {" ( % Used)"}</td>
+    </SectionTableWrapper>
+    </>  
 );
+

--- a/libs/tup-components/src/projects/ProjectsCells.tsx
+++ b/libs/tup-components/src/projects/ProjectsCells.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Cell } from 'react-table';
-import { ProjectsRawSystem } from '@tacc/tup-hooks';
+import { ProjectsRawSystem, ProjectsAllocations } from '@tacc/tup-hooks';
 import { Pill } from '@tacc/core-components';
 
 export const ProjectTitle: React.FC<{
@@ -15,21 +15,19 @@ export const PrinInv: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
 }) => <div>{value}</div>;
 
 export const Allocations: React.FC<{
-  cell: Cell<ProjectsRawSystem, string>;
-}> = ({ cell: { value } }) => <div>{value}</div>;
+  cell: Cell<ProjectsRawSystem, number>;
+}> = ({ cell: { value, row } }) =>  <tr><td>{'Compute: ' + row.original.allocations}</td></tr>
 
 export const ProjectSummary: React.FC<{
-  cell: Cell<ProjectsRawSystem, string>;
+  cell: Cell<ProjectsRawSystem>;
 }> = ({ cell: { value, row } }) => (
   <div>
-    <p>
       <h6>
         <b><Link to={`/projects/${row.original.id}`}>{value}</Link></b>
       </h6>
-    </p>
-    <p>{'Project Charge Code: '} <b>{row.original.chargeCode}</b></p>
-    <p><Pill type='success'>{row.original.pi.firstName + ' ' + row.original.pi.lastName}</Pill></p>
-    <p>{'Compute: ' + row.original.allocations?.keys('computeRequested')}</p>
-
-  </div>
+      {'Project Charge Code: '} <b>{row.original.chargeCode}</b>
+    <p><Pill type='success'>{"Principle Investigator: "} 
+      <b>{row.original.pi.firstName + ' ' + row.original.pi.lastName}</b>
+      </Pill></p>
+    </div>
 );

--- a/libs/tup-components/src/projects/ProjectsCells.tsx
+++ b/libs/tup-components/src/projects/ProjectsCells.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Cell } from 'react-table';
 import { ProjectsRawSystem } from '@tacc/tup-hooks';
-import { Pill, SectionTableWrapper } from '@tacc/core-components';
-import { valuesIn } from 'lodash';
+import { Pill } from '@tacc/core-components';
 
 export const ProjectTitle: React.FC<{
   cell: Cell<ProjectsRawSystem, string>;
@@ -15,26 +14,19 @@ export const PrinInv: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
   cell: { value },
 }) => <div>{value}</div>;
 
-
 export const ProjectSummaryAll: React.FC<{
   cell: Cell<ProjectsRawSystem>;
 }> = ({ cell: { value, row } }) => (
-  <>
+  <div>
     <Link to={`/projects/${row.original.id}`}>{value}</Link>
-      <div>{'Project Charge Code: '} {row.original.chargeCode}</div>
-      <Pill type='success'>{"Principle Investigator: " + row.original.pi.firstName + ' ' + row.original.pi.lastName}
-      </Pill><p/>
-    <SectionTableWrapper>
-      <td colSpan={2 }>{'Compute: '} 
-        <b>{row.original.allocations?.reduce((acc, e) => acc + e.computeRequested, 0) + ' SUs'}</b>
-        {" (" + row.original.allocations?.reduce((acc, e) => (((acc + e.used) /(acc+ e.computeRequested)) * 100), 0).toFixed(0) + "  % Used)"}</td>
-      <td>{'Storage: '} 
-        <b>{row.original.allocations?.reduce((acc, e) => acc + e.storageRequested, 0) + ' GBs'}</b>
-        {" (" + row.original.allocations?.reduce((acc, e) => (((acc + e.storageUsed) /(acc+ e.storageRequested)) * 100), 0).toFixed(0) + "  % Used)"}</td>
-        {"used" + row.original.allocations?.reduce((acc, e) => acc + e.storageUsed , 0)};
-        {"requested" + row.original.allocations?.reduce((acc, e) => acc + e.storageRequested , 0)};
-        {"percent" +row.original.allocations?.reduce((acc, e) => ((acc + e.storageUsed) / (acc+ e.storageRequested)) * 100, 0) }
-    </SectionTableWrapper>
-    </>  
+    <div>
+      {'Project Charge Code: '} {row.original.chargeCode}
+    </div>
+    <Pill type="success">
+      {'Principle Investigator: ' +
+        row.original.pi.firstName +
+        ' ' +
+        row.original.pi.lastName}
+    </Pill>
+  </div>
 );
-

--- a/libs/tup-components/src/projects/ProjectsCells.tsx
+++ b/libs/tup-components/src/projects/ProjectsCells.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Cell } from 'react-table';
 import { ProjectsRawSystem } from '@tacc/tup-hooks';
 import { Pill, SectionTableWrapper } from '@tacc/core-components';
+import { valuesIn } from 'lodash';
 
 export const ProjectTitle: React.FC<{
   cell: Cell<ProjectsRawSystem, string>;
@@ -14,27 +15,25 @@ export const PrinInv: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
   cell: { value },
 }) => <div>{value}</div>;
 
-/*Refactor ProjectSummary Cell to have Storage and Compute in their own export const StorageAllocations: React.FC<{
-  cell: Cell<ProjectsRawSystem>;
-}> = ({ cell: { value, row } }) => (<SectionTableWrapper content={row.original.id}>{value}{'Compute: ' + row.original.allocations?.reduce((acc, e) => acc + e.computeRequested, 0) + ' SUs'},
-{'Storage: ' + row.original.allocations?.reduce((acc, e) => acc + e.storageRequested, 0) + ' SUs'}
-</SectionTableWrapper>);*/
 
-export const ProjectSummary: React.FC<{
+export const ProjectSummaryAll: React.FC<{
   cell: Cell<ProjectsRawSystem>;
 }> = ({ cell: { value, row } }) => (
   <>
     <Link to={`/projects/${row.original.id}`}>{value}</Link>
       <div>{'Project Charge Code: '} {row.original.chargeCode}</div>
       <Pill type='success'>{"Principle Investigator: " + row.original.pi.firstName + ' ' + row.original.pi.lastName}
-      </Pill>
+      </Pill><p/>
     <SectionTableWrapper>
       <td colSpan={2 }>{'Compute: '} 
         <b>{row.original.allocations?.reduce((acc, e) => acc + e.computeRequested, 0) + ' SUs'}</b>
-        {" ( % Used)"}</td>
+        {" (" + row.original.allocations?.reduce((acc, e) => (((acc + e.used) /(acc+ e.computeRequested)) * 100), 0).toFixed(0) + "  % Used)"}</td>
       <td>{'Storage: '} 
-        <b>{row.original.allocations?.reduce((acc, e) => acc + e.storageRequested, 0) + ' SUs'}</b>
-        {" ( % Used)"}</td>
+        <b>{row.original.allocations?.reduce((acc, e) => acc + e.storageRequested, 0) + ' GBs'}</b>
+        {" (" + row.original.allocations?.reduce((acc, e) => (((acc + e.storageUsed) /(acc+ e.storageRequested)) * 100), 0).toFixed(0) + "  % Used)"}</td>
+        {"used" + row.original.allocations?.reduce((acc, e) => acc + e.storageUsed , 0)};
+        {"requested" + row.original.allocations?.reduce((acc, e) => acc + e.storageRequested , 0)};
+        {"percent" +row.original.allocations?.reduce((acc, e) => ((acc + e.storageUsed) / (acc+ e.storageRequested)) * 100, 0) }
     </SectionTableWrapper>
     </>  
 );

--- a/libs/tup-components/src/projects/ProjectsCells.tsx
+++ b/libs/tup-components/src/projects/ProjectsCells.tsx
@@ -16,18 +16,27 @@ export const PrinInv: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
 
 export const Allocations: React.FC<{
   cell: Cell<ProjectsRawSystem, number>;
-}> = ({ cell: { value, row } }) =>  <tr><td>{'Compute: ' + row.original.allocations}</td></tr>
+}> = ({ cell: { value, row } }) => (
+  <tr>
+    <td>{'Compute: ' + row.original.allocations}</td>
+  </tr>
+);
 
 export const ProjectSummary: React.FC<{
   cell: Cell<ProjectsRawSystem>;
 }> = ({ cell: { value, row } }) => (
   <div>
-      <h6>
-        <b><Link to={`/projects/${row.original.id}`}>{value}</Link></b>
-      </h6>
-      {'Project Charge Code: '} <b>{row.original.chargeCode}</b>
-    <p><Pill type='success'>{"Principle Investigator: "} 
-      <b>{row.original.pi.firstName + ' ' + row.original.pi.lastName}</b>
-      </Pill></p>
-    </div>
+    <h6>
+      <b>
+        <Link to={`/projects/${row.original.id}`}>{value}</Link>
+      </b>
+    </h6>
+    {'Project Charge Code: '} <b>{row.original.chargeCode}</b>
+    <p>
+      <Pill type="success">
+        {'Principle Investigator: '}
+        <b>{row.original.pi.firstName + ' ' + row.original.pi.lastName}</b>
+      </Pill>
+    </p>
+  </div>
 );

--- a/libs/tup-components/src/projects/ProjectsCells.tsx
+++ b/libs/tup-components/src/projects/ProjectsCells.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Cell } from 'react-table';
 import { ProjectsRawSystem } from '@tacc/tup-hooks';
+import { Pill } from '@tacc/core-components';
 
 export const ProjectTitle: React.FC<{
   cell: Cell<ProjectsRawSystem, string>;
@@ -16,3 +17,19 @@ export const PrinInv: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
 export const Allocations: React.FC<{
   cell: Cell<ProjectsRawSystem, string>;
 }> = ({ cell: { value } }) => <div>{value}</div>;
+
+export const ProjectSummary: React.FC<{
+  cell: Cell<ProjectsRawSystem, string>;
+}> = ({ cell: { value, row } }) => (
+  <div>
+    <p>
+      <h6>
+        <b><Link to={`/projects/${row.original.id}`}>{value}</Link></b>
+      </h6>
+    </p>
+    <p>{'Project Charge Code: '} <b>{row.original.chargeCode}</b></p>
+    <p><Pill type='success'>{row.original.pi.firstName + ' ' + row.original.pi.lastName}</Pill></p>
+    <p>{'Compute: ' + row.original.allocations?.keys('computeRequested')}</p>
+
+  </div>
+);

--- a/libs/tup-components/src/projects/ProjectsCells.tsx
+++ b/libs/tup-components/src/projects/ProjectsCells.tsx
@@ -15,18 +15,51 @@ export const PrinInv: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
 }) => <div>{value}</div>;
 
 export const ProjectSummaryAll: React.FC<{
-  cell: Cell<ProjectsRawSystem>;
-}> = ({ cell: { value, row } }) => (
-  <div>
-    <Link to={`/projects/${row.original.id}`}>{value}</Link>
+  project: ProjectsRawSystem;
+}> = ({ project }) => {
+  const totalStorageRequested =
+    project.allocations?.reduce((acc, e) => acc + e.storageRequested, 0) ?? 0;
+  const totalStorageUsed =
+    project.allocations?.reduce((acc, e) => acc + e.storageUsed, 0) ?? 0;
+  const totalComputeRequested =
+    project.allocations?.reduce((acc, e) => acc + e.computeRequested, 0) ?? 0;
+  const totalComputeUsed =
+    project.allocations?.reduce((acc, e) => acc + e.used, 0) ?? 0;
+
+  return (
     <div>
-      {'Project Charge Code: '} {row.original.chargeCode}
+      <Link to={`/projects/${project.id}`}>{project.title}</Link>
+      <div>
+        {'Project Charge Code: '} {project.chargeCode}
+      </div>
+      <Pill type="success">
+        {'Principle Investigator: ' +
+          project.pi.firstName +
+          ' ' +
+          project.pi.lastName}
+      </Pill>
+      <div>{`Compute: ${
+        totalComputeRequested ? totalComputeRequested : '--'
+      } SUs `}</div>
+      <div>
+        {totalComputeUsed
+          ? ' (' +
+            ((totalComputeUsed / totalComputeRequested) * 100).toFixed(0) +
+            '  % Used) '
+          : ' (0% Used) '}
+      </div>
+      <div>
+        {`Storage: ${
+          totalStorageRequested ? totalStorageRequested : '--'
+        } GBs `}
+      </div>
+      <div>
+        {totalStorageUsed
+          ? ' (' +
+            ((totalStorageUsed / totalStorageRequested) * 100).toFixed(0) +
+            '  % Used) '
+          : ' (0% Used) '}
+      </div>
     </div>
-    <Pill type="success">
-      {'Principle Investigator: ' +
-        row.original.pi.firstName +
-        ' ' +
-        row.original.pi.lastName}
-    </Pill>
-  </div>
-);
+  );
+};

--- a/libs/tup-components/src/projects/ProjectsLayout.tsx
+++ b/libs/tup-components/src/projects/ProjectsLayout.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { PageLayout } from '../layout';
-import { Section } from '@tacc/core-components';
+import { Section, SectionTableWrapper } from '@tacc/core-components';
 import { ProjectsTable } from './ProjectsTable';
+import ProjectSummaryListing from './ProjectsSummaryListing';
 
 const ProjectsLayout: React.FC = () => {
-  return <Section header="Projects & Allocations" content={<PageLayout />} />;
+  return <Section header="Projects & Allocations" content={<SectionTableWrapper><ProjectSummaryListing /> </SectionTableWrapper>} />;
 };
 export default ProjectsLayout;

--- a/libs/tup-components/src/projects/ProjectsLayout.tsx
+++ b/libs/tup-components/src/projects/ProjectsLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Section } from '@tacc/core-components';
-import { ProjectsSummaryListing } from '@tacc/tup-components';
+import { ProjectsSummaryListing } from './ProjectsSummaryListing';
 
 const ProjectsLayout: React.FC = () => {
   return (

--- a/libs/tup-components/src/projects/ProjectsLayout.tsx
+++ b/libs/tup-components/src/projects/ProjectsLayout.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
-import { PageLayout } from '../layout';
-import { Section, SectionTableWrapper } from '@tacc/core-components';
-import { ProjectsTable } from './ProjectsTable';
-import ProjectSummaryListing from './ProjectsSummaryListing';
+import { Section } from '@tacc/core-components';
+import { ProjectsSummaryListing } from '@tacc/tup-components';
 
 const ProjectsLayout: React.FC = () => {
   return (
     <Section
       header="Projects & Allocations"
-      content={
-        <SectionTableWrapper>
-          <ProjectSummaryListing />{' '}
-        </SectionTableWrapper>
-      }
+      content={<ProjectsSummaryListing />}
     />
   );
 };

--- a/libs/tup-components/src/projects/ProjectsLayout.tsx
+++ b/libs/tup-components/src/projects/ProjectsLayout.tsx
@@ -5,6 +5,15 @@ import { ProjectsTable } from './ProjectsTable';
 import ProjectSummaryListing from './ProjectsSummaryListing';
 
 const ProjectsLayout: React.FC = () => {
-  return <Section header="Projects & Allocations" content={<SectionTableWrapper><ProjectSummaryListing /> </SectionTableWrapper>} />;
+  return (
+    <Section
+      header="Projects & Allocations"
+      content={
+        <SectionTableWrapper>
+          <ProjectSummaryListing />{' '}
+        </SectionTableWrapper>
+      }
+    />
+  );
 };
 export default ProjectsLayout;

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.test.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { ProjectsSummaryListing } from './ProjectsSummaryListing';
+import { server, testRender } from '@tacc/tup-testing';
+import { screen } from '@testing-library/react';
+import { rest } from 'msw';
+
+describe('Projects Summary Listing Component', () => {
+  it('should display a spinner while loading', async () => {
+    const { getByTestId } = testRender(<ProjectsSummaryListing />);
+    expect(getByTestId('loading-spinner')).toBeDefined();
+  });
+  it('should display an error message if an error is returned', async () => {
+    server.use(
+      rest.get('http://localhost:8001/projects', (req, res, ctx) =>
+        res.once(ctx.status(404))
+      )
+    );
+    testRender(<ProjectsSummaryListing />);
+    await screen.findAllByText(/Unable to retrieve projects/);
+  });
+  it('should display project summary', async () => {
+    testRender(<ProjectsSummaryListing />);
+    await screen.findByText('JAR TUP Development Project');
+    expect(screen.findAllByText('/projects/59184', { exact: false }));
+    expect(screen.findAllByText('Project Charge Code: STA22002'));
+    expect(screen.findAllByText('Principle Investigator: Jake Rosenberg'));
+    expect(screen.getAllByText('Compute: 10 SUs'));
+    expect(screen.getAllByText('(0% Used)'));
+    expect(screen.getAllByText('Storage: -- GBs'));
+  });
+});

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useTable, Column } from 'react-table';
 import { LoadingSpinner, InlineMessage, SectionTableWrapper } from '@tacc/core-components';
-import { ProjectTitle, ProjectSummary } from './ProjectsCells';
+import { ProjectTitle, ProjectSummaryAll } from './ProjectsCells';
 import {
   ProjectsRawSystem,
   useProjects,
@@ -20,7 +20,7 @@ export const ProjectSummaryListing: React.FC = () => {
           {
             accessor: 'title',
             Header: 'Project Summary',
-            Cell: ProjectSummary,
+            Cell: ProjectSummaryAll,
           },
         ],
       },

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -1,43 +1,44 @@
 import React, { useMemo } from 'react';
 import { useTable, Column } from 'react-table';
-import { LoadingSpinner, InlineMessage, SectionTableWrapper } from '@tacc/core-components';
-import { ProjectTitle, ProjectSummaryAll } from './ProjectsCells';
-import {
-  ProjectsRawSystem,
-  useProjects,
-} from '@tacc/tup-hooks';
+import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
+import { ProjectSummaryAll } from './ProjectsCells';
+import { ProjectsRawSystem, useProjects } from '@tacc/tup-hooks';
 
 export const ProjectSummaryListing: React.FC = () => {
   const { data, isLoading, error } = useProjects();
+  const totalAllocations = data?.map((e) => {
+    e.totalStorageRequested = e.allocations?.reduce(
+      (acc, e) => acc + e.storageRequested,
+      0
+    );
+    e.totalStorageUsed = e.allocations?.reduce(
+      (acc, e) => acc + e.storageUsed,
+      0
+    );
+    e.totalComputeRequested = e.allocations?.reduce(
+      (acc, e) => acc + e.computeRequested,
+      0
+    );
+    e.totalComputeUsed = e.allocations?.reduce((acc, e) => acc + e.used, 0);
+    return e;
+  });
 
   const columns = useMemo<Column<ProjectsRawSystem>[]>(
     () => [
       {
         accessor: 'title',
-        Header: 'Active Projects',
-        Cell: ProjectTitle,
-        columns: [
-          {
-            accessor: 'title',
-            Header: 'Project Summary',
-            Cell: ProjectSummaryAll,
-          },
-        ],
+        Header: 'Project Summary',
+        Cell: ProjectSummaryAll,
       },
     ],
     []
   );
 
-  const {
-    getTableProps,
-    getTableBodyProps,
-    rows,
-    prepareRow,
-    headerGroups,
-  } = useTable({
-    columns,
-    data: data ?? [],
-  });
+  const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups } =
+    useTable({
+      columns,
+      data: data ?? [],
+    });
   if (isLoading) {
     return <LoadingSpinner />;
   }
@@ -47,40 +48,70 @@ export const ProjectSummaryListing: React.FC = () => {
     );
   }
   return (
-    <SectionTableWrapper>
-      <table {...getTableProps()}>
-        <thead>
-          {headerGroups.map((headerGroup) => (
-            <tr {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map((column) => {
-                return column.isVisible === true ? null : (
-                  <th {...column.getHeaderProps()}>{column.render('Header')}</th>
-                );
-              })}
-            </tr>
-          ))}
-        </thead>
-        <tbody {...getTableBodyProps()}>
-          {rows.length ? (
-            rows.map((row, idx) => {
-              prepareRow(row);
-              return (
-                <tr {...row.getRowProps()}>
-                  {row.cells.map((cell) => (
-                    <td {...cell.getCellProps()}>
-                      {cell.render('Cell')}
-                    </td>
-                  ))}
-                </tr>
-            )})
-          ) : (
-            <tr>
-              <td colSpan={5}>No active projects found.</td>
-            </tr>
-          )}
-        </tbody>
-      </table>
-    </SectionTableWrapper>
+    <table {...getTableProps()}>
+      <thead>
+        {headerGroups.map((headerGroup) => (
+          <tr {...headerGroup.getHeaderGroupProps()}>
+            {headerGroup.headers.map((column) => {
+              return column.isVisible === true ? null : (
+                <th {...column.getHeaderProps()}>{column.render('Header')}</th>
+              );
+            })}
+          </tr>
+        ))}
+      </thead>
+      <tbody {...getTableBodyProps()}>
+        {rows.length ? (
+          rows.map((row, idx) => {
+            prepareRow(row);
+            return (
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell) => (
+                  <td {...cell.getCellProps()}>
+                    {cell.render('Cell')}
+                    {`Compute: ${
+                      totalAllocations
+                        ? totalAllocations[idx].totalComputeRequested
+                        : '--'
+                    } SUs `}
+
+                    {row.original.totalComputeRequested &&
+                    row.original.totalComputeUsed
+                      ? ' (' +
+                        (
+                          (row.original.totalComputeUsed /
+                            row.original.totalComputeRequested) *
+                          100
+                        ).toFixed(0) +
+                        '  % Used) '
+                      : ' (0% Used) '}
+                    {`Storage: ${
+                      totalAllocations
+                        ? totalAllocations[idx].totalStorageRequested
+                        : '--'
+                    } GBs `}
+                    {row.original.totalStorageRequested &&
+                    row.original.totalStorageUsed
+                      ? ' (' +
+                        (
+                          (row.original.totalStorageUsed /
+                            row.original.totalStorageRequested) *
+                          100
+                        ).toFixed(0) +
+                        '  % Used) '
+                      : ' (0% Used) '}
+                  </td>
+                ))}
+              </tr>
+            );
+          })
+        ) : (
+          <tr>
+            <td colSpan={5}>No active projects found.</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
   );
 };
 export default ProjectSummaryListing;

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -2,12 +2,12 @@ import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
 import { ProjectSummaryAll } from './ProjectsCells';
 import { useProjects } from '@tacc/tup-hooks';
 
-export const ProjectSummaryListing: React.FC = () => {
+export const ProjectsSummaryListing: React.FC = () => {
   const { data, isLoading, error } = useProjects();
   if (isLoading) return <LoadingSpinner />;
   if (error)
     return (
-      <InlineMessage type="warn">Unable to retrieve projects.</InlineMessage>
+      <InlineMessage type="warning">Unable to retrieve projects.</InlineMessage>
     );
   return (
     <div>
@@ -19,4 +19,4 @@ export const ProjectSummaryListing: React.FC = () => {
     </div>
   );
 };
-export default ProjectSummaryListing;
+export default ProjectsSummaryListing;

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -1,117 +1,22 @@
-import React, { useMemo } from 'react';
-import { useTable, Column } from 'react-table';
 import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
 import { ProjectSummaryAll } from './ProjectsCells';
-import { ProjectsRawSystem, useProjects } from '@tacc/tup-hooks';
+import { useProjects } from '@tacc/tup-hooks';
 
 export const ProjectSummaryListing: React.FC = () => {
   const { data, isLoading, error } = useProjects();
-  const totalAllocations = data?.map((e) => {
-    e.totalStorageRequested = e.allocations?.reduce(
-      (acc, e) => acc + e.storageRequested,
-      0
-    );
-    e.totalStorageUsed = e.allocations?.reduce(
-      (acc, e) => acc + e.storageUsed,
-      0
-    );
-    e.totalComputeRequested = e.allocations?.reduce(
-      (acc, e) => acc + e.computeRequested,
-      0
-    );
-    e.totalComputeUsed = e.allocations?.reduce((acc, e) => acc + e.used, 0);
-    return e;
-  });
-
-  const columns = useMemo<Column<ProjectsRawSystem>[]>(
-    () => [
-      {
-        accessor: 'title',
-        Header: 'Project Summary',
-        Cell: ProjectSummaryAll,
-      },
-    ],
-    []
-  );
-
-  const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups } =
-    useTable({
-      columns,
-      data: data ?? [],
-    });
-  if (isLoading) {
-    return <LoadingSpinner />;
-  }
-  if (error) {
+  if (isLoading) return <LoadingSpinner />;
+  if (error)
     return (
       <InlineMessage type="warn">Unable to retrieve projects.</InlineMessage>
     );
-  }
   return (
-    <table {...getTableProps()}>
-      <thead>
-        {headerGroups.map((headerGroup) => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map((column) => {
-              return column.isVisible === true ? null : (
-                <th {...column.getHeaderProps()}>{column.render('Header')}</th>
-              );
-            })}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()}>
-        {rows.length ? (
-          rows.map((row, idx) => {
-            prepareRow(row);
-            return (
-              <tr {...row.getRowProps()}>
-                {row.cells.map((cell) => (
-                  <td {...cell.getCellProps()}>
-                    {cell.render('Cell')}
-                    {`Compute: ${
-                      totalAllocations
-                        ? totalAllocations[idx].totalComputeRequested
-                        : '--'
-                    } SUs `}
-
-                    {row.original.totalComputeRequested &&
-                    row.original.totalComputeUsed
-                      ? ' (' +
-                        (
-                          (row.original.totalComputeUsed /
-                            row.original.totalComputeRequested) *
-                          100
-                        ).toFixed(0) +
-                        '  % Used) '
-                      : ' (0% Used) '}
-                    {`Storage: ${
-                      totalAllocations
-                        ? totalAllocations[idx].totalStorageRequested
-                        : '--'
-                    } GBs `}
-                    {row.original.totalStorageRequested &&
-                    row.original.totalStorageUsed
-                      ? ' (' +
-                        (
-                          (row.original.totalStorageUsed /
-                            row.original.totalStorageRequested) *
-                          100
-                        ).toFixed(0) +
-                        '  % Used) '
-                      : ' (0% Used) '}
-                  </td>
-                ))}
-              </tr>
-            );
-          })
-        ) : (
-          <tr>
-            <td colSpan={5}>No active projects found.</td>
-          </tr>
-        )}
-      </tbody>
-    </table>
+    <div>
+      {data?.map((project) => (
+        <div>
+          <ProjectSummaryAll project={project} />
+        </div>
+      ))}
+    </div>
   );
 };
 export default ProjectSummaryListing;

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from 'react';
+import { useTable, Column } from 'react-table';
+import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
+import { ProjectSummary } from './ProjectsCells';
+import { ProjectsRawSystem, useProjects } from '@tacc/tup-hooks';
+
+export const ProjectSummaryListing: React.FC = () => {
+    const { data, isLoading, error } = useProjects();
+    const columns = useMemo<Column<ProjectsRawSystem>[]>(
+        () => [
+          {
+            accessor: 'title',
+            Header: 'Project Title',
+            Cell: ProjectSummary,
+            columns:
+            [
+                {
+                    accessor: 'title',
+                    Header: 'Project Title',
+                    Cell: ProjectSummary,
+                },
+            ],
+          },
+          ],
+      []
+    );
+
+    const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups } =
+      useTable({
+        columns,
+        data: data ?? [],
+      });
+    if (isLoading) {
+      return <LoadingSpinner />;
+    }
+    if (error) {
+      return (
+        <InlineMessage type="warn">Unable to retrieve projects.</InlineMessage>
+      );
+    }
+    return (
+        <table {...getTableProps()}>
+          <thead>
+            {headerGroups.map((headerGroup) => (
+              <tr {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column) => {
+                    return column.isVisible === true ? null : (
+                  <th {...column.getHeaderProps()}>{column.render('Header')}</th>
+                    );
+                    })}
+              </tr>
+            ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {rows.length ? (
+              rows.map((row, idx) => {
+                prepareRow(row);
+                return (
+                  <tr {...row.getRowProps()}>
+                    {row.cells.map((cell) => (
+                      <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+                    ))}
+                  </tr>
+                );
+              })
+            ) : (
+              <tr>
+                <td colSpan={5}>No active projects found.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+    );
+  };
+  export default ProjectSummaryListing;
+  

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useMemo } from 'react';
-import { useTable, Column, FooterProps, Cell } from 'react-table';
-import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
-import { ProjectTitle, ProjectSummary, Allocations } from './ProjectsCells';
+import React, { useMemo } from 'react';
+import { useTable, Column } from 'react-table';
+import { LoadingSpinner, InlineMessage, SectionTableWrapper } from '@tacc/core-components';
+import { ProjectTitle, ProjectSummary } from './ProjectsCells';
 import {
-  ProjectsAllocations,
   ProjectsRawSystem,
   useProjects,
 } from '@tacc/tup-hooks';
@@ -17,13 +16,11 @@ export const ProjectSummaryListing: React.FC = () => {
         accessor: 'title',
         Header: 'Active Projects',
         Cell: ProjectTitle,
-        Footer: 'Storage: ' + ' SUs',
         columns: [
           {
             accessor: 'title',
             Header: 'Project Summary',
             Cell: ProjectSummary,
-            Footer: 'Compute: ' + ' SUs',
           },
         ],
       },
@@ -37,7 +34,6 @@ export const ProjectSummaryListing: React.FC = () => {
     rows,
     prepareRow,
     headerGroups,
-    footerGroups,
   } = useTable({
     columns,
     data: data ?? [],
@@ -51,51 +47,40 @@ export const ProjectSummaryListing: React.FC = () => {
     );
   }
   return (
-    <table {...getTableProps()}>
-      <thead>
-        {headerGroups.map((headerGroup) => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map((column) => {
-              return column.isVisible === true ? null : (
-                <th {...column.getHeaderProps()}>{column.render('Header')}</th>
-              );
-            })}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()}>
-        {rows.length ? (
-          rows.map((row, idx) => {
-            prepareRow(row);
-            return (
-              <tr {...row.getRowProps()}>
-                {row.cells.map((cell) => (
-                  <td {...cell.getCellProps()}>
-                    {cell.render('Cell')}
-                    <tfoot>
-                      {' '}
-                      {footerGroups.map((footerGroup) => (
-                        <td colSpan={2} {...footerGroup.getFooterGroupProps()}>
-                          {footerGroup.headers.map((column) => (
-                            <td {...column.getFooterProps}>
-                              {column.render('Footer')}
-                            </td>
-                          ))}
-                        </td>
-                      ))}
-                    </tfoot>
-                  </td>
-                ))}
-              </tr>
-            );
-          })
-        ) : (
-          <tr>
-            <td colSpan={5}>No active projects found.</td>
-          </tr>
-        )}
-      </tbody>
-    </table>
+    <SectionTableWrapper>
+      <table {...getTableProps()}>
+        <thead>
+          {headerGroups.map((headerGroup) => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column) => {
+                return column.isVisible === true ? null : (
+                  <th {...column.getHeaderProps()}>{column.render('Header')}</th>
+                );
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {rows.length ? (
+            rows.map((row, idx) => {
+              prepareRow(row);
+              return (
+                <tr {...row.getRowProps()}>
+                  {row.cells.map((cell) => (
+                    <td {...cell.getCellProps()}>
+                      {cell.render('Cell')}
+                    </td>
+                  ))}
+                </tr>
+            )})
+          ) : (
+            <tr>
+              <td colSpan={5}>No active projects found.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </SectionTableWrapper>
   );
 };
 export default ProjectSummaryListing;

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -1,23 +1,27 @@
-import React, { useMemo } from 'react';
-import { useTable, Column } from 'react-table';
+import React, { useEffect, useMemo } from 'react';
+import { useTable, Column, FooterProps, Cell } from 'react-table';
 import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
-import { ProjectSummary } from './ProjectsCells';
-import { ProjectsRawSystem, useProjects } from '@tacc/tup-hooks';
+import { ProjectTitle, ProjectSummary, Allocations } from './ProjectsCells';
+import { ProjectsAllocations, ProjectsRawSystem, useProjects } from '@tacc/tup-hooks';
+
 
 export const ProjectSummaryListing: React.FC = () => {
     const { data, isLoading, error } = useProjects();
+
     const columns = useMemo<Column<ProjectsRawSystem>[]>(
         () => [
           {
             accessor: 'title',
-            Header: 'Project Title',
-            Cell: ProjectSummary,
+            Header: 'Active Projects',
+            Cell: ProjectTitle,
+            Footer: ({allocations}) => allocations ? allocations.map((e) => e.resource).join(', ') : '--',
             columns:
             [
                 {
                     accessor: 'title',
-                    Header: 'Project Title',
+                    Header: 'Project Summary',
                     Cell: ProjectSummary,
+                    Footer: ({allocations}) => allocations ? allocations.map((e) => e.resource).join(', ') : '--',
                 },
             ],
           },
@@ -25,7 +29,7 @@ export const ProjectSummaryListing: React.FC = () => {
       []
     );
 
-    const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups } =
+    const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups, footerGroups } =
       useTable({
         columns,
         data: data ?? [],
@@ -58,17 +62,29 @@ export const ProjectSummaryListing: React.FC = () => {
                 return (
                   <tr {...row.getRowProps()}>
                     {row.cells.map((cell) => (
-                      <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
-                    ))}
-                  </tr>
+                      <td {...cell.getCellProps()}>{cell.render('Cell')}
+                    <tfoot> {
+                      footerGroups.map(footerGroup => (
+                        <td colSpan={2} {...footerGroup.getFooterGroupProps()}>
+                          {
+                            footerGroup.headers.map(column => (
+                              <td {...column.getFooterProps}>
+                                {column.render('Footer')}
+                              </td>
+                            ))}
+                        </td>
+                      ))}
+                    </tfoot></td>
+                    ))}</tr>   
                 );
               })
-            ) : (
-              <tr>
-                <td colSpan={5}>No active projects found.</td>
-              </tr>
-            )}
-          </tbody>
+              ) : (
+                <tr>
+                  <td colSpan={5}>No active projects found.</td>
+                </tr>
+              )}
+            </tbody>
+
         </table>
     );
   };

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -2,91 +2,100 @@ import React, { useEffect, useMemo } from 'react';
 import { useTable, Column, FooterProps, Cell } from 'react-table';
 import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
 import { ProjectTitle, ProjectSummary, Allocations } from './ProjectsCells';
-import { ProjectsAllocations, ProjectsRawSystem, useProjects } from '@tacc/tup-hooks';
-
+import {
+  ProjectsAllocations,
+  ProjectsRawSystem,
+  useProjects,
+} from '@tacc/tup-hooks';
 
 export const ProjectSummaryListing: React.FC = () => {
-    const { data, isLoading, error } = useProjects();
+  const { data, isLoading, error } = useProjects();
 
-    const columns = useMemo<Column<ProjectsRawSystem>[]>(
-        () => [
+  const columns = useMemo<Column<ProjectsRawSystem>[]>(
+    () => [
+      {
+        accessor: 'title',
+        Header: 'Active Projects',
+        Cell: ProjectTitle,
+        Footer: 'Storage: ' + ' SUs',
+        columns: [
           {
             accessor: 'title',
-            Header: 'Active Projects',
-            Cell: ProjectTitle,
-            Footer: ({allocations}) => allocations ? allocations.map((e) => e.resource).join(', ') : '--',
-            columns:
-            [
-                {
-                    accessor: 'title',
-                    Header: 'Project Summary',
-                    Cell: ProjectSummary,
-                    Footer: ({allocations}) => allocations ? allocations.map((e) => e.resource).join(', ') : '--',
-                },
-            ],
+            Header: 'Project Summary',
+            Cell: ProjectSummary,
+            Footer: 'Compute: ' + ' SUs',
           },
-          ],
-      []
-    );
+        ],
+      },
+    ],
+    []
+  );
 
-    const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups, footerGroups } =
-      useTable({
-        columns,
-        data: data ?? [],
-      });
-    if (isLoading) {
-      return <LoadingSpinner />;
-    }
-    if (error) {
-      return (
-        <InlineMessage type="warn">Unable to retrieve projects.</InlineMessage>
-      );
-    }
+  const {
+    getTableProps,
+    getTableBodyProps,
+    rows,
+    prepareRow,
+    headerGroups,
+    footerGroups,
+  } = useTable({
+    columns,
+    data: data ?? [],
+  });
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+  if (error) {
     return (
-        <table {...getTableProps()}>
-          <thead>
-            {headerGroups.map((headerGroup) => (
-              <tr {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column) => {
-                    return column.isVisible === true ? null : (
-                  <th {...column.getHeaderProps()}>{column.render('Header')}</th>
-                    );
-                    })}
-              </tr>
-            ))}
-          </thead>
-          <tbody {...getTableBodyProps()}>
-            {rows.length ? (
-              rows.map((row, idx) => {
-                prepareRow(row);
-                return (
-                  <tr {...row.getRowProps()}>
-                    {row.cells.map((cell) => (
-                      <td {...cell.getCellProps()}>{cell.render('Cell')}
-                    <tfoot> {
-                      footerGroups.map(footerGroup => (
+      <InlineMessage type="warn">Unable to retrieve projects.</InlineMessage>
+    );
+  }
+  return (
+    <table {...getTableProps()}>
+      <thead>
+        {headerGroups.map((headerGroup) => (
+          <tr {...headerGroup.getHeaderGroupProps()}>
+            {headerGroup.headers.map((column) => {
+              return column.isVisible === true ? null : (
+                <th {...column.getHeaderProps()}>{column.render('Header')}</th>
+              );
+            })}
+          </tr>
+        ))}
+      </thead>
+      <tbody {...getTableBodyProps()}>
+        {rows.length ? (
+          rows.map((row, idx) => {
+            prepareRow(row);
+            return (
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell) => (
+                  <td {...cell.getCellProps()}>
+                    {cell.render('Cell')}
+                    <tfoot>
+                      {' '}
+                      {footerGroups.map((footerGroup) => (
                         <td colSpan={2} {...footerGroup.getFooterGroupProps()}>
-                          {
-                            footerGroup.headers.map(column => (
-                              <td {...column.getFooterProps}>
-                                {column.render('Footer')}
-                              </td>
-                            ))}
+                          {footerGroup.headers.map((column) => (
+                            <td {...column.getFooterProps}>
+                              {column.render('Footer')}
+                            </td>
+                          ))}
                         </td>
                       ))}
-                    </tfoot></td>
-                    ))}</tr>   
-                );
-              })
-              ) : (
-                <tr>
-                  <td colSpan={5}>No active projects found.</td>
-                </tr>
-              )}
-            </tbody>
-
-        </table>
-    );
-  };
-  export default ProjectSummaryListing;
-  
+                    </tfoot>
+                  </td>
+                ))}
+              </tr>
+            );
+          })
+        ) : (
+          <tr>
+            <td colSpan={5}>No active projects found.</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+};
+export default ProjectSummaryListing;

--- a/libs/tup-components/src/projects/index.ts
+++ b/libs/tup-components/src/projects/index.ts
@@ -1,3 +1,4 @@
 export { default as ProjectsTable } from './ProjectsTable';
 export { default as ProjectsDashboard } from './ProjectsDashboard';
 export { default as ProjectsLayout } from './ProjectsLayout';
+export { default as ProjectsSummaryListing } from './ProjectsSummaryListing';

--- a/libs/tup-hooks/src/index.ts
+++ b/libs/tup-hooks/src/index.ts
@@ -111,7 +111,7 @@ export type ProjectsRawSystem = {
   id: number;
   title: string;
   description: string;
-  chardeCode: string;
+  chargeCode: string;
   gid: number;
   source: string;
   fieldId: number;

--- a/libs/tup-hooks/src/index.ts
+++ b/libs/tup-hooks/src/index.ts
@@ -117,6 +117,10 @@ export type ProjectsRawSystem = {
   fieldId: number;
   secondaryFieldId: number;
   typeId: number;
+  totalStorageUsed?: number;
+  totalStorageRequested?: number;
+  totalComputeRequested?: number;
+  totalComputeUsed?: number;
   pi: {
     id: number;
     username: string;

--- a/libs/tup-hooks/src/index.ts
+++ b/libs/tup-hooks/src/index.ts
@@ -1,5 +1,4 @@
 import { setLogger } from 'react-query';
-import { string } from 'yup';
 
 // Disable error logging when we throw inside a react-query fetcher method.
 setLogger({


### PR DESCRIPTION
## Overview:
Created one column table to eventually be able to map to separate systems table component for Projects page. 

## Related:

- [TUP-373](https://jira.tacc.utexas.edu/browse/TUP-373)

## Changes:

- Created new ProjectSummaryListing component. 
- Added new cells to ProjectCells. Added types to the existing ProjectRawSystem type in tup-hooks. 
- Added tests for ProjectSummaryListing component.

## Testing:

1. Go to [localhost:8000/dashboard](localhost:8000/dashboard)
2. Click the Projects tab from the sidebar
3. Make sure listing populate correctly. Compare with the existing TUP site [here.](https://portal.tacc.utexas.edu/projects-and-allocations)
4. Go back to dashboard and click the link above the Projects table
5. Make sure the results are the same as the other view. 

## UI:
<img width="658" alt="Screen Shot 2022-12-13 at 1 54 57 PM" src="https://user-images.githubusercontent.com/96220951/207431199-61e1b30b-1330-42a6-897c-867198d76e0f.png">

## Notes:
- Please send feedback! Tried to keep styling as dry as possible. I want to refactor eventually so that a hook gathers the allocation usage rather than having the calculations inside component. 

-There's some discrepancies in the numbers between existing TUP and what I'm getting back in the response for my usage specifically for the Advanced Computing Interfaces' Project TACC-ACI. 

 ** Is this because the old TUP is still factoring in Longhorn and the new TUP is not?
