### PR TITLE
feat: new font sizes - cms & portal

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:d8080a9
+FROM taccwma/core-cms:c7d1761
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:407fb21
+FROM taccwma/core-cms:d8080a9
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:e342d51
+FROM taccwma/core-cms:76dc2f5
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:c7d1761
+FROM taccwma/core-cms:e342d51
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/apps/dashboard/templates/dashboard/assets.html
+++ b/apps/tup-cms/src/apps/dashboard/templates/dashboard/assets.html
@@ -3,6 +3,7 @@
 <style>
   /* TODO: What of cms.css can move to base.css (so we don't load cms here)? */
   @import url("{% static 'site_cms/css/build/core-styles.cms.css' %}") layer(base);
+  @import url("{% static 'site_cms/css/build/core-styles.portal.css' %}") layer(base);
   @import url("{% static 'site_cms/css/build/core-styles.header.css' %}") layer(base);
 </style>
 <style>

--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -19,6 +19,20 @@ body > main {
   flex-grow: 1;
 }
 
+/* To give Portal its own scrollbar */
 #cms-content {
   overflow: auto;
+}
+
+/* Headings */
+h1, h2, h3, h4, h5, h6 {
+  margin-block: 0; /* overwrite Bootstrap <h1> through <h6> */
+}
+h1 {
+  font-size: var(--global-font-size--x-large);
+  font-weight: var(--regular);
+}
+h2 {
+  font-size: var(--global-font-size--large);
+  font-weight: var(--bold);
 }

--- a/apps/tup-ui/src/pages/Login/Login.module.css
+++ b/apps/tup-ui/src/pages/Login/Login.module.css
@@ -36,7 +36,7 @@
   gap: 1.5em;
   margin-top: var(--global-space--normal);
 
-  font-size: var(--global-font-size--x-small); /* use standard nearest design */
+  font-size: var(--global-font-size--small);
   font-weight: var(--bold);
 
   @media (--narrow-and-below) {

--- a/apps/tup-ui/src/pages/Login/Login.module.css
+++ b/apps/tup-ui/src/pages/Login/Login.module.css
@@ -36,6 +36,7 @@
   gap: 1.5em;
   margin-top: var(--global-space--normal);
 
+  font-family: var(--global-font-family--sans--cms);
   font-size: var(--global-font-size--small);
   font-weight: var(--bold);
 

--- a/libs/core-components/src/lib/SectionHeader/SectionHeader.jsx
+++ b/libs/core-components/src/lib/SectionHeader/SectionHeader.jsx
@@ -45,7 +45,7 @@ function SectionHeader({
 }) {
   let styleName = '';
   const styleNameList = [styles['root']];
-  const HeadingTagName = isForForm || isForTable || isForList ? 'h3' : 'h2';
+  const HeadingTagName = isForForm || isForTable || isForList ? 'h2' : 'h1';
 
   if (isForForm) styleNameList.push(styles['for-form']);
   if (isForTable) styleNameList.push(styles['for-table']);

--- a/libs/core-components/src/lib/SectionHeader/SectionHeader.module.css
+++ b/libs/core-components/src/lib/SectionHeader/SectionHeader.module.css
@@ -1,6 +1,3 @@
-@import url('@tacc/core-styles/dist/settings/border.css');
-@import url('@tacc/core-styles/dist/settings/color.css');
-
 /* Block */
 
 .root {
@@ -8,37 +5,28 @@
   justify-content: space-between;
   align-items: flex-end;
   flex-wrap: wrap;
-
   align-content: flex-end; /* preserve alignment of items when wrapped */
 
-  min-height: 2rem;
-  box-sizing: content-box;
-
-  padding-bottom: 0.75rem; /* 12px (~10px design * 1.2 design-to-app ratio) */
-  border-bottom: var(--global-border-width--normal) solid
-    var(--global-color-primary--dark);
+  margin-bottom: 15px;
 }
+.root:not(.for-form, .for-table, .for-list) {
+  padding-bottom: 15px;
+  border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--dark);
+}
+
+
 
 /* Elements */
 
-/* Add vertical space between children that, without wrapping, is invisible */
-/* FAQ: Take away space added, in direction that does not disturb other CSS */
-/* WARNING: `DataFilesToolbar.scss` needs `margin-bottom` */
-.root {
-  margin-top: -5px;
-}
-.root > * {
-  margin-top: 5px;
-}
-
-/* Do not allow external margin styles */
-.heading {
-  margin-bottom: 0; /* Overwrite Bootstrap `h1`–`h6` styles */
-}
-/* Header actions are always after heading text */
+/* Elements: Header Actions */
 .heading ~ * {
   max-height: 100%; /* (gently) force oversized elements to fit */
 }
+.heading ~ a {
+  font-weight: var(--bold);
+}
+
+
 
 /* Modifiers */
 

--- a/libs/core-components/src/lib/SectionHeader/SectionHeader.test.js
+++ b/libs/core-components/src/lib/SectionHeader/SectionHeader.test.js
@@ -57,7 +57,7 @@ describe('SectionHeader', () => {
         expect(container.querySelector(`[class*="${className}"]`)).not.toEqual(
           null
         );
-        expect(getByText('Heading').tagName.toLowerCase()).toEqual('h1');
+        expect(getByText('Heading').tagName.toLowerCase()).toEqual('h2');
       }
     );
   });

