### PR TITLE
fix(tup-ui): limit dashboard min height solution to wide & short screens

### DIFF
--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.css
@@ -1,3 +1,5 @@
+@import url('@tacc/core-styles/src/lib/_imports/tools/media-queries.css');
+
 /* To avoid creating a cramped wide+short screen layout */
 @media (--wide-and-above) {
   body.dashboard {

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.css
@@ -1,4 +1,0 @@
-/* To avoid creating a short screen layout by adding body scrollbar */
-body.dashboard {
-  min-height: 900px;
-}

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.css
@@ -1,4 +1,6 @@
-/* To avoid creating a short screen layout by adding body scrollbar */
-body.dashboard {
-  min-height: 900px;
+/* To avoid creating a cramped wide+short screen layout */
+@media (--wide-and-above) {
+  body.dashboard {
+    min-height: 900px; /* to add body scrollbar */
+  }
 }

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.css
@@ -1,0 +1,4 @@
+/* To avoid creating a short screen layout by adding body scrollbar */
+body.dashboard {
+  min-height: 900px;
+}

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
@@ -8,9 +8,20 @@ import {
   UserNews,
 } from '@tacc/tup-components';
 
+import './Dashboard.css';
 import styles from './Dashboard.module.css';
 
 const Layout: React.FC = () => {
+  const bodyClassName = 'dashboard';
+
+  useEffect(() => {
+    if (bodyClassName) document.body.classList.add(bodyClassName);
+
+    return function cleanup() {
+      if (bodyClassName) document.body.classList.remove(bodyClassName);
+    };
+  }, [bodyClassName]);
+
   return (
     <RequireAuth>
       <section className={`c-page ${styles.section}`}>

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
@@ -8,20 +8,9 @@ import {
   UserNews,
 } from '@tacc/tup-components';
 
-import './Dashboard.css';
 import styles from './Dashboard.module.css';
 
 const Layout: React.FC = () => {
-  const bodyClassName = 'dashboard';
-
-  useEffect(() => {
-    if (bodyClassName) document.body.classList.add(bodyClassName);
-
-    return function cleanup() {
-      if (bodyClassName) document.body.classList.remove(bodyClassName);
-    };
-  }, [bodyClassName]);
-
   return (
     <RequireAuth>
       <section className={`c-page ${styles.section}`}>


### PR DESCRIPTION
## Overview & Changes

Limit dashboard body scroll solution to **only** screens that are _wide_ **and** _short_**.

## Related:

- replaces #115

## Testing

0. Load dashboard.
1. **If** you are a CMS admin, **then**—using "Inspect Element" tool—delete `margin-top: 46px` from `<html>`.
    <sub>That style is added dynamically by CMS admin to make room for the CMS admin header/toolbar.</sub>
2. Verify scrollbar state at window sizes matches table data.

**At given size (w x h), is scroll(bar) required to see footer?**

| `px` | 1199– | 1200+ |
| - | - | - |
| 899– | **no** | **yes** |
| 900+ | **no** | **no** |

## UI

| `px` | 1199– | 1200+ |
| - | - | - |
| 899– | ![narrow short](https://user-images.githubusercontent.com/62723358/215183975-2a24257c-c57e-40ec-bbbd-bccfd8640d66.png) | ![wide short](https://user-images.githubusercontent.com/62723358/215183978-e9f5a8b8-ece9-4c1b-aa14-c5d2ce0507b6.png) |
| 900+ | ![narrow tall](https://user-images.githubusercontent.com/62723358/215183977-30ac93e9-eeb0-440e-9a7f-b8cd4af6c993.png) | ![wide tall](https://user-images.githubusercontent.com/62723358/215183972-acea470c-0128-4864-847a-0e2b032401af.png) |
