### PR TITLE
Tup 374 allocation table display

### DIFF
--- a/libs/tup-components/src/allocations/Allocation.module.css
+++ b/libs/tup-components/src/allocations/Allocation.module.css
@@ -1,0 +1,80 @@
+.root {
+    --table-border: 1px solid black;
+  
+    margin: 0;
+    width: 100%;
+  
+    font-size: 0.875rem; /* 14px (approved deviation from design) */
+    
+  }
+  
+  .rows tr:nth-child(even) {
+    background-color: rgb(0 0 0 / 3%);
+  }
+  .rows tr:hover {
+    background-color: rgb(0 0 0 / 5%);
+  }
+  .rows td {
+    padding: 5px 8px;
+    white-space: pre-wrap;
+  }
+  
+  .header {
+    border-bottom: var(--table-border);
+  }
+  
+  /* Columns */
+  @media only screen and (min-width: 1200px) {
+    /* name */
+    .root tr > *:nth-child(1) {
+      width: 22%;
+    }
+    /* status */
+    .root tr > *:nth-child(2) {
+      width: 30%;
+    }
+    /* load */
+    .root tr > *:nth-child(3) {
+      width: 16%;
+    }
+    /* run */
+    .root tr > *:nth-child(4) {
+      width: 16%;
+    }
+    /* queue */
+    .root tr > *:nth-child(5) {
+      width: 16%;
+    }
+  }
+  @media only screen and (max-width: 1199px) {
+    /* name */
+    .root tr > *:nth-child(1) {
+      width: 22%;
+    }
+    /* status */
+    .root tr > *:nth-child(2) {
+      width: 24%;
+    }
+    /* load */
+    .root tr > *:nth-child(3) {
+      width: 18%;
+    }
+    /* run */
+    .root tr > *:nth-child(4) {
+      width: 18%;
+    }
+    /* queue */
+    .root tr > *:nth-child(5) {
+      width: 18%;
+    }
+  }
+  
+  /* Messaging */
+  .error {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--global-color-accent--normal);
+    padding: 30px;
+  }
+  

--- a/libs/tup-components/src/allocations/Allocation.module.css
+++ b/libs/tup-components/src/allocations/Allocation.module.css
@@ -16,7 +16,6 @@
   }
   .rows td {
     padding: 5px 8px;
-    white-space: pre-wrap;
   }
   
   .header {
@@ -76,5 +75,9 @@
     align-items: center;
     color: var(--global-color-accent--normal);
     padding: 30px;
+  }
+
+  .list{
+    white-space: pre-wrap;
   }
   

--- a/libs/tup-components/src/allocations/AllocationCells.tsx
+++ b/libs/tup-components/src/allocations/AllocationCells.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import { Cell } from 'react-table';
-import { ProjectsRawSystem } from '@tacc/tup-hooks';
-import { formatDate } from '../utils/timeFormat';
-
-export const DateExpires: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
-  cell: { value },
-}) => <span>{ value.split(', ').map((e)=> `${formatDate(new Date(e))}`).join("\n") }</span> ;

--- a/libs/tup-components/src/allocations/AllocationCells.tsx
+++ b/libs/tup-components/src/allocations/AllocationCells.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Cell } from 'react-table';
+import { ProjectsRawSystem } from '@tacc/tup-hooks';
+import { formatDate } from '../utils/timeFormat';
+
+export const DateExpires: React.FC<{ cell: Cell<ProjectsRawSystem, string> }> = ({
+  cell: { value },
+}) => <span>{ value.split(', ').map((e)=> `${formatDate(new Date(e))}`).join("\n") }</span> ;