--- a/libs/core-components/src/lib/SectionHeader/SectionHeader.test.js
+++ b/libs/core-components/src/lib/SectionHeader/SectionHeader.test.js
@@ -57,7 +57,7 @@ describe('SectionHeader', () => {
         expect(container.querySelector(`[class*="${className}"]`)).not.toEqual(
           null
         );
-        expect(getByText('Heading').tagName.toLowerCase()).toEqual('h3');
+        expect(getByText('Heading').tagName.toLowerCase()).toEqual('h1');
       }
     );
   });

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
@@ -54,10 +54,6 @@
   /* @tacc/core-styles#22783d8:/src/lib/_imports/elements/form.cms.css#L56 */
   padding: 12px 12px;
 }
-/* TODO: Fix this in @tacc/core-styles (then remove this) */
-.root label {
-  font-weight: var(--medium);
-}
 
 
 

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
@@ -46,6 +46,10 @@
 
 /* FORM */
 
+/* To hide "(required)" which is obvious ona  login form */
+.root label :global(.c-form__star) {
+  display: none;
+}
 /* TODO: Do not load CMS CSS (except header) on Portal app (then remove this) */
 .field {
   max-width: unset; /* undo Core-CMS forms.cms.css */

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
@@ -2,6 +2,7 @@
 
 .root {
   font-size: 1.6rem;
+  font-family: var(--global-font-family--sans--cms);
 }
 
 
@@ -19,6 +20,7 @@
 .title,
 .subtitle {
   text-align: center;
+  color: var(--global-color-primary--xx-dark);
 }
 .title {
   font-size: 2.4rem;
@@ -36,7 +38,6 @@
 }
 
 .subtitle {
-  color: var(--global-color-primary--xx-dark);
   font-weight: var(--medium); /* mimics value--not appearance--from design */
   margin-block: 25px; /* mimics Core-CMS django.cms.forms.css .description */
 }

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
@@ -1,6 +1,8 @@
 /* CONTAINER */
 
-/* .root {} */
+.root {
+  font-size: 1.6rem;
+}
 
 
 
@@ -19,7 +21,11 @@
   text-align: center;
 }
 .title {
+  font-size: 2.4rem;
   font-weight: var(--black);
+}
+.subtitle {
+  font-size: 1.6rem;
 }
 
 .logo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@nrwl/react": "15.0.6",
         "@nrwl/web": "15.0.6",
         "@nrwl/workspace": "15.0.6",
-        "@tacc/core-styles": "github:TACC/Core-Styles#task/new-font-sizes-for-cms-and-portal",
+        "@tacc/core-styles": "github:TACC/Core-Styles#task/custom-cms-and-portal-styles",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@types/jest": "28.1.8",
@@ -5599,7 +5599,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#17a9393cf598331e1d96926838898cf43160ed23",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9d6d6c639d17a8bcb52976bb2d7657d35589d412",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -29288,9 +29288,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#17a9393cf598331e1d96926838898cf43160ed23",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9d6d6c639d17a8bcb52976bb2d7657d35589d412",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/new-font-sizes-for-cms-and-portal",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/custom-cms-and-portal-styles",
       "requires": {}
     },
     "@testing-library/dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5599,7 +5599,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9d6d6c639d17a8bcb52976bb2d7657d35589d412",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#bcda55bc6a4d30e93bce8f8fa9003b42538ae00a",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -29288,7 +29288,7 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9d6d6c639d17a8bcb52976bb2d7657d35589d412",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#bcda55bc6a4d30e93bce8f8fa9003b42538ae00a",
       "dev": true,
       "from": "@tacc/core-styles@github:TACC/Core-Styles#task/custom-cms-and-portal-styles",
       "requires": {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@nrwl/react": "15.0.6",
         "@nrwl/web": "15.0.6",
         "@nrwl/workspace": "15.0.6",
-        "@tacc/core-styles": "github:TACC/Core-Styles#382ab54",
+        "@tacc/core-styles": "github:TACC/Core-Styles#task/new-font-sizes-for-cms-and-portal",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@types/jest": "28.1.8",
@@ -5599,7 +5599,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#382ab54045db5112fa7270388e494f4d7e19d136",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#17a9393cf598331e1d96926838898cf43160ed23",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -29288,9 +29288,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#382ab54045db5112fa7270388e494f4d7e19d136",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#17a9393cf598331e1d96926838898cf43160ed23",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#382ab54",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/new-font-sizes-for-cms-and-portal",
       "requires": {}
     },
     "@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nrwl/react": "15.0.6",
     "@nrwl/web": "15.0.6",
     "@nrwl/workspace": "15.0.6",
