### PR TITLE
feat(tup-cms): "hotjar" analytics (heatmap)

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/assets_custom_delayed.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/assets_custom_delayed.html
@@ -1,0 +1,31 @@
+{# Overwrite this template from Core (in which the template is empty) #}
+{# !!!: This should extend taccsite_cms via taccsite_custom not overwrite it #}
+{# FAQ: To support app template inheritance, see TACC/Core-CMS#492 #}
+
+
+
+{# COPIED FROM CORE #}
+{# https://github.com/TACC/Core-CMS/blob/c8844e1/taccsite_cms/templates/assets_custom.html #}
+
+{% load staticfiles %}
+
+<!-- Custom Site Assets: Favicon. -->
+{% with settings.FAVICON as favicon %}
+<link rel="icon" href="{% static favicon.img_file_src %}" type="image/x-icon" />
+{% endwith %}
+
+
+
+{# NEW CODE #}
+
+<!-- Hotjar Tracking Code for https://dev.tup.tacc.utexas.edu/ -->
+<script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:3319380,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>


### PR DESCRIPTION
## Overview

Install [Hotjar Heatmap Analytics](https://www.hotjar.com/heatmaps/).

## Related:

- [TUP-1234](https://jira.tacc.utexas.edu/browse/TUP-1234)

## Changes

- added template to override Core CMS and install hotjar

## Testing

1. Confirm an internal script is added to head.
2. Confirm a second external script is added to head.
3. Confirm the external script loads successfully.
4. ❓ Verify installation of Hotjar with Hotjar itself.

## UI

| loaded in network tab | added to markup | resulted in script in head |
| - | - | - |
| ![hotjar loaded (network tab check)](https://user-images.githubusercontent.com/62723358/212144955-bdb55d39-a34b-4785-a9dc-c8a9a084eebb.png) | ![hotjar via custom_assets_delayed](https://user-images.githubusercontent.com/62723358/212144958-8c02579a-fcdd-4801-b5e7-de7b4ad1aeef.png) | ![hotjar resulting script](https://user-images.githubusercontent.com/62723358/212144960-20b0d08b-3f71-4c16-903c-1ec0ad544e54.png) |

## Notes

1. <details><summary>The install uses a safe workaround.</summary>

    It overwrites a Core template instead of extending it via inheritance, because template inheritance requires TACC/Core-CMS#492.

    </details>
