### PR TITLE
fix(tup-ui): page layout spacing, icon size, use global vars, core-styles patches

### DIFF
--- a/apps/tup-ui/src/main.global.for-core-styles.css
+++ b/apps/tup-ui/src/main.global.for-core-styles.css
@@ -1,0 +1,33 @@
+/* These changes and additions belong in Core-Styles */
+
+/* TODO: Remove this after:
+         1. fixing this in core-styles.cms <hr /> styles, and
+         2. either, moving those fixed styles to core-styles.base
+         2. or, cloning those fixed styles to core-styles.portal */
+hr {
+  --global-space--hr-buffer-below: var(--global-space--hr-buffer-above);
+}
+
+/* TODO: Remove this after:
+         0. confirming this new spacing with lead designer
+         1. and updating these in core-styles.base
+         2. (and maybe) moving those fixed styles to core-styles.portal */
+:root {
+  --global-space--section-top: 15px;
+  --global-space--section-left: 20px;
+  --global-space--section-right: 15px;
+}
+
+/* TODO: Remove this after:
+         0. confirming this size with lead designer
+         1. adding these to core-styles.base */
+.icon-xs {
+  font-size: 1.6rem;
+  width: 1.6rem;
+  height: 1.6rem;
+}
+.icon-16 {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+}

--- a/apps/tup-ui/src/main.tsx
+++ b/apps/tup-ui/src/main.tsx
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 
 import './main.global.css';
+import './main.global.for-core-styles.css';
 
 const queryClient = new QueryClient();
 

--- a/apps/tup-ui/src/pages/Projects/Projects.module.css
+++ b/apps/tup-ui/src/pages/Projects/Projects.module.css
@@ -1,7 +1,5 @@
 .project-header {
     font-size: 2.6rem;
-    margin-top: 12px;
-    margin-left: 24px;
-    border-bottom: 1px solid #707070;
+    border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--dark);
     padding-bottom: 5px;
 }

--- a/libs/core-components/src/lib/Icon/Icon.tsx
+++ b/libs/core-components/src/lib/Icon/Icon.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import './Icon.css';
 
+type sizes = 'xs' | 'sm' | 'md' | 'lg';
+
 type IconProps = React.PropsWithChildren<{
   className?: string;
   dataTestid?: string;
   label?: string;
   name: string;
+  size?: sizes;
 }>;
 
