### PR TITLE
task/TUP-405: Dropdown UI for delegate selection

### DIFF
--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
@@ -1,5 +1,5 @@
 .user-detail-container {
-    width: 50%;
+    width: 60%;
     margin-left: -25px;
     margin-top: -20px;
 }
@@ -29,8 +29,14 @@
 .manage-user-container {
     display: flex;
     padding: 20px;
+    align-items: center;
     justify-content: space-between;
 }
+
+.link-button > span {
+    vertical-align: baseline;
+}
+
 
 .usage-table {
     width: 100%;
@@ -44,5 +50,11 @@
 
 .role-selector > :first-child {
     display: inline-block;
-    margin-right: 0.75rem;
 }
+.role-selector form {
+    display: inline-block
+}
+.role-selector select {
+    padding: 1px;
+}
+

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -22,58 +22,43 @@ const UserRoleSelector: React.FC<{ projectId: number; user: ProjectUser }> = ({
   const { mutate: mutateSetDelegate } = useSetProjectDelegate(projectId);
   const { mutate: mutateRemoveDelegate } = useRemoveProjectDelegate(projectId);
 
-  const [confirmState, setConfirmState] = useState<'DEFAULT' | 'CONFIRM'>(
-    'DEFAULT'
+  const [selectedUserRole, setSelectedUserRole] = useState<string>(
+    user.role ?? ''
   );
 
-  const setDelegate = () => {
-    mutateSetDelegate(
-      { username: user.username },
-      {
-        onSuccess: () => {
-          setConfirmState('DEFAULT');
-        },
-      }
-    );
+  const setRole = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (selectedUserRole === 'Delegate' && user.role === 'Standard')
+      mutateSetDelegate({ username: user.username });
+    if (selectedUserRole === 'Standard' && user.role === 'Delegate')
+      mutateRemoveDelegate(undefined);
   };
 
-  const removeDelegate = () => {
-    mutateRemoveDelegate(undefined, {
-      onSuccess: () => {
-        setConfirmState('DEFAULT');
-      },
-    });
-  };
   const canSetDelegate = currentUserRole === 'PI' && user.role !== 'PI';
-  if (!canSetDelegate) return null;
+  if (!canSetDelegate)
+    return (
+      <span>{user.role === 'Standard' ? 'Standard User' : user.role}</span>
+    );
 
   return (
-    <>
-      {confirmState === 'DEFAULT' && (
-        <Button onClick={() => setConfirmState('CONFIRM')} type="link">
-          {user.role !== 'Delegate' && 'Set as Project Delegate'}
-          {user.role === 'Delegate' && 'Remove as Project Delegate'}
+    <form onSubmit={setRole}>
+      <label hidden htmlFor="user-role-select">
+        Select a new role for this user.
+      </label>
+      <select
+        value={selectedUserRole}
+        onChange={(e) => setSelectedUserRole(e.target.value)}
+        id="user-role-select"
+      >
+        <option value={'Standard'}>Standard User</option>
+        <option value={'Delegate'}>Delegate</option>
+      </select>{' '}
+      {selectedUserRole !== user.role && (
+        <Button className={styles['link-button']} type="link" attr="submit">
+          Confirm
         </Button>
       )}
-      {confirmState === 'CONFIRM' && (
-        <>
-          {user.role !== 'Delegate' && (
-            <Button onClick={setDelegate} type="link">
-              Confirm Delegate Selection
-            </Button>
-          )}
-          {user.role === 'Delegate' && (
-            <Button onClick={removeDelegate} type="link">
-              Confirm Delegate Removal
-            </Button>
-          )}
-          <span> | </span>
-          <Button onClick={() => setConfirmState('DEFAULT')} type="link">
-            Cancel
-          </Button>
-        </>
-      )}
-    </>
+    </form>
   );
 };
 
@@ -104,19 +89,31 @@ const RemoveUser: React.FC<{ projectId: number; user: ProjectUser }> = ({
 
   if (confirmState === 'DEFAULT')
     return (
-      <Button onClick={() => setConfirmState('CONFIRM')} type="link">
+      <Button
+        className={styles['link-button']}
+        onClick={() => setConfirmState('CONFIRM')}
+        type="link"
+      >
         Remove User
       </Button>
     );
   if (confirmState === 'CONFIRM')
     return (
       <>
-        <Button onClick={removeUserCallback} type="link">
+        <Button
+          className={styles['link-button']}
+          onClick={removeUserCallback}
+          type="link"
+        >
           {!isLoading && 'Remove'}{' '}
           {isLoading && <LoadingSpinner placement="inline" />}
         </Button>{' '}
         |{' '}
-        <Button onClick={() => setConfirmState('DEFAULT')} type="link">
+        <Button
+          className={styles['link-button']}
+          onClick={() => setConfirmState('DEFAULT')}
+          type="link"
+        >
           Cancel
         </Button>
       </>
@@ -200,9 +197,7 @@ const UserDetail: React.FC<{ projectId: number; username: string }> = ({
       </div>
       <div className={styles['manage-user-container']}>
         <div className={styles['role-selector']}>
-          <span>
-            <strong>Role:</strong> {user.role}
-          </span>
+          <div>Role:</div>{' '}
           <UserRoleSelector projectId={projectId} user={user} />
         </div>
         <div>

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -10,7 +10,7 @@ import {
   useSetProjectDelegate,
   useRemoveProjectDelegate,
 } from '@tacc/tup-hooks';
-import { useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from './UserDetail.module.css';
 
@@ -25,6 +25,9 @@ const UserRoleSelector: React.FC<{ projectId: number; user: ProjectUser }> = ({
   const [selectedUserRole, setSelectedUserRole] = useState<string>(
     user.role ?? ''
   );
+  useLayoutEffect(() => {
+    return setSelectedUserRole(user.role ?? '');
+  }, [user]);
 
   const setRole = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -73,6 +76,7 @@ const RemoveUser: React.FC<{ projectId: number; user: ProjectUser }> = ({
   const [confirmState, setConfirmState] = useState<'DEFAULT' | 'CONFIRM'>(
     'DEFAULT'
   );
+  useEffect(() => setConfirmState('DEFAULT'), [user.username]);
   const { mutate, isLoading } = useRemoveProjectUser(projectId, user.username);
   const removeUserCallback = () => {
     mutate(undefined, {


### PR DESCRIPTION
## Overview:
Use a dropdown selector for setting user roles.

## Related:

- [TUP-405](https://jira.tacc.utexas.edu/browse/TUP-405)

## Changes:
- Update the UserRoleSelector to use a dropdown instead of an add/remove link.

## Testing:

1. Set a user as a delegate on a project.
2. Change the user's role back to a "standard" user.

## UI:
Default view (user is not a PI or is looking at their own role)
![image](https://user-images.githubusercontent.com/12601812/217351634-2e003275-2bdf-4fcd-9655-3dede078eaef.png)
Default view for PI looking at standard user: 
![image](https://user-images.githubusercontent.com/12601812/217355277-2b313616-bcc4-4586-ad10-7eeae352a5ea.png)
Confirmation view when a new role is selected:
![image](https://user-images.githubusercontent.com/12601812/217355378-85ac98e5-9ab1-4c1d-ac14-d5d105dae25d.png)


## Notes:
