### PR TITLE
fix(tup-ui): do not load core cms styles in portal

### DIFF
--- a/apps/tup-cms/src/apps/dashboard/templates/dashboard/assets.html
+++ b/apps/tup-cms/src/apps/dashboard/templates/dashboard/assets.html
@@ -1,14 +1,6 @@
 {% load staticfiles %}
 
 <style>
-  /* TODO: What of cms.css can move to base.css (so we don't load cms here)? */
-  @import url("{% static 'site_cms/css/build/core-styles.cms.css' %}") layer(base);
   @import url("{% static 'site_cms/css/build/core-styles.portal.css' %}") layer(base);
   @import url("{% static 'site_cms/css/build/core-styles.header.css' %}") layer(base);
-</style>
-<style>
-  /* To overwrite irrelevant and breaking styles from core-styles.cms.css */
-  body > main {
-    margin-bottom: unset;
-  }
 </style>

--- a/apps/ui-patterns/src/main.css
+++ b/apps/ui-patterns/src/main.css
@@ -1,5 +1,14 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
+/* Layer via MCSS */
+/* NOTE: Usage requires either solution:
+         A. Vite/PostCSS NOT hoist/parse our Bootstrap import outside its layer.
+         B. Save/Load external Bootstrap stylesheet as internal file.
+*/
+/* FAQ: Bootstrap external URL not allowed in @layer by Vite/PostCSS */
+/* https://confluence.tacc.utexas.edu/x/b53tDg */
+/* @layer foundation, base, project; */
+
 /* Organize via ITCSS */
 /* https://confluence.tacc.utexas.edu/x/b53tDg */
 

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
@@ -1,3 +1,6 @@
+/* So login form is built off CMS styles */
+@import url('@tacc/core-styles/dist/elements/form.cms.css') layer(base);
+
 /* CONTAINER */
 
 .root {
@@ -38,31 +41,29 @@
 }
 
 .subtitle {
-  font-weight: var(--medium); /* mimics value--not appearance--from design */
-  margin-block: 25px; /* mimics Core-CMS django.cms.forms.css .description */
+  font-weight: var(--medium); /* mimics value (not appearance) from design */
+  margin-block: 25px; /* mimics django-cms-forms.css `.description` */
 }
 
 
 
 /* FORM */
 
-/* To hide "(required)" which is obvious ona  login form */
-.root label :global(.c-form__star) {
+/* To hide "(required)" (which is an obvious attribute on a login form) */
+.root label :global(.badge) {
   display: none;
 }
-/* TODO: Do not load CMS CSS (except header) on Portal app (then remove this) */
 .field {
-  max-width: unset; /* undo Core-CMS forms.cms.css */
+  max-width: unset; /* undo forms.cms.css `input...` */
 
   /* To use larger field inputs, always (not just coarse pointer devices) */
-  /* @tacc/core-styles#22783d8:/src/lib/_imports/elements/form.cms.css#L56 */
-  padding: 12px 12px;
+  padding: 12px 12px; /* mimic forms.cms.css `@media (pointer: coarse)` */
 }
 
 
 
 .submit {
-  padding-block: 10px; /* overrides @tacc/core-styles c-form__button/c-button */
+  padding-block: 10px; /* overrides core-styles.base.css button styles */
 }
 
 .submit-container {
@@ -81,7 +82,7 @@
   align-items: flex-end;
   gap: 12px;
 
-  margin-top: 35px; /* mimics @tacc/core-styles margin-top */
+  margin-top: 35px; /* mimics django-cms-forms.css `.button-wrapper` */
 }
 .footer > p {
   margin-block: 0; /* overwrite browser */
@@ -91,11 +92,11 @@
 /* ERRORS */
 
 .error {
-  margin-bottom: 2rem; /* TODO: Move to @tacc/core-styles */
+  margin-bottom: 2rem; /* TODO: move to @tacc/core-styles */
 }
 
 /* When (the only known) error would wrap, move all lines to one line */
 @media screen and (max-width: 435px) {
-  .error br { content: ""; } /* remove new line */
-  .error br::after { content: " "; } /* add space */
+  .error br { content: ""; } /* to remove new line */
+  .error br::after { content: " "; } /* to add space */
 }


### PR DESCRIPTION
## Overview

Remove CMS styles from Portal.

<details><summary>Why were they ever loaded at all?</summary>

Because, initially, TACC/Core-Styles had a `core-styles.base.css` and `core-styles.cms.css` and an **empty** `core-styles.portal.css`. The `core-styles.cms.css` had some stuff Portal needed, but also stuff it did **not** need. But now TACC/Core-Styles has a minimal, usable `core-styles.portal.css`.

</details>

<details><summary>I took some actions in CMS to support these changes once deployed.</summary>

The CMS uses snippets for a lot of new code (because we are developing too fast for me to develop all new CSS in Core-CMS or Core-Styles. Some of those snippets' styles used selectors that accidentally matched Portal markup. I have fixed those mistakes.

</details>

## Related

None.

## Changes

- CMS Dashboard App:
    - Do not load `core-styles.cms.css`.
- UI Patterns App:
    - Comment why `@layer` is not used yet.
- Login Component:
    - Load CMS form styles.
    - Update outdated comments.
    - Update selector that matched (thus hid) in-house "Required" badge, but not Reactstrap "Required" badge.

## Testing

_Deployed ([dev.tup](https://dev.tup.tacc.utexas.edu/dashboard), 2023-01-26 @ 15:30) via branch `dev/tup-cms--task/no-global-core-cms-css-in-portal` so CMS editors are not without the vital code from `dev/tup-cms`._

1. Portal login form does **not** have "required" label tags.
2. Portal login form otherwise looks the same.
3. Portal page headings are **not** using [CMS styles](https://dev.tup.tacc.utexas.edu/static/ui/components/detail/headings--cms.html).*

You might notice that Portal projects page spacing is less. Looks good, and I assume that is because of this change.

<sub>* The headings are also **not** _that demo's_ [Portal styles](https://dev.tup.tacc.utexas.edu/static/ui/components/detail/headings--portal.html) because I have not ported those styles to Core-Styles.*</sub>

## UI

| | before | after |
| - | - | - |
| login | ![local login BEFORE](https://user-images.githubusercontent.com/62723358/214970109-9846edc5-0420-4902-8662-4c84fc07d050.png) | ![local login AFTER](https://user-images.githubusercontent.com/62723358/214970118-c0415aa3-e5da-46c2-9a6c-109612b38487.png)
| dashboard | ![local dashboard BEFORE](https://user-images.githubusercontent.com/62723358/214970128-968da947-3ea1-4824-9b12-f3b46baf1cb3.png) | ![local dashboard AFTER](https://user-images.githubusercontent.com/62723358/214970129-5fe99487-9949-480c-acb9-02c8dbb03e85.png)
| projects | ![local projects BEFORE](https://user-images.githubusercontent.com/62723358/214970117-c05723a9-81e7-4241-9fd3-701932e0e7c6.png) | ![local projects AFTER](https://user-images.githubusercontent.com/62723358/214970119-aec0f38f-eb28-4bae-86d3-470847219f1f.png)
| tickets | ![local tickets BEFORE](https://user-images.githubusercontent.com/62723358/214970116-d6dbe25f-fa0a-43c4-b592-a13d1dfdc94e.png) | ![local tickets AFTER](https://user-images.githubusercontent.com/62723358/214970123-8a3a7063-189c-4a46-bf75-b9e1c5cf8d03.png)
