### PR TITLE
Update Github Actions to improve npm caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,7 @@ jobs:
         with:
           node-version: 16
           cache: 'npm'
-
-      - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+      - run: npm ci
 
       - uses: nrwl/nx-set-shas@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,10 @@ jobs:
         with:
           node-version: 16
           cache: 'npm'
-      - run: npm ci
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
 
       - uses: nrwl/nx-set-shas@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v2
 
-      # Check linting/formatting of workspace files
+      # Check linting/formatting of workspace files.
       - run: npx nx workspace-lint
       - run: npx nx format:check
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,26 +9,17 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+      - uses: actions/setup-node@v3
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          node-version: 16
+          cache: 'npm'
+      - run: npm ci
 
       - uses: nrwl/nx-set-shas@v2
-      - run: npm ci
 
       # Check linting/formatting of workspace files
       - run: npx nx workspace-lint


### PR DESCRIPTION
## Overview:
Use the setup-node action to reduce runtime for actions. Our current caching setup doesn't seem to cache npm modules correctly.
