### PR TITLE
Demo: running a callback on django-cms form submission

### DIFF
--- a/apps/tup-cms/src/apps/dashboard/apps.py
+++ b/apps/tup-cms/src/apps/dashboard/apps.py
@@ -1,5 +1,17 @@
 from django.apps import AppConfig
+import logging
+from django.dispatch import receiver
+from djangocms_forms.signals import form_submission
 
+logger = logging.getLogger(f"portal.{__name__}")
+
+def callback(form, cleaned_data, **kwargs):
+    logger.debug(f"received submission from {form.name}")
+    logger.debug(cleaned_data)
 
 class DashboardConfig(AppConfig):
-    name = 'dashboard'
+    name = "apps.dashboard"
+
+    def ready(self):
+        form_submission.connect(callback)
+

--- a/apps/tup-cms/src/taccsite_cms/custom_app_settings.py
+++ b/apps/tup-cms/src/taccsite_cms/custom_app_settings.py
@@ -1,3 +1,3 @@
-CUSTOM_APPS = ['apps.portal_nav', 'apps.dashboard']
+CUSTOM_APPS = ['apps.portal_nav', 'apps.dashboard.apps.DashboardConfig']
 CUSTOM_MIDDLEWARE = []
 STATICFILES_DIRS = ()


### PR DESCRIPTION
Demo: In this branch any form submission from inside Django-CMS should trigger a callback with the name of the form and the validated data. The main use case for this is to catch submissions to a public Tickets form and make a call to RT. 
