### PR TITLE
fix(tup-ui): remvove my lazy mobile dashboard

### DIFF
--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.css
@@ -1,4 +1,0 @@
-/* To avoid creating a short screen layout by adding body scrollbar */
-body.dashboard {
-  min-height: 900px;
-}

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
@@ -8,20 +8,9 @@ import {
   UserNews,
 } from '@tacc/tup-components';
 
-import './Dashboard.css';
 import styles from './Dashboard.module.css';
 
 const Layout: React.FC = () => {
-  const bodyClassName = 'dashboard';
-
-  useEffect(() => {
-    if (bodyClassName) document.body.classList.add(bodyClassName);
-
-    return function cleanup() {
-      if (bodyClassName) document.body.classList.remove(bodyClassName);
-    };
-  }, [bodyClassName]);
-
   return (
     <RequireAuth>
       <section className={`c-page ${styles.section}`}>


### PR DESCRIPTION
## Overview & Changes

Remove min-height on Dashboard i.e. discard my old lazy mobile UI solution, rely totally on #110.

## Related:

- lets #110 solution take lead on very short (height) browser viewports

## Testing

1. View page with a window <767px by <900px.
2. **If** you are a CMS admin, **then**—using "Inspect Element" tool—delete `margin-top: 46px` from `<html>`.
    <sub>That style is added dynamically by CMS admin to make room for the CMS admin header/toolbar.</sub>
3. Verify there is no scrollbar needed to see the entire footer.

## UI

<details open><summary>No Minimum Height</summary>

Ignore the different foot content. That is because my localhost footer is just a sentence.

| | before | after |
| - | - | - |
| shorter than 900px | ![short, before](https://user-images.githubusercontent.com/62723358/215171605-96efe4f9-c3f9-4b35-bd98-c7e58d6a9bf2.png) | ![short, after](https://user-images.githubusercontent.com/62723358/215171604-edfb311b-d111-4859-93f3-c3b00b2228c7.png) |

</details>

## Taller than 900px

Ignore the different foot content. That is because my localhost footer is just a sentence.

<details><summary>No Change</summary>

| | before | after |
| - | - | - |
| taller than 900px | ![tall, before](https://user-images.githubusercontent.com/62723358/215172001-d94b10cc-27a3-4d67-97f1-f45637116007.png) | ![tall, after](https://user-images.githubusercontent.com/62723358/215171553-86be0af6-8a21-4ba2-941f-b46dac592a20.png) |

</details>