### PR TITLE
Blur inputs in Formik tests to ensure buttons are active

### DIFF
--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.test.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.test.tsx
@@ -9,12 +9,15 @@ describe('TicketCreateForm Component', () => {
     testRender(<TicketCreateForm />);
     const subject = screen.getByLabelText(/Subject/);
     const description = screen.getByLabelText(/Problem Description/);
-    const submit = screen.getByRole('button', { name: /add ticket/i });
 
     expect(await screen.findByDisplayValue('mock')).toBeDefined();
 
     fireEvent.change(subject, { target: { value: 'test' } });
     fireEvent.change(description, { target: { value: 'test' } });
+    fireEvent.blur(description);
+
+    const submit = screen.getByRole('button', { name: /add ticket/i });
+    expect(submit.getAttribute('disabled')).toBe(null);
     fireEvent.click(submit);
 
     expect(
@@ -34,15 +37,17 @@ describe('TicketCreateForm Component', () => {
 
     const subject = screen.getByLabelText(/Subject/);
     const description = screen.getByLabelText(/Problem Description/);
-    const submit = screen.getByRole('button', { name: /add ticket/i });
 
     fireEvent.change(subject, { target: { value: 'test' } });
     fireEvent.change(description, { target: { value: 'test' } });
+    fireEvent.blur(description);
+
+    const submit = screen.getByRole('button', { name: /add ticket/i });
+    expect(submit.getAttribute('disabled')).toBe(null);
     fireEvent.click(submit);
 
     expect(
       await screen.findByText(/There was an error creating your ticket/)
     ).toBeDefined();
-    server.resetHandlers();
   });
 });

--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.test.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.test.tsx
@@ -64,6 +64,7 @@ describe('Ticket Modal', () => {
     const reply = getByLabelText(/Reply/);
     const submit = getByRole('button', { name: 'Reply' });
     fireEvent.change(reply, { target: { value: 'error message?' } });
+    fireEvent.blur(reply);
     fireEvent.click(submit);
 
     await waitFor(() =>


### PR DESCRIPTION
Some tests might be flaking out because they're firing a click event on an inactive input.