-    "@tacc/core-styles": "github:TACC/Core-Styles#task/new-font-sizes-for-cms-and-portal",
+    "@tacc/core-styles": "github:TACC/Core-Styles#task/custom-cms-and-portal-styles",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@types/jest": "28.1.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nrwl/react": "15.0.6",
     "@nrwl/web": "15.0.6",
     "@nrwl/workspace": "15.0.6",
-    "@tacc/core-styles": "github:TACC/Core-Styles#382ab54",
+    "@tacc/core-styles": "github:TACC/Core-Styles#task/new-font-sizes-for-cms-and-portal",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@types/jest": "28.1.8",


### PR DESCRIPTION
## Overview

1. Load font variables and un-styled* headings from Core-Styles and new CMS image.
    <sup>* Technically, Bootstrap has styled them, but please do not remind me. I fantasize I am not building atop Bootstrap.</sup>
3. Style headings on CMS and Portal.

## Related

- requires https://github.com/TACC/Core-Styles/pull/90
- includes #91
- includes #88
- required by #90

## Changes

- changed https://github.com/TACC/Core-CMS image
- added `core-styles.portal.css` load
- added styles for headings
- changed `<Section…>` components to use `<h1>` and `<h2>`
- changed `<Section…>` components to use simpler CSS
- changed https://github.com/TACC/Core-Styles commit

## Testing & UI

[Deployed to dev.tup on 2022-12-20.](https://tacc-team.slack.com/archives/C02GF2X2AS3/p1671571908970539)

### Login Page Matches [Design](https://xd.adobe.com/view/5d4860e3-cdbc-4e17-ab11-c411437e31c7-081b/specs/)

Except for "Email or" of "Email or User Name" and "User " or "User Policies".

| Login Form | Login Footer Font Size Fix |
| - | - |
| ![Login Form](https://user-images.githubusercontent.com/62723358/208556296-9f4003f9-48c8-4d4b-8b05-1479f51e53cd.png) | ![Login Footer Link Font Size Fix](https://user-images.githubusercontent.com/62723358/208556292-0d58a11e-230a-4700-ae24-af26b441efde.png) |

### Portal Heading Size & Styles Match [Design](https://xd.adobe.com/view/cc3dc245-2792-4e10-bdc1-50d2a7d32979-996e/screen/b1728cf1-1c38-45d1-91c3-560b803632cd/specs/)

Dashboard layout is fixed in #90.

| Dashboard (scroll up) | Dashboard (scroll down) | Projects |
| - | - | - |
| ![Dashboard - Up](https://user-images.githubusercontent.com/62723358/208556350-22dbbf85-868f-46e6-b678-ef7392c07f67.png) | ![Dashboard - Down](https://user-images.githubusercontent.com/62723358/208556349-7438ebbb-51fa-40db-b06c-8a36418e5982.png) | ![Projects](https://user-images.githubusercontent.com/62723358/208556346-f2e77151-2823-4571-bcdc-2b69c858be16.png) |

### Core Styles Demo Testing

<details><summary>Heading Elements Pattern (Prototype)</summary>

\
Intentionally not styled. I will move CMS and Portal heading styles into Core only after they are approved in clients. CMS is styling headings via a snippet. Portal is styling headings via global CSS (in this PR).

| CMS | Portal |
| - | - |
| ![Headings CMS - Preview](https://user-images.githubusercontent.com/62723358/208765712-12cbd1ac-1616-44d6-9b8a-f38ea5aa634d.png) | ![Headings Portal - Preview](https://user-images.githubusercontent.com/62723358/208765716-1f275bdd-7b9b-4f4c-8c78-e0e1edb2a974.png) |

</details>

<details><summary>Font Settings Pattern (Ready)</summary>

| CMS | Portal |
| - | - |
| ![Font CMS - Preview](https://user-images.githubusercontent.com/62723358/208765720-aac13e6f-a9ca-4a34-a5ae-db3c44da678b.png) | ![Font Portal - Preview](https://user-images.githubusercontent.com/62723358/208765721-4ebfe5ca-58e9-4e8a-b19f-19affcacb6f7.png) |
| ![Font CMS - Complete](https://user-images.githubusercontent.com/62723358/208765719-e43d1a7f-f8b2-44e6-b038-7eea21a60207.png) | ![Font Portal - Complete](https://user-images.githubusercontent.com/62723358/208765723-ed0f820f-a522-46c5-8ed5-5553e85e3c78.png)

</details>