-const Icon: React.FC<IconProps> = ({ className, dataTestid, label, name }) => {
-  const iconClassName = `icon icon-${name}`;
+const Icon: React.FC<IconProps> = ({ className, dataTestid, label, name, size }) => {
+  const iconClassName = `icon icon-${name}` + (size
+    ? ` icon-${size}`
+    : '');
   // FAQ: The conditional avoids an extra space in class attribute value
   const fullClassName = className
     ? [className, iconClassName].join(' ')

--- a/libs/core-components/src/lib/Icon/Icon.tsx
+++ b/libs/core-components/src/lib/Icon/Icon.tsx
@@ -11,10 +11,14 @@ type IconProps = React.PropsWithChildren<{
   size?: sizes;
 }>;
 
-const Icon: React.FC<IconProps> = ({ className, dataTestid, label, name, size }) => {
-  const iconClassName = `icon icon-${name}` + (size
-    ? ` icon-${size}`
-    : '');
+const Icon: React.FC<IconProps> = ({
+  className,
+  dataTestid,
+  label,
+  name,
+  size,
+}) => {
+  const iconClassName = `icon icon-${name}` + (size ? ` icon-${size}` : '');
   // FAQ: The conditional avoids an extra space in class attribute value
   const fullClassName = className
     ? [className, iconClassName].join(' ')

--- a/libs/core-wrappers/src/lib/Navbar/Navbar.tsx
+++ b/libs/core-wrappers/src/lib/Navbar/Navbar.tsx
@@ -18,7 +18,7 @@ export const NavItem: React.FC<
           isActive ? styles['nav-active'] : ''
         }`}
       >
-        {icon && <Icon name={icon} className={styles['nav-icon']} />}
+        {icon && <Icon name={icon} size="xs" className={styles['nav-icon']} />}
         {/* we'll want to set name based on the app */}
         <span className={styles['nav-text']}>{children}</span>
       </div>
@@ -43,7 +43,7 @@ export const QueryNavItem: React.FC<
           active ? styles['nav-active'] : ''
         }`}
       >
-        {icon && <Icon name={icon} className={styles['nav-icon']} />}
+        {icon && <Icon name={icon} size="xs" className={styles['nav-icon']} />}
         {/* we'll want to set name based on the app */}
         <span className={styles['nav-text']}>{children}</span>
       </div>

--- a/libs/tup-components/src/layout/PageLayout/PageLayout.module.css
+++ b/libs/tup-components/src/layout/PageLayout/PageLayout.module.css
@@ -24,6 +24,8 @@
 .content {
   display: grid;
   grid-area: _content;
+
+  padding: var(--global-space--section);
 }
 
 .footer {

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectSummary.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectSummary.tsx
@@ -16,7 +16,7 @@ export const ProjectSummary: React.FC<{
 
   return (
     <>
-      <Link to={`/projects/${project.id}`}  className={styles['project-title']}>
+      <Link to={`/projects/${project.id}`} className={styles['project-title']}>
         {project.title}
       </Link>
       <div>
@@ -31,9 +31,10 @@ export const ProjectSummary: React.FC<{
       <hr />
       <div>
         <span>
-          Compute: <strong>{`${
-          totalComputeRequested ? totalComputeRequested : '--'
-        } SUs `}</strong>
+          Compute:{' '}
+          <strong>{`${
+            totalComputeRequested ? totalComputeRequested : '--'
+          } SUs `}</strong>
         </span>
         <span>
           {totalComputeUsed
@@ -44,7 +45,8 @@ export const ProjectSummary: React.FC<{
         </span>
         <span className={styles['compute-separator']}>|</span>
         <span>
-          Storage: <strong>{`${
+          Storage:{' '}
+          <strong>{`${
             totalStorageRequested ? totalStorageRequested : '--'
           } GBs `}</strong>
         </span>

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectSummary.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectSummary.tsx
@@ -15,12 +15,12 @@ export const ProjectSummary: React.FC<{
     project.allocations?.reduce((acc, e) => acc + e.used, 0) ?? 0;
 
   return (
-    <div>
-      <Link to={`/projects/${project.id}`}>
-        <span className={styles['project-title']}>{project.title}</span>
+    <>
+      <Link to={`/projects/${project.id}`}  className={styles['project-title']}>
+        {project.title}
       </Link>
       <div>
-        {'Project Charge Code: '} {project.chargeCode}
+        {'Project Charge Code: '} <strong>{project.chargeCode}</strong>
       </div>
       <div className={styles['project-pi']}>
         {'Principal Investigator: ' +
@@ -28,11 +28,13 @@ export const ProjectSummary: React.FC<{
           ' ' +
           project.pi.lastName}
       </div>
-      <div className={styles['project-summary-separator']} />
+      <hr />
       <div>
-        <span>{`Compute: ${
+        <span>
+          Compute: <strong>{`${
           totalComputeRequested ? totalComputeRequested : '--'
-        } SUs `}</span>
+        } SUs `}</strong>
+        </span>
         <span>
           {totalComputeUsed
             ? ' (' +
@@ -42,9 +44,9 @@ export const ProjectSummary: React.FC<{
         </span>
         <span className={styles['compute-separator']}>|</span>
         <span>
-          {`Storage: ${
+          Storage: <strong>{`${
             totalStorageRequested ? totalStorageRequested : '--'
-          } GBs `}
+          } GBs `}</strong>
         </span>
         <span>
           {totalStorageUsed
@@ -54,6 +56,6 @@ export const ProjectSummary: React.FC<{
             : ' (0% Used) '}
         </span>
       </div>
-    </div>
+    </>
   );
 };

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.module.css
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.module.css
@@ -16,16 +16,23 @@
 
 
 /* Project listing */
+.project-listing {
+  margin-bottom: unset; /* undo core-styles.base.css */
+  padding-left: 10px;
+}
+
 .project-listing-row {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     gap: 5%;
-    padding-top: 20px;
-    padding-right: 20px;
     padding-bottom: 20px;
-
-    border-bottom: 1px solid #707070;
+}
+.project-listing-row:not(:first-child) {
+    padding-top: 20px;
+}
+.project-listing-row:not(:last-child) {
+    border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--dark);
 }
 
 .project-listing-row > * {
@@ -35,19 +42,14 @@
 
 /* Project summary */
 .project-title {
-    font-weight: 500;
+    font-weight: var(--bold);
+    font-size: var(--global-font-size--medium);
 }
 .project-pi {
     background: #CAFCC8;
     width: fit-content;
     padding: 3px;
     margin-left: -3px;
-}
-.project-summary-separator {
-    border-bottom: 1px solid #C7C7C7;
-    width: 100%;
-    margin-top: 10px;
-    margin-bottom: 10px;
 }
 .compute-separator {
     padding-left: 1rem;
@@ -57,6 +59,6 @@
 /* Project navbar */
 .projects-listing-navbar {
     height: 100%;
-    border-right: 1px solid #C7C7C7;
+    border-right:var(--global-border-width--normal) solid var(--global-color-primary--light);
 }
 

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.test.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.test.tsx
@@ -26,9 +26,9 @@ describe('Projects Summary Listing Component', () => {
     expect(screen.findAllByText('/projects/59184', { exact: false }));
     expect(screen.findAllByText('Project Charge Code: STA22002'));
     expect(screen.findAllByText('Principle Investigator: Jake Rosenberg'));
-    expect(screen.getAllByText('Compute: 10 SUs'));
+    expect(screen.getAllByText('10 SUs'));
     expect(screen.getAllByText('(0% Used)'));
-    expect(screen.getAllByText('Storage: -- GBs'));
+    expect(screen.getAllByText('-- GBs'));
 
     // Allocations table
     expect(screen.getAllByText('10 SU'));

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.tsx
@@ -26,7 +26,7 @@ export const ProjectsListing: React.FC = () => {
     );
 
   return (
-    <ul>
+    <ul className={styles['project-listing']}>
       {data?.filter(prjFilter).map((project) => (
         <li key={project.id} className={styles['project-listing-row']}>
           <div>


### PR DESCRIPTION
## Overview

CSS: Tweak page layout spacing. Use global variables. Larger nav icons. Global CSS for Core-Styles.

## Related

- https://github.com/TACC/tup-ui/pull/101

## Changes

- feat(core-components): Icon, add size prop d3e45ca
- feat(tup-ui): global css destined for core-styles 6c21c94
- fix(core-wrappers): nav icon size 4bc1ed8
- fix(tup-ui): page layout spacing & use global vars bdf20fe
- fix(tup-ui): ProjectSummary markup clean up 9777ea3

## Testing

See https://github.com/TACC/tup-ui/pull/101.

## UI

| scroll to top | scroll to bottom |
| - | - |
| ![Screen Shot 2023-01-18 at 15 16 23](https://user-images.githubusercontent.com/62723358/213296544-58b0b0f0-abaa-44ed-b61b-33d0dd4598d3.png) | ![Screen Shot 2023-01-18 at 15 16 26](https://user-images.githubusercontent.com/62723358/213296540-2556f3b1-4b5a-4e70-84e7-e320511ba2ab.png) |