### PR TITLE
Simulate user events when testing Formik components

### DIFF
--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.test.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.test.tsx
@@ -1,20 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { TicketCreateForm } from './TicketCreateForm';
 import { server, testRender } from '@tacc/tup-testing';
 import { fireEvent, waitFor, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 
 describe('TicketCreateForm Component', () => {
   it('should display a success message after mutation', async () => {
+    const user = userEvent.setup();
     testRender(<TicketCreateForm />);
     const subject = screen.getByLabelText(/Subject/);
     const description = screen.getByLabelText(/Problem Description/);
 
     expect(await screen.findByDisplayValue('mock')).toBeDefined();
 
-    fireEvent.change(subject, { target: { value: 'test' } });
-    fireEvent.change(description, { target: { value: 'test' } });
-    fireEvent.blur(description);
+    await user.type(subject, 'test');
+    await user.type(description, 'test');
 
     const submit = screen.getByRole('button', { name: /add ticket/i });
     expect(submit.getAttribute('disabled')).toBe(null);
@@ -26,6 +27,7 @@ describe('TicketCreateForm Component', () => {
   });
 
   it('should display an error message if an error is returned from useMutation hook', async () => {
+    const user = userEvent.setup();
     server.use(
       rest.post('http://localhost:8001/tickets', (req, res, ctx) =>
         res.once(ctx.status(404))
@@ -38,9 +40,8 @@ describe('TicketCreateForm Component', () => {
     const subject = screen.getByLabelText(/Subject/);
     const description = screen.getByLabelText(/Problem Description/);
 
-    fireEvent.change(subject, { target: { value: 'test' } });
-    fireEvent.change(description, { target: { value: 'test' } });
-    fireEvent.blur(description);
+    await user.type(subject, 'test');
+    await user.type(description, 'test');
 
     const submit = screen.getByRole('button', { name: /add ticket/i });
     expect(submit.getAttribute('disabled')).toBe(null);

--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.test.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.test.tsx
@@ -7,6 +7,7 @@ import {
   within,
   screen,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { TicketHistory } from './TicketHistory';
 import { TicketReplyForm } from './TicketReplyForm';
@@ -25,6 +26,7 @@ describe('Ticket Modal', () => {
     expect(getByText('testFile.txt (10b)')).toBeDefined();
   });
   it('should render a loading spinner if the form is valid and the Reply button is clicked', async () => {
+    const user = userEvent.setup();
     server.use(
       rest.post(
         'http://localhost:8001/tickets/85411/reply',
@@ -37,9 +39,9 @@ describe('Ticket Modal', () => {
       <TicketReplyForm ticketId="85411" />
     );
     const reply = getByLabelText(/Reply/);
+    await user.type(reply, 'it works!');
 
     const submit = getByRole('button', { name: 'Reply' });
-    fireEvent.change(reply, { target: { value: 'It works!' } });
     fireEvent.click(submit);
 
     await waitFor(() =>
@@ -52,6 +54,7 @@ describe('Ticket Modal', () => {
   });
 
   it('should render an error message if an error is returned from the useMutation hook', async () => {
+    const user = userEvent.setup();
     server.use(
       rest.post('http://localhost:8001/tickets/85411/reply', (req, res, ctx) =>
         res.once(ctx.status(404))
@@ -63,8 +66,7 @@ describe('Ticket Modal', () => {
 
     const reply = getByLabelText(/Reply/);
     const submit = getByRole('button', { name: 'Reply' });
-    fireEvent.change(reply, { target: { value: 'error message?' } });
-    fireEvent.blur(reply);
+    await user.type(reply, 'error message?');
     fireEvent.click(submit);
 
     await waitFor(() =>


### PR DESCRIPTION
Tests were flaking when `fireEvent` was used to update form text in tests, maybe due to a race condition.