--- a/libs/tup-components/src/allocations/AllocationTable.test.tsx
+++ b/libs/tup-components/src/allocations/AllocationTable.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { AllocationsTable } from './AllocationTable';
+import { server, testRender } from '@tacc/tup-testing';
+import { screen,waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+
+describe('Projects Allocation Table', () => {
+  it('should display a spinner while loading', async () => {
+    const { getByTestId } = testRender(<AllocationsTable />);
+    expect(getByTestId('loading-spinner')).toBeDefined();
+  });
+  it('should display an error message if an error is returned', async () => {
+    server.use(
+      rest.get('http://localhost:8001/projects', (req, res, ctx) =>
+        res.once(ctx.status(404))
+      )
+    );
+    testRender(<AllocationsTable />);
+    await screen.findAllByText(/Unable to retrieve allocation information./);
+  });
+  it('should display project allocation information', async () => {
+    const { getByText, getByTestId, getAllByRole } = testRender(
+        <AllocationsTable />
+      );;
+    await waitFor(() => getAllByRole('columnheader'));
+    const columnHeaders: HTMLElement[] = getAllByRole('columnheader');
+    expect(columnHeaders[0].textContent).toEqual('Active Resources');
+    expect(columnHeaders[1].textContent).toEqual('Awarded');
+    expect(columnHeaders[2].textContent).toEqual('Used');
+    expect(columnHeaders[3].textContent).toEqual('Expires');
+    expect(getByText('Lonestar6')).toBeDefined();
+    expect(getByText('10')).toBeDefined();
+    expect(getByText('0')).toBeDefined();
+    expect(getByText('09/30/2023')).toBeDefined();
+  });
+});

--- a/libs/tup-components/src/allocations/AllocationTable.tsx
+++ b/libs/tup-components/src/allocations/AllocationTable.tsx
@@ -1,160 +1,44 @@
-import React, { useMemo } from 'react';
-import { useTable, Column } from 'react-table';
-import { LoadingSpinner, InlineMessage, InfiniteScrollTable } from '@tacc/core-components';
-import { ProjectsRawSystem, useProjects, ProjectsAllocations, useProjectsAllocations } from '@tacc/tup-hooks';
-import { DateExpires } from './AllocationCells';
+import React from 'react';
+import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
+import { useProjects } from '@tacc/tup-hooks';
+import { formatDate } from '../utils/timeFormat';
 import styles from './Allocation.module.css';
-
-// export const AllocationsTable: React.FC = () => {
-//   const { data, isLoading, error } = useProjectsAllocations();
-//   const columns = useMemo<Column<ProjectsAllocations>[]>(
-//     () => [
-//         {
-//           accessor: 'resource',
-//           Header: 'Active Resources',
-//           // Cell: Allocations,
-//         },
-//         {
-//           accessor: 'total',
-//           Header: 'Awarded',
-//         },
-//         {
-//           accessor: 'used',
-//           Header: 'Used',
-//         },
-//         {
-//           accessor: 'end',
-//           Header: 'Expires',
-//           // Cell: DateExpires,
-//         },
-//       ],
-//       []
-//   );
 
 export const AllocationsTable: React.FC = () => {
 const { data, isLoading, error } = useProjects();
-const columns = useMemo<Column<ProjectsRawSystem>[]>(
-    () => [
-      {
-        accessor: ({ allocations }) =>
-          allocations ? allocations.map((e) => e.resource).join('\n') : '--',
-        Header: 'Active Resources',
-        // Cell: Allocations,
-      },
-      {
-        accessor: ({ allocations }) =>
-        allocations ? allocations.map((e) => e.total).join('\n') : '--',
-        Header: 'Awarded',
-      },
-      {
-        accessor: ({ allocations }) =>
-        allocations ? allocations.map((e) => e.used).join('\n') : '--',
-        Header: 'Used',
-      },
-      {
-        accessor: ({ allocations }) =>
-        allocations ? allocations.map((e) => e.end).join(', ') : '--',
-        Header: 'Expires',
-        Cell: DateExpires,
-      },
-    ],
-    []
-  );
 
-  const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups } =
-    useTable({
-      columns,
-      data: data ?? [],
-    });
   if (isLoading) {
     return <LoadingSpinner />;
   }
+
   if (error) {
     return (
-      <InlineMessage type="warn">Unable to retrieve projects.</InlineMessage>
+      <InlineMessage type="warn">Unable to retrieve allocation information.</InlineMessage>
     );
   }
-
+  
   return (
     <div>
-      {data?.map(project => project.allocations.map(e =>{
-        return (
-          <table className={styles['usage-table']}>
-            <thead>
-              <tr>
-                <th>Active Resources</th>
-                <th>Awarded</th>
-                <th>Used</th>
-                <th>Expires</th>
-              </tr>
-            </thead>
-            <tbody>
-                <tr>
-                  <th>{project.allocations?.map(e => e.resource)}</th>
-                  <th>{project.allocations?.map(e => e.total)}</th>
-                  <th>{project.allocations?.map(e => e.used)}</th>
-                </tr>            
-            </tbody>
-          </table>
-        )
-      }))}
+      {data?.map((project) => (
+        <table className={styles['usage-table']}>
+          <thead>
+            <tr>
+              <th>Active Resources</th>
+              <th>Awarded</th>
+              <th>Used</th>
+              <th>Expires</th>
+            </tr>
+          </thead>
+          <tbody>
+              <tr className={styles['list']}>
+                <th>{project.allocations?.map(e => e.resource).join('\n')}</th>
+                <th>{project.allocations?.map(e => e.total).join('\n')}</th>
+                <th>{project.allocations?.map(e => e.used).join('\n')}</th>
+                <th>{project.allocations?.map(e => e.end).join(', ').split(', ').map((e)=> `${formatDate(new Date(e))}`).join("\n")}</th>
+              </tr>            
+          </tbody>
+        </table>
+      ))}
     </div>
-  )};
-
-//   return (
-//     <table className={styles['usage-table']}>
-//       <thead>
-//         <tr>
-//           <th>Active Resources</th>
-//           <th>Awarded</th>
-//           <th>Used</th>
-//           <th>Expires</th>
-//         </tr>
-//       </thead>
-//       <tbody>
-//         {data?.map((allocation) => (
-//           <tr key={allocation.resource}>
-//             <th>{allocation.resource}</th>
-//             <th>{allocation.total}</th>
-//             <th>{allocation.used}</th>
-//           </tr>
-//         ))}
-//       </tbody>
-//     </table>
-//   );
-// };
-
-//     return (
-//     <div className="o-fixed-header-table">
-//       <table {...getTableProps()}>
-//         <thead>
-//           {headerGroups.map((headerGroup) => (
-//             <tr {...headerGroup.getHeaderGroupProps()}>
-//               {headerGroup.headers.map((column) => (
-//                 <th {...column.getHeaderProps()}>{column.render('Header')}</th>
-//               ))}
-//             </tr>
-//           ))}
-//         </thead>
-//         <tbody {...getTableBodyProps()} className={styles['rows']}>
-//           {rows.length ? (
-//             rows.map((row) => {
-//               prepareRow(row);
-//               return (
-//                 <tr {...row.getRowProps()}>
-//                   {row.cells.map((cell) => (
-//                     <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
-//                   ))}
-//                 </tr>
-//               );
-//             })
-//           ) : (
-//             <tr>
-//               <td colSpan={5}>No active projects found.</td>
-//             </tr>
-//           )}
-//         </tbody>
-//       </table>
-//     </div>
-//   );
-// };
+  );
+};

