### PR TITLE
bug/TUP-413: Show only active projects/allocations in the Dashboard

### DIFF
--- a/libs/tup-components/src/projects/ProjectsTable.tsx
+++ b/libs/tup-components/src/projects/ProjectsTable.tsx
@@ -5,12 +5,21 @@ import { Link } from 'react-router-dom';
 
 const allocationDisplay = (allocations: ProjectsAllocations[]) => {
   return allocations.length
-    ? Array.from(new Set(allocations.map((e) => e.resource))).join(', ')
+    ? Array.from(
+        new Set(
+          allocations
+            .filter((e) => e.status === 'Active')
+            .map((e) => e.resource)
+        )
+      ).join(', ')
     : '--';
 };
 
 export const ProjectsTable: React.FC = () => {
   const { data, isLoading, error } = useProjects();
+  const projectData = data?.filter((prj) =>
+    prj.allocations?.some((alloc) => alloc.status === 'Active')
+  );
 
   if (isLoading) {
     return <LoadingSpinner />;
@@ -31,8 +40,8 @@ export const ProjectsTable: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {data && data.length ? (
-            data.map((project) => (
+          {projectData && projectData.length ? (
+            projectData.map((project) => (
               <tr key={project.id}>
                 <td style={{ width: '30%' }}>
                   <Link to={`/projects/${project.id}`}>{project.title}</Link>


### PR DESCRIPTION
## Overview:
Add filters so we only show active projects/allocations in the Projects section on the Dashboard.
## Related:

- [TUP-413](https://jira.tacc.utexas.edu/browse/TUP-413)

## Changes:
- Filter allocation list to only use active allocations
- Filter projects list for projects with at least 1 active allocation.


## UI:
before:
![image](https://user-images.githubusercontent.com/12601812/219094638-ce94c0fe-14bc-4709-b75a-5b3b6211c5cc.png)

after:
![image](https://user-images.githubusercontent.com/12601812/219094528-da91bce2-5a98-446a-ae45-a3cd2c181bf4.png)


## Notes:
