### PR TITLE
fix dashboard css so media queries compile

### DIFF
--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
@@ -1,3 +1,5 @@
+@import url('@tacc/core-styles/src/lib/_imports/tools/media-queries.css');
+
 .panels {
   display: grid;
 


### PR DESCRIPTION
Import from core-styles in the dashboard module css. This causes the styles to be compiled correctly at build time.

Proof that this actually works (excerpt from built CSS): 
```@media (min-width: 1200px){._panels_auj3z_2{gap:25px;grid-template-columns:.65fr .35fr;grid-template-rows:auto 1fr 1fr 1fr;overflow:auto;grid-template-areas:"projects systems" "projects updates" "tickets updates" "tickets updates"}```

Previously the media query was being compiled with a custom variable, which the browser didn't know what to do with. This is probably what was causing the 4-car pileup on the dashboard.