### PR TITLE
Task/tup 408 mfa help link

### DIFF
--- a/libs/tup-components/src/mfa/MfaHeader.tsx
+++ b/libs/tup-components/src/mfa/MfaHeader.tsx
@@ -1,12 +1,13 @@
 import { Link } from 'react-router-dom';
 import styles from './Mfa.module.css';
+import TicketCreateModal from '../tickets/TicketCreateModal';
 
 const MfaHeader: React.FC = () => {
   return (
     <div className={styles['mfa-header']}>
       <div>Multifactor Authentication Pairing</div>
       <div>
-        Get Help | <Link to="/account">Exit Pairing Process</Link>
+      <TicketCreateModal /> | <Link to="/account">Exit Pairing Process</Link>
       </div>
     </div>
   );

--- a/libs/tup-components/src/mfa/MfaHeader.tsx
+++ b/libs/tup-components/src/mfa/MfaHeader.tsx
@@ -7,7 +7,8 @@ const MfaHeader: React.FC = () => {
     <div className={styles['mfa-header']}>
       <div>Multifactor Authentication Pairing</div>
       <div>
-      <TicketCreateModal title={'Get Help'}/> | <Link to="/account">Exit Pairing Process</Link>
+        <TicketCreateModal title={'Get Help'} /> |{' '}
+        <Link to="/account">Exit Pairing Process</Link>
       </div>
     </div>
   );

--- a/libs/tup-components/src/mfa/MfaHeader.tsx
+++ b/libs/tup-components/src/mfa/MfaHeader.tsx
@@ -7,7 +7,7 @@ const MfaHeader: React.FC = () => {
     <div className={styles['mfa-header']}>
       <div>Multifactor Authentication Pairing</div>
       <div>
-      <TicketCreateModal /> | <Link to="/account">Exit Pairing Process</Link>
+      <TicketCreateModal title={'Get Help'}/> | <Link to="/account">Exit Pairing Process</Link>
       </div>
     </div>
   );

--- a/libs/tup-components/src/mfa/MfaHeader.tsx
+++ b/libs/tup-components/src/mfa/MfaHeader.tsx
@@ -7,7 +7,7 @@ const MfaHeader: React.FC = () => {
     <div className={styles['mfa-header']}>
       <div>Multifactor Authentication Pairing</div>
       <div>
-        <TicketCreateModal display='link'>Get Help</TicketCreateModal> |{' '}
+        <TicketCreateModal display="link">Get Help</TicketCreateModal> |{' '}
         <Link to="/account">Exit Pairing Process</Link>
       </div>
     </div>

--- a/libs/tup-components/src/mfa/MfaHeader.tsx
+++ b/libs/tup-components/src/mfa/MfaHeader.tsx
@@ -7,7 +7,7 @@ const MfaHeader: React.FC = () => {
     <div className={styles['mfa-header']}>
       <div>Multifactor Authentication Pairing</div>
       <div>
-        <TicketCreateModal title={'Get Help'} /> |{' '}
+        <TicketCreateModal display='link'>Get Help</TicketCreateModal> |{' '}
         <Link to="/account">Exit Pairing Process</Link>
       </div>
     </div>

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
@@ -4,7 +4,9 @@ import { Button } from '@tacc/core-components';
 import { TicketCreateForm } from './TicketCreateForm';
 import styles from './TicketCreateModal.module.css';
 
-const TicketCreateModal: React.FC = () => {
+const TicketCreateModal: React.FC<{
+  title: string;
+}> = ({ title }) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => {
     setIsOpen(!isOpen);
@@ -18,8 +20,8 @@ const TicketCreateModal: React.FC = () => {
 
   return (
     <>
-      <Button type="secondary" onClick={() => toggle()}>
-        + New Ticket
+      <Button type="link" onClick={() => toggle()}>
+        {title}
       </Button>
       <Modal isOpen={isOpen} toggle={toggle} size="lg">
         <ModalHeader

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
@@ -4,11 +4,12 @@ import { Button } from '@tacc/core-components';
 import { TicketCreateForm } from './TicketCreateForm';
 import styles from './TicketCreateModal.module.css';
 
-const TicketCreateModal: React.FC<React.PropsWithChildren<{
-  display: 'secondary' | 'link';
-  }> 
+const TicketCreateModal: React.FC<
+  React.PropsWithChildren<{
+    display: 'secondary' | 'link';
+  }>
 > = ({ children, display }) => {
-  const [isOpen, setIsOpen] = useState(false);    
+  const [isOpen, setIsOpen] = useState(false);
   const toggle = () => {
     setIsOpen(!isOpen);
   };

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
@@ -4,10 +4,11 @@ import { Button } from '@tacc/core-components';
 import { TicketCreateForm } from './TicketCreateForm';
 import styles from './TicketCreateModal.module.css';
 
-const TicketCreateModal: React.FC<{
-  title: string;
-}> = ({ title }) => {
-  const [isOpen, setIsOpen] = useState(false);
+const TicketCreateModal: React.FC<React.PropsWithChildren<{
+  display: 'secondary' | 'link';
+  }> 
+> = ({ children, display }) => {
+  const [isOpen, setIsOpen] = useState(false);    
   const toggle = () => {
     setIsOpen(!isOpen);
   };
@@ -20,8 +21,8 @@ const TicketCreateModal: React.FC<{
 
   return (
     <>
-      <Button type="link" onClick={() => toggle()}>
-        {title}
+      <Button type={display} onClick={() => toggle()}>
+        {children}
       </Button>
       <Modal isOpen={isOpen} toggle={toggle} size="lg">
         <ModalHeader

--- a/libs/tup-components/src/tickets/Tickets.tsx
+++ b/libs/tup-components/src/tickets/Tickets.tsx
@@ -9,7 +9,7 @@ const Tickets: React.FC = () => {
   return (
     <RequireAuth>
       <section style={{ display: 'flex', flexDirection: 'column' }}>
-        <SectionHeader actions={<TicketCreateModal title={'+ New Ticket'} />}>
+        <SectionHeader actions={<TicketCreateModal display='secondary'>+ New Ticket</TicketCreateModal>}>
           Tickets
         </SectionHeader>
         <SectionTableWrapper contentShouldScroll className="ticket-container">

--- a/libs/tup-components/src/tickets/Tickets.tsx
+++ b/libs/tup-components/src/tickets/Tickets.tsx
@@ -9,7 +9,13 @@ const Tickets: React.FC = () => {
   return (
     <RequireAuth>
       <section style={{ display: 'flex', flexDirection: 'column' }}>
-        <SectionHeader actions={<TicketCreateModal display='secondary'>+ New Ticket</TicketCreateModal>}>
+        <SectionHeader
+          actions={
+            <TicketCreateModal display="secondary">
+              + New Ticket
+            </TicketCreateModal>
+          }
+        >
           Tickets
         </SectionHeader>
         <SectionTableWrapper contentShouldScroll className="ticket-container">

--- a/libs/tup-components/src/tickets/Tickets.tsx
+++ b/libs/tup-components/src/tickets/Tickets.tsx
@@ -9,7 +9,9 @@ const Tickets: React.FC = () => {
   return (
     <RequireAuth>
       <section style={{ display: 'flex', flexDirection: 'column' }}>
-        <SectionHeader actions={<TicketCreateModal title={'+ New Ticket'}/>}>Tickets</SectionHeader>
+        <SectionHeader actions={<TicketCreateModal title={'+ New Ticket'} />}>
+          Tickets
+        </SectionHeader>
         <SectionTableWrapper contentShouldScroll className="ticket-container">
           <TicketsTable />
         </SectionTableWrapper>

--- a/libs/tup-components/src/tickets/Tickets.tsx
+++ b/libs/tup-components/src/tickets/Tickets.tsx
@@ -9,7 +9,7 @@ const Tickets: React.FC = () => {
   return (
     <RequireAuth>
       <section style={{ display: 'flex', flexDirection: 'column' }}>
-        <SectionHeader actions={<TicketCreateModal />}>Tickets</SectionHeader>
+        <SectionHeader actions={<TicketCreateModal title={'+ New Ticket'}/>}>Tickets</SectionHeader>
         <SectionTableWrapper contentShouldScroll className="ticket-container">
           <TicketsTable />
         </SectionTableWrapper>

--- a/libs/tup-components/src/tickets/TicketsDashboard.tsx
+++ b/libs/tup-components/src/tickets/TicketsDashboard.tsx
@@ -7,7 +7,7 @@ const TicketsDashboard: React.FC = () => {
   return (
     <SectionTableWrapper
       header="My Tickets"
-      headerActions={<TicketCreateModal title={'+ New Ticket'}/>}
+      headerActions={<TicketCreateModal title={'+ New Ticket'} />}
       contentShouldScroll
     >
       <TicketsTable />

--- a/libs/tup-components/src/tickets/TicketsDashboard.tsx
+++ b/libs/tup-components/src/tickets/TicketsDashboard.tsx
@@ -7,7 +7,7 @@ const TicketsDashboard: React.FC = () => {
   return (
     <SectionTableWrapper
       header="My Tickets"
-      headerActions={<TicketCreateModal />}
+      headerActions={<TicketCreateModal title={'+ New Ticket'}/>}
       contentShouldScroll
     >
       <TicketsTable />

--- a/libs/tup-components/src/tickets/TicketsDashboard.tsx
+++ b/libs/tup-components/src/tickets/TicketsDashboard.tsx
@@ -7,7 +7,7 @@ const TicketsDashboard: React.FC = () => {
   return (
     <SectionTableWrapper
       header="My Tickets"
-      headerActions={<TicketCreateModal title={'+ New Ticket'} />}
+      headerActions={<TicketCreateModal display='secondary'>+ New Ticket</TicketCreateModal>}
       contentShouldScroll
     >
       <TicketsTable />

--- a/libs/tup-components/src/tickets/TicketsDashboard.tsx
+++ b/libs/tup-components/src/tickets/TicketsDashboard.tsx
@@ -7,7 +7,9 @@ const TicketsDashboard: React.FC = () => {
   return (
     <SectionTableWrapper
       header="My Tickets"
-      headerActions={<TicketCreateModal display='secondary'>+ New Ticket</TicketCreateModal>}
+      headerActions={
+        <TicketCreateModal display="secondary">+ New Ticket</TicketCreateModal>
+      }
       contentShouldScroll
     >
       <TicketsTable />


### PR DESCRIPTION
## Overview: 
Clicking "get help" during MFA pairing should open the ticket modal. 
The ticket component will need to be updated to support a link-style button and custom text.

## Related:

- [TUP-408](https://jira.tacc.utexas.edu/browse/TUP-408)

## Changes:
The ticket component now has a required 'title' property. The title appears as the button text. 
The ticket modal appears as a link instead of button. 

## Testing:
Changes appear in three place. All three links open the ticket modal.
1. Dashboard --> Click [+ New Ticket], ticket modal should appear. 
2. NavBar --> Tickets --> Click [+ New Ticket], ticket modal should appear. 
3. Dashboard --> Manage Account (top right) --> [Pair Device] --> Click on [Get Help] (top right), ticket modal should appear

## UI:
![Screen Shot 2023-02-13 at 10 30 26 AM](https://user-images.githubusercontent.com/35277477/218515548-ee119e77-0749-4f61-bd4c-03d949018254.png)
![Screen Shot 2023-02-13 at 10 30 19 AM](https://user-images.githubusercontent.com/35277477/218515554-160ff3e7-c49d-46fb-b4fe-aebfedc2621d.png)
![Screen Shot 2023-02-13 at 10 30 09 AM](https://user-images.githubusercontent.com/35277477/218515580-ce619cf0-99be-4e06-9dc6-18a9ed98dd9c.png)




## Notes:
