### PR TITLE
task/TUP-406: Add UI for deleting publications and grants on projects

### DIFF
--- a/libs/tup-components/src/projects/details/ProjectDetails.tsx
+++ b/libs/tup-components/src/projects/details/ProjectDetails.tsx
@@ -21,6 +21,8 @@ import {
 import { ProjectGrantEditModal, ProjectGrantCreateModal } from './grants';
 import { ProjectsListingAllocationTable } from '../ProjectsListing/ProjectsListingAllocationTable';
 import { ProjectEditModal } from './ProjectEdit';
+import ProjectPublicationRemove from './publications/ProjectPublicationDelete';
+import ProjectGrantDelete from './grants/ProjectGrantDelete';
 
 const formatDate = (datestring: string): string => {
   const date = new Date(datestring);
@@ -39,10 +41,17 @@ const Publication: React.FC<{
           <strong>{pub.title}</strong>
         </span>
         {canManage && (
-          <ProjectPublicationEditModal
-            projectId={projectId}
-            publicationId={pub.id}
-          />
+          <span>
+            <ProjectPublicationEditModal
+              projectId={projectId}
+              publicationId={pub.id}
+            />
+            {' | '}
+            <ProjectPublicationRemove
+              projectId={projectId}
+              publicationId={pub.id}
+            />
+          </span>
         )}
       </div>
       <div className={styles['pub-grants-title']}>
@@ -78,7 +87,11 @@ const Grant: React.FC<{
           <strong>{grant.title}</strong>
         </span>
         {canManage && (
-          <ProjectGrantEditModal projectId={projectId} grantId={grant.id} />
+          <span>
+            <ProjectGrantEditModal projectId={projectId} grantId={grant.id} />
+            {' | '}
+            <ProjectGrantDelete projectId={projectId} grantId={grant.id} />
+          </span>
         )}
       </div>
       <div className={styles['pub-grants-title']}>

--- a/libs/tup-components/src/projects/details/grants/ProjectGrantDelete.tsx
+++ b/libs/tup-components/src/projects/details/grants/ProjectGrantDelete.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@tacc/core-components';
+import { useGrantDelete } from '@tacc/tup-hooks';
+import React, { useState } from 'react';
+
+const ProjectGrantDelete: React.FC<{
+  projectId: number;
+  grantId: number;
+}> = ({ projectId, grantId }) => {
+  const [confirmState, setConfirmState] = useState<'CONFIRM' | 'DEFAULT'>(
+    'DEFAULT'
+  );
+
+  const { mutate } = useGrantDelete(projectId, grantId);
+
+  const deleteGrant = () =>
+    mutate(undefined, {
+      onSuccess: () => {
+        setConfirmState('DEFAULT');
+      },
+    });
+
+  switch (confirmState) {
+    case 'DEFAULT':
+      return (
+        <Button onClick={() => setConfirmState('CONFIRM')} type="link">
+          Delete
+        </Button>
+      );
+    case 'CONFIRM':
+      return (
+        <>
+          <Button type="link" onClick={deleteGrant}>
+            <strong>Confirm Deletion</strong>
+          </Button>
+          {' | '}
+          <Button onClick={() => setConfirmState('DEFAULT')} type="link">
+            <strong>Cancel</strong>
+          </Button>
+        </>
+      );
+  }
+};
+
+export default ProjectGrantDelete;

--- a/libs/tup-components/src/projects/details/publications/ProjectPublicationDelete.tsx
+++ b/libs/tup-components/src/projects/details/publications/ProjectPublicationDelete.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@tacc/core-components';
+import { usePublicationDelete } from '@tacc/tup-hooks';
+import React, { useState } from 'react';
+
+const ProjectPublicationDelete: React.FC<{
+  projectId: number;
+  publicationId: number;
+}> = ({ projectId, publicationId }) => {
+  const [confirmState, setConfirmState] = useState<'CONFIRM' | 'DEFAULT'>(
+    'DEFAULT'
+  );
+
+  const { mutate } = usePublicationDelete(projectId, publicationId);
+
+  const deletePublication = () =>
+    mutate(undefined, {
+      onSuccess: () => {
+        setConfirmState('DEFAULT');
+      },
+    });
+
+  switch (confirmState) {
+    case 'DEFAULT':
+      return (
+        <Button onClick={() => setConfirmState('CONFIRM')} type="link">
+          Delete
+        </Button>
+      );
+    case 'CONFIRM':
+      return (
+        <>
+          <Button type="link" onClick={deletePublication}>
+            <strong>Confirm Deletion</strong>
+          </Button>
+          {' | '}
+          <Button onClick={() => setConfirmState('DEFAULT')} type="link">
+            <strong>Cancel</strong>
+          </Button>
+        </>
+      );
+  }
+};
+
+export default ProjectPublicationDelete;

--- a/libs/tup-hooks/src/projects/index.ts
+++ b/libs/tup-hooks/src/projects/index.ts
@@ -145,6 +145,12 @@ export {
   usePublications,
   usePublicationEdit,
   usePublicationCreate,
+  usePublicationDelete,
 } from './usePublications';
-export { useGrants, useGrantEdit, useGrantCreate } from './useGrants';
+export {
+  useGrants,
+  useGrantEdit,
+  useGrantCreate,
+  useGrantDelete,
+} from './useGrants';
 export { default as useProjectScienceField } from './useProjectScienceField';

--- a/libs/tup-hooks/src/projects/useGrants.ts
+++ b/libs/tup-hooks/src/projects/useGrants.ts
@@ -1,6 +1,6 @@
 import { UseQueryResult, useQueryClient } from '@tanstack/react-query';
 import { ProjectGrant, ProjectGrantBody } from '.';
-import { useGet, usePost, usePut } from '../requests';
+import { useGet, usePost, usePut, useDelete } from '../requests';
 
 // Query to retrieve the user's grants.
 export const useGrants = (id: number): UseQueryResult<ProjectGrant[]> => {
@@ -27,6 +27,17 @@ export const useGrantCreate = (projectId: number) => {
 export const useGrantEdit = (projectId: number, grantId: number) => {
   const queryClient = useQueryClient();
   const mutation = usePut<ProjectGrant, string>({
+    endpoint: `/projects/${projectId}/grants/${grantId}`,
+    options: {
+      onSuccess: () => queryClient.invalidateQueries(['grants', projectId]),
+    },
+  });
+  return mutation;
+};
+
+export const useGrantDelete = (projectId: number, grantId: number) => {
+  const queryClient = useQueryClient();
+  const mutation = useDelete<string>({
     endpoint: `/projects/${projectId}/grants/${grantId}`,
     options: {
       onSuccess: () => queryClient.invalidateQueries(['grants', projectId]),

--- a/libs/tup-hooks/src/projects/usePublications.ts
+++ b/libs/tup-hooks/src/projects/usePublications.ts
@@ -1,6 +1,6 @@
 import { UseQueryResult, useQueryClient } from '@tanstack/react-query';
 import { ProjectPublication, ProjectPublicationBody } from '.';
-import { useGet, usePost, usePut } from '../requests';
+import { useDelete, useGet, usePost, usePut } from '../requests';
 
 // Query to retrieve the user's publications.
 export const usePublications = (
@@ -33,6 +33,21 @@ export const usePublicationEdit = (
 ) => {
   const queryClient = useQueryClient();
   const mutation = usePut<ProjectPublicationBody, string>({
+    endpoint: `/projects/${projectId}/publications/${publicationId}`,
+    options: {
+      onSuccess: () =>
+        queryClient.invalidateQueries(['publications', projectId]),
+    },
+  });
+  return mutation;
+};
+
+export const usePublicationDelete = (
+  projectId: number,
+  publicationId: number
+) => {
+  const queryClient = useQueryClient();
+  const mutation = useDelete<string>({
     endpoint: `/projects/${projectId}/publications/${publicationId}`,
     options: {
       onSuccess: () =>


### PR DESCRIPTION
## Overview:
Add UI for deleting publications and grants on projects.
## Related:

- [TUP-1234](https://jira.tacc.utexas.edu/browse/TUP-1234)

## Changes:
- Add hooks for deleting pubs/grants.
- Add components that confirm the user's intent before they delete a pub/grant.

## Testing:

1. Go to a project you have PI/delegate privileges on and delete a publication.
2. Go to a project you have PI/delegate privileges on and delete a grant.

## UI:
Default view:
![image](https://user-images.githubusercontent.com/12601812/217365548-66f5336c-2796-4ed4-861d-bd772302b979.png)
After clicking "Delete": 
![image](https://user-images.githubusercontent.com/12601812/217365600-eb2e5691-cebb-49e6-99c6-a881cdd658e5.png)



## Notes:
