### PR TITLE
chore(core-styles): tup-cms table style updates

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:da64653
+FROM taccwma/core-cms:831f541
 
 WORKDIR /code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@nrwl/vite": "^15.6.3",
         "@nrwl/web": "15.6.3",
         "@nrwl/workspace": "15.6.3",
-        "@tacc/core-styles": "github:TACC/Core-Styles#bugfix/picture-plugin-template-annoyances",
+        "@tacc/core-styles": "github:TACC/Core-Styles#e9d14e6",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5705,7 +5705,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#e8231f2860a98f5c6aeb74802148a6aa36ce9006",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#e9d14e6c1c6225d2e22c89c6eefd21a2da4c5552",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -29588,9 +29588,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#e8231f2860a98f5c6aeb74802148a6aa36ce9006",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#e9d14e6c1c6225d2e22c89c6eefd21a2da4c5552",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#bugfix/picture-plugin-template-annoyances",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#e9d14e6",
       "requires": {}
     },
     "@tanstack/query-core": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nrwl/vite": "^15.6.3",
     "@nrwl/web": "15.6.3",
     "@nrwl/workspace": "15.6.3",
-    "@tacc/core-styles": "github:TACC/Core-Styles#bugfix/picture-plugin-template-annoyances",
+    "@tacc/core-styles": "github:TACC/Core-Styles#e9d14e6",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## Overview / Changes

Table styles updates from Core-Styles.

> **After Merge:**
> Delete https://dev.tup.tacc.utexas.edu/admin/djangocms_snippet/snippet/35/.

## Related

- requires https://github.com/TACC/Core-Styles/pull/127
- requires https://github.com/TACC/Core-CMS/pull/603

## Testing & UI

See https://github.com/TACC/Core-Styles/pull/127.

And:
- single-column tables with paragraphs: [demo](https://dev.tup.tacc.utexas.edu/static/ui/components/detail/table--via-paragraphs-cms.html), [example](https://dev.tup.tacc.utexas.edu/education/educators/publications/), classes: s-paragraph-table or paragraph-table
- default table styles vs. cms table styles: [basic default](https://dev.tup.tacc.utexas.edu/static/ui/components/detail/table--default.html), [basic cms](https://dev.tup.tacc.utexas.edu/static/ui/components/detail/table--cms.html) (see side nav of this demo for more)