### PR TITLE
fix(tup-components): proj's layout & alloc's todos (i think)

### DIFF
--- a/libs/tup-components/src/projects/ProjectsLayout.tsx
+++ b/libs/tup-components/src/projects/ProjectsLayout.tsx
@@ -7,11 +7,19 @@ const ProjectsLayout: React.FC = () => {
   return (
     <Section
       header="Projects & Allocations"
+      contentLayoutName="hasSidebar"
       content={
-        <tbody>
-          <ProjectsSummaryListing />
-          <AllocationsTable />
-        </tbody>
+        <>
+          <nav>
+            TODO: Replace this <code>&lt;nav&gt;</code> with a{' '}
+            <code>&lt;Sidebar&gt;</code>.
+          </nav>
+          {/* TODO: Once Allocations are loaded within Projects (i.e. `<AllocationsTable />` is not loaded here), remove this temporary <div> wrapper */}
+          <div>
+            <ProjectsSummaryListing />
+            <AllocationsTable />
+          </div>
+        </>
       }
     />
   );

--- a/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsSummaryListing.tsx
@@ -10,13 +10,18 @@ export const ProjectsSummaryListing: React.FC = () => {
       <InlineMessage type="warning">Unable to retrieve projects.</InlineMessage>
     );
   return (
-    <div>
-      {data?.map((project) => (
-        <div key={project.id}>
-          <ProjectSummaryAll project={project} />
-        </div>
-      ))}
-    </div>
+    <table>
+      <tbody>
+        {data?.map((project) => (
+          <tr>
+            <td>
+              <ProjectSummaryAll project={project} key={project.id} />
+            </td>
+            <td>TODO: Load project-specific Allocations table.</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 };
 export default ProjectsSummaryListing;


### PR DESCRIPTION
## Overview

Tweak layout to clarify how the layout and markup is expected to look based on [intended design](https://xd.adobe.com/view/cc3dc245-2792-4e10-bdc1-50d2a7d32979-996e/screen/65e6e9fd-faf0-4de6-9283-f9d0b57bf576/).\*

<sub>* If the assumptions of the design are incongruent with actual data, please begin a discussion about that.</sub>

## Related:

- [TUP-374](https://jira.tacc.utexas.edu/browse/TUP-374)
- builds upon https://github.com/TACC/tup-ui/pull/95

## Changes

- clarified that `<Section>` is (by default) using layout `hasSidebar`\*
- added placeholder for `<Sidebar>`
- wrapped projects and allocations listings in a **temporary** `<div>`
- changed `ProjectSummaryListing` to output a proper `<table>`

<sub>* I intend to replace `<Section>` with direct CSS grid styles. I am not there yet.</sub>

## Testing

1. Open"Projects & Allocations".
2. Verify placeholder for sidebar is in accurate layout location.
3. Verify projects are listed in a proper table, one row per project.
4. Verify allocations are still beneath projects, but have placeholder cells in right column of table.

## UI

| Scroll Top | Scroll Bottom |
| - | - |
| ![Screen Shot 2023-01-03 at 12 32 21](https://user-images.githubusercontent.com/62723358/210419466-69e47c40-42fc-476f-918f-eb1da8e16543.png) | ![Screen Shot 2023-01-03 at 12 32 13](https://user-images.githubusercontent.com/62723358/210419470-e437bc41-5539-4b58-9502-6cff7208cfd8.png) |

## Notes

The use of `<Section>` will eventually be replaced with direct CSS Grid styles per `<…Layout>` component.

I think Allocations should be a table within each project. I may be wrong. If I am correct, this is my guess as to how to do that:
1. The `AllocationsTable` could return a single table, instead of all the tables.
2. The `ProjectsLayout` could merely load `ProjectsSummaryListing` as its `<Section>`’s content.
3. The `ProjectSummaryListing` loads an `<AllocationsTable>` after each `<ProjectSummaryAll>`.