### PR TITLE
task/TUP-404: Logout button for both Dashboard and CMS

### DIFF
--- a/apps/tup-cms/src/apps/dashboard/urls.py
+++ b/apps/tup-cms/src/apps/dashboard/urls.py
@@ -1,8 +1,9 @@
 from django.urls import re_path
-from .views import LoginView, DashboardView
+from .views import LoginView, DashboardView, LogoutView
 
 app_name = 'dashboard'
 urlpatterns = [
     re_path('login', LoginView, name='login'),
+    re_path('logout', LogoutView, name='logout'),
     re_path('', DashboardView, name='index'),
 ]

--- a/apps/tup-cms/src/apps/dashboard/views.py
+++ b/apps/tup-cms/src/apps/dashboard/views.py
@@ -1,9 +1,9 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.conf import settings
 from django.template import loader
 from django.shortcuts import redirect
 from django.conf import settings
-from django.contrib.auth import authenticate, login
+from django.contrib.auth import authenticate, login, logout
 from apps.dashboard.decorators import tup_login_required
 
 
@@ -20,6 +20,16 @@ def LoginView(request):
     resp = HttpResponse(template.render({'baseUrl': settings.TUP_SERVICES_URL}, request))
     return resp
 
+
+def LogoutView(request):
+    user = authenticate(request)
+    if user:
+        logout(request)
+
+    resp = HttpResponseRedirect("/")
+    resp.set_cookie("x-tup-token", "")
+    return resp
+    
 
 @tup_login_required()
 def DashboardView(request):

--- a/apps/tup-cms/src/apps/dashboard/views.py
+++ b/apps/tup-cms/src/apps/dashboard/views.py
@@ -22,10 +22,7 @@ def LoginView(request):
 
 
 def LogoutView(request):
-    user = authenticate(request)
-    if user:
-        logout(request)
-
+    logout(request)
     resp = HttpResponseRedirect("/")
     resp.set_cookie("x-tup-token", "")
     return resp

--- a/apps/tup-ui/src/App.tsx
+++ b/apps/tup-ui/src/App.tsx
@@ -12,7 +12,6 @@ import {
 import {
   Dashboard,
   Login,
-  Logout,
   Projects,
   ProjectView,
   ProjectDetail,
@@ -51,7 +50,6 @@ function App() {
             </RequireAuth>
           }
         />
-        <Route path="logout" element={<Logout />}></Route>
       </Route>
       <Route path="/login" element={<Login />} />
     </Routes>

--- a/libs/core-wrappers/src/index.ts
+++ b/libs/core-wrappers/src/index.ts
@@ -1,5 +1,5 @@
 import { WizardStep as WizardStepType } from './lib/Wizard';
-export { Navbar, NavItem, QueryNavItem } from './lib/Navbar';
+export { Navbar, NavItem, QueryNavItem, AnchorNavItem } from './lib/Navbar';
 export { default as QueryWrapper } from './lib/QueryWrapper';
 export { default as SubmitWrapper } from './lib/SubmitWrapper';
 export { default as Wizard, useWizard, WizardNavigation } from './lib/Wizard';

--- a/libs/core-wrappers/src/lib/Navbar/Navbar.tsx
+++ b/libs/core-wrappers/src/lib/Navbar/Navbar.tsx
@@ -26,6 +26,23 @@ export const NavItem: React.FC<
   </NavLink>
 );
 
+export const AnchorNavItem: React.FC<
+  React.PropsWithChildren<{
+    to: string;
+    icon?: string;
+    end?: boolean;
+    className?: string;
+  }>
+> = ({ to, icon, end, className, children }) => (
+  <a href={to} className={`${styles['nav-link']} ${className}`}>
+    <div className={styles['nav-content']}>
+      {icon && <Icon name={icon} size="xs" className={styles['nav-icon']} />}
+      {/* we'll want to set name based on the app */}
+      <span className={styles['nav-text']}>{children}</span>
+    </div>
+  </a>
+);
+
 // Alternate nav item with active state set by a prop
 export const QueryNavItem: React.FC<
   React.PropsWithChildren<{

--- a/libs/core-wrappers/src/lib/Navbar/index.ts
+++ b/libs/core-wrappers/src/lib/Navbar/index.ts
@@ -1,2 +1,2 @@
 export { default as Navbar } from './Navbar';
-export { NavItem, QueryNavItem } from './Navbar';
+export { NavItem, QueryNavItem, AnchorNavItem } from './Navbar';

--- a/libs/tup-components/src/layout/Sidebar/Sidebar.tsx
+++ b/libs/tup-components/src/layout/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navbar, NavItem } from '@tacc/core-wrappers';
+import { Navbar, NavItem, AnchorNavItem } from '@tacc/core-wrappers';
 import { useAuth } from '@tacc/tup-hooks';
 import styles from './Sidebar.module.css';
 
@@ -18,9 +18,9 @@ const Sidebar: React.FC = () => {
           Tickets
         </NavItem>
         {loggedIn && (
-          <NavItem icon="exit" to={'/logout'}>
+          <AnchorNavItem icon="exit" to={'/dashboard/logout'}>
             Log Out
-          </NavItem>
+          </AnchorNavItem>
         )}
       </Navbar>
     </div>


### PR DESCRIPTION
## Overview:
Prevent the situation where clicking "Log Out' would redirect to the dashboard but still display a logged-in state in the navbar and let CMS users continue to edit. 
## Related:

- [TUP-404](https://jira.tacc.utexas.edu/browse/TUP-404)

## Changes:
Replace the client-side logout with a server-side route that kills the user's Django session and unsets their x-tup-token cookie.

## Testing:

1. From the dashboard, click "Log Out" from the sidebar or top nav.
2. confirm that you are actually logged out-- The top nav should say "Log in" instead of your username, and the CMS admin panel should be inaccessible.