--- a/libs/tup-components/src/allocations/AllocationTable.tsx
+++ b/libs/tup-components/src/allocations/AllocationTable.tsx
@@ -1,0 +1,102 @@
+import React, { useMemo } from 'react';
+import { useTable, Column, useSortBy } from 'react-table';
+import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
+import { ProjectsRawSystem, useProjects, ProjectsAllocations, useProjectsAllocations } from '@tacc/tup-hooks';
+import { DateExpires } from './AllocationCells';
+import styles from './Allocation.module.css';
+
+// export const AllocationsTable: React.FC = () => {
+//   const { data, isLoading, error } = useProjectsAllocations();
+//   const columns = useMemo<Column<ProjectsAllocations>[]>(
+//     () => [
+//       {
+//         accessor: 'id',
+//         Header: 'ID',
+//       },
+//       {
+//         accessor: 'resource',
+//         Header: 'Resource',
+//       },
+//     ],
+//     []
+//   );
+
+export const AllocationsTable: React.FC = () => {
+const { data, isLoading, error } = useProjects();
+const columns = useMemo<Column<ProjectsRawSystem>[]>(
+    () => [
+      {
+        accessor: ({ allocations }) =>
+          allocations ? allocations.map((e) => e.resource).join('\n') : '--',
+        Header: 'Active Resources',
+        // Cell: Allocations,
+      },
+      {
+        accessor: ({ allocations }) =>
+        allocations ? allocations.map((e) => e.total).join('\n') : '--',
+        Header: 'Awarded',
+      },
+      {
+        accessor: ({ allocations }) =>
+        allocations ? allocations.map((e) => e.used).join('\n') : '--',
+        Header: 'Used',
+      },
+      {
+        accessor: ({ allocations }) =>
+        allocations ? allocations.map((e) => e.end).join(', ') : '--',
+        Header: 'Expires',
+        Cell: DateExpires,
+      },
+    ],
+    []
+  );
+
+  const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups } =
+    useTable({
+      columns,
+      data: data ?? [],
+    },
+    useSortBy,
+    );
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+  if (error) {
+    return (
+      <InlineMessage type="warn">Unable to retrieve projects.</InlineMessage>
+    );
+  }
+  return (
+    <div className="o-fixed-header-table">
+      <table {...getTableProps()}>
+        <thead>
+          {headerGroups.map((headerGroup) => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column) => (
+                <th {...column.getHeaderProps()}>{column.render('Header')}</th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()} className={styles['rows']}>
+          {rows.length ? (
+            rows.map((row) => {
+              prepareRow(row);
+              return (
+                <tr {...row.getRowProps()}>
+                  {row.cells.map((cell) => (
+                    <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+                  ))}
+                </tr>
+              );
+            })
+          ) : (
+            <tr>
+              <td colSpan={5}>No active projects found.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/libs/tup-components/src/allocations/AllocationTable.tsx
+++ b/libs/tup-components/src/allocations/AllocationTable.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
-import { useTable, Column, useSortBy } from 'react-table';
-import { LoadingSpinner, InlineMessage } from '@tacc/core-components';
+import { useTable, Column } from 'react-table';
+import { LoadingSpinner, InlineMessage, InfiniteScrollTable } from '@tacc/core-components';
 import { ProjectsRawSystem, useProjects, ProjectsAllocations, useProjectsAllocations } from '@tacc/tup-hooks';
 import { DateExpires } from './AllocationCells';
 import styles from './Allocation.module.css';
@@ -9,16 +9,26 @@ import styles from './Allocation.module.css';
 //   const { data, isLoading, error } = useProjectsAllocations();
 //   const columns = useMemo<Column<ProjectsAllocations>[]>(
 //     () => [
-//       {
-//         accessor: 'id',
-//         Header: 'ID',
-//       },
-//       {
-//         accessor: 'resource',
-//         Header: 'Resource',
-//       },
-//     ],
-//     []
+//         {
+//           accessor: 'resource',
+//           Header: 'Active Resources',
+//           // Cell: Allocations,
+//         },
+//         {
+//           accessor: 'total',
+//           Header: 'Awarded',
+//         },
+//         {
+//           accessor: 'used',
+//           Header: 'Used',
+//         },
+//         {
+//           accessor: 'end',
+//           Header: 'Expires',
+//           // Cell: DateExpires,
+//         },
+//       ],
+//       []
 //   );
 
 export const AllocationsTable: React.FC = () => {
@@ -55,9 +65,7 @@ const columns = useMemo<Column<ProjectsRawSystem>[]>(
     useTable({
       columns,
       data: data ?? [],
-    },
-    useSortBy,
-    );
+    });
   if (isLoading) {
     return <LoadingSpinner />;
   }
@@ -66,37 +74,87 @@ const columns = useMemo<Column<ProjectsRawSystem>[]>(
       <InlineMessage type="warn">Unable to retrieve projects.</InlineMessage>
     );
   }
+
   return (
-    <div className="o-fixed-header-table">
-      <table {...getTableProps()}>
-        <thead>
-          {headerGroups.map((headerGroup) => (
-            <tr {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map((column) => (
-                <th {...column.getHeaderProps()}>{column.render('Header')}</th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody {...getTableBodyProps()} className={styles['rows']}>
-          {rows.length ? (
-            rows.map((row) => {
-              prepareRow(row);
-              return (
-                <tr {...row.getRowProps()}>
-                  {row.cells.map((cell) => (
-                    <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
-                  ))}
-                </tr>
-              );
-            })
-          ) : (
-            <tr>
-              <td colSpan={5}>No active projects found.</td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+    <div>
+      {data?.map(project => project.allocations.map(e =>{
+        return (
+          <table className={styles['usage-table']}>
+            <thead>
+              <tr>
+                <th>Active Resources</th>
+                <th>Awarded</th>
+                <th>Used</th>
+                <th>Expires</th>
+              </tr>
+            </thead>
+            <tbody>
+                <tr>
+                  <th>{project.allocations?.map(e => e.resource)}</th>
+                  <th>{project.allocations?.map(e => e.total)}</th>
+                  <th>{project.allocations?.map(e => e.used)}</th>
+                </tr>            
+            </tbody>
+          </table>
+        )
+      }))}
     </div>
-  );
-};
+  )};
+
+//   return (
+//     <table className={styles['usage-table']}>
+//       <thead>
+//         <tr>
+//           <th>Active Resources</th>
+//           <th>Awarded</th>
+//           <th>Used</th>
+//           <th>Expires</th>
+//         </tr>
+//       </thead>
+//       <tbody>
+//         {data?.map((allocation) => (
+//           <tr key={allocation.resource}>
+//             <th>{allocation.resource}</th>
+//             <th>{allocation.total}</th>
+//             <th>{allocation.used}</th>
+//           </tr>
+//         ))}
+//       </tbody>
+//     </table>
+//   );
+// };
+
+//     return (
+//     <div className="o-fixed-header-table">
+//       <table {...getTableProps()}>
+//         <thead>
+//           {headerGroups.map((headerGroup) => (
+//             <tr {...headerGroup.getHeaderGroupProps()}>
+//               {headerGroup.headers.map((column) => (
+//                 <th {...column.getHeaderProps()}>{column.render('Header')}</th>
+//               ))}
+//             </tr>
+//           ))}
+//         </thead>
+//         <tbody {...getTableBodyProps()} className={styles['rows']}>
+//           {rows.length ? (
+//             rows.map((row) => {
+//               prepareRow(row);
+//               return (
+//                 <tr {...row.getRowProps()}>
+//                   {row.cells.map((cell) => (
+//                     <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+//                   ))}
+//                 </tr>
+//               );
+//             })
+//           ) : (
+//             <tr>
+//               <td colSpan={5}>No active projects found.</td>
+//             </tr>
+//           )}
+//         </tbody>
+//       </table>
+//     </div>
+//   );
+// };

--- a/libs/tup-components/src/allocations/index.ts
+++ b/libs/tup-components/src/allocations/index.ts
@@ -1,0 +1,1 @@
+export { AllocationsTable } from './AllocationTable';

--- a/libs/tup-components/src/index.ts
+++ b/libs/tup-components/src/index.ts
@@ -5,3 +5,4 @@ export * from './profile';
 export * from './projects';
 export * from './system_monitor';
 export * from './tickets';
+export * from './allocations';

--- a/libs/tup-components/src/projects/ProjectsLayout.tsx
+++ b/libs/tup-components/src/projects/ProjectsLayout.tsx
@@ -1,9 +1,21 @@
 import React from 'react';
 import { PageLayout } from '../layout';
 import { Section } from '@tacc/core-components';
-import { ProjectsTable } from './ProjectsTable';
+import { AllocationsTable } from '../allocations';
+
+
+// const ProjectsLayout: React.FC = () => {
+//   return <Section header="Projects & Allocations" content={<PageLayout />} />;
+// };
+// export default ProjectsLayout;
 
 const ProjectsLayout: React.FC = () => {
-  return <Section header="Projects & Allocations" content={<PageLayout />} />;
+  return (
+    <Section header="Projects & Allocations">
+      <div>
+        <AllocationsTable />
+      </div>
+    </Section>
+  );
 };
 export default ProjectsLayout;

--- a/libs/tup-hooks/src/index.ts
+++ b/libs/tup-hooks/src/index.ts
@@ -174,4 +174,5 @@ export { default as useProfile } from './useProfile';
 export { default as useJwt } from './useJwt';
 export { default as useSystemMonitor } from './useSystemMonitor';
 export { default as useProjects } from './useProjects';
+export { default as useProjectsAllocations } from './useAllocations';
 export { default as useTickets } from './useTickets';

--- a/libs/tup-hooks/src/useAllocations.ts
+++ b/libs/tup-hooks/src/useAllocations.ts
@@ -1,0 +1,14 @@
+import { UseQueryResult } from 'react-query';
+import { ProjectsAllocations } from '.';
+import { useGet } from './requests';
+
+// Query to retrieve the user's active projects.
+const useProjectsAllocations = (): UseQueryResult<ProjectsAllocations[]> => {
+  const query = useGet<ProjectsAllocations[]>({
+    endpoint: '/projects',
+    key: 'projects',
+  });
+  return query;
+};
+
+export default useProjectsAllocations;


### PR DESCRIPTION
## Overview: Create the allocations table for the Projects display page. Each project has it's own table that lists the System, Amount Awarded, Amount Used, and Expiration Date. 

## Related:

- [TUP-374](https://jira.tacc.utexas.edu/browse/TUP-374)

## Changes:

-     Created new Allocations folder.
-     In the folder, added AllocationTable and css for Allocations.
-     Added tests for AllocationTable.

## Testing:

1. Go to localhost:8000/dashboard
2. Click the Projects & Allocations tab from the sidebar
3. Make sure listing populate correctly. Compare with the existing TUP site [here.](https://portal.tacc.utexas.edu/projects-and-allocations)

## UI:
![Screen Shot 2022-12-20 at 10 17 53 AM](https://user-images.githubusercontent.com/35277477/208714477-ea3319e9-c5ff-469f-a6d6-4d7be3e80b80.png)


## Notes:
Awarded and Used are missing their units (SUs and GBs). We've discussed this in meetings and are waiting to find out how and when to assign them correctly. 
