### PR TITLE
fix(tup-cms): get latest core-cms image / tup-412

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:a944f57
+FROM taccwma/core-cms:8fee781
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview / Changes

Fix TUP-412 (and maybe others) by using the latest Core-CMS image.

## Related:

- fix [TUP-412](https://jira.tacc.utexas.edu/browse/TUP-412) again

## Testing

1. Test [TUP-412](https://jira.tacc.utexas.edu/browse/TUP-412) again.

## UI

| login | homepage | dashboard - projects | dashboard |
| - | - | - | - |
| ![login](https://user-images.githubusercontent.com/62723358/217950118-ce5e1c88-3198-4cfa-9fcb-892302ddc16e.png) | ![homepage](https://user-images.githubusercontent.com/62723358/217950124-af4fb05d-a44d-43b1-b3a5-b82b8b514bef.png) | ![dashboard - projects](https://user-images.githubusercontent.com/62723358/217950127-5a66505e-8c36-44b7-90c4-1796544d0957.png) | ![dashboard](https://user-images.githubusercontent.com/62723358/217950128-8b404322-598f-4d9c-b26a-8ac25cb2573b.png) |