### PR TITLE
fix(tup-cms): tup-412, giant dashboard footer

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:e86175b
+FROM taccwma/core-cms:a944f57
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/apps/dashboard/templates/dashboard/dashboard.debug.html
+++ b/apps/tup-cms/src/apps/dashboard/templates/dashboard/dashboard.debug.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block html_page_id %}dashboard{% endblock %}
+
 {% block assets_core_project %}
 {% include './assets.html' %}
 {% endblock %}

--- a/apps/tup-cms/src/apps/dashboard/templates/dashboard/dashboard.html
+++ b/apps/tup-cms/src/apps/dashboard/templates/dashboard/dashboard.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block html_page_id %}dashboard{% endblock %}
+
 {% block assets_core_project %}
 {% include './assets.html' %}
 {% endblock %}


### PR DESCRIPTION
## Overview

Consistently hide and show version of footer by using a more reliable flag in the markup.

<details>

- Set page ID (html_page_id) so markup has `<html id="page-dashboard" ...>`.
- Load CMS image that supports `html_page_id` template variable.

</details>

## Related

- [TUP-412](https://jira.tacc.utexas.edu/browse/TUP-412)

## Changes

- **added** `html_page_id` setting in `dashboard(.debug).html` 
- **changed** cms image

## Testing

1. Log in to Dashboard.
2. Navigate to another page (e.g. `tickets/`, `profile/`, `projects/`).
3. Refresh.

## UI

| homepage | login | dashboard | projects (after refresh) |
| - | - | - | - |
| ![homepage](https://user-images.githubusercontent.com/62723358/217674442-9ce91411-860f-4a8a-b36a-9fd9ba42d338.png) | ![login](https://user-images.githubusercontent.com/62723358/217674441-629caac1-2b35-4d2a-a4e0-f31cbbf3b096.png) | ![dashboard](https://user-images.githubusercontent.com/62723358/217674446-d11da0f0-0733-48fc-b8fe-72711934eb04.png) | ![projects (after refresh)](https://user-images.githubusercontent.com/62723358/217674444-b5cec752-cb5b-4d55-b923-aa23f19c6aba.png) |

## Notes

1. The [snippet #65 on dev.tup](https://dev.tup.tacc.utexas.edu/admin/djangocms_snippet/snippet/65/) was updated to accommodate the new solution.
    - <details><summary>before</summary>

        ```
        html:not([data-page-id="dashboard"]) footer .row:nth-of-type(2) /* TUP */,
        html:is([data-page-id="dashboard"]) footer .row:nth-of-type(1) /* CMS */ {
        	display: none;
        }
        ```

        </details>

    - <details><summary>after</summary>

        ```
        /* To hide/show CMS/Portal footer */
        /* IMPORTANT: Requires TACC/tup-ui#135 */
        html:not(#page-dashboard) #portal-footer,
        html[data-page-id="dashboard-login"] #portal-footer,
        html#page-dashboard:not([data-page-id="dashboard-login"]) #cms-footer {
			display: none;
        }
        ```

        </details>