### PR TITLE
Support flush layouts in the Projects area

### DIFF
--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
@@ -36,4 +36,5 @@
 
 .section {
   display: grid;
+  padding: var(--global-space--section)
 }

--- a/apps/tup-ui/src/pages/Mfa/Mfa.module.css
+++ b/apps/tup-ui/src/pages/Mfa/Mfa.module.css
@@ -1,3 +1,3 @@
 .mfa-layout {
-  padding: var(--global-space-section);
+  padding: var(--global-space--section);
 }

--- a/apps/tup-ui/src/pages/ProjectView/ProjectView.module.css
+++ b/apps/tup-ui/src/pages/ProjectView/ProjectView.module.css
@@ -1,0 +1,7 @@
+.project-view {
+    display: grid;
+}
+
+.project-view div {
+    overflow: auto;
+}

--- a/apps/tup-ui/src/pages/ProjectView/ProjectView.module.css
+++ b/apps/tup-ui/src/pages/ProjectView/ProjectView.module.css
@@ -2,6 +2,6 @@
     display: grid;
 }
 
-.project-view div {
+.project-view > div {
     overflow: auto;
 }

--- a/apps/tup-ui/src/pages/ProjectView/ProjectView.tsx
+++ b/apps/tup-ui/src/pages/ProjectView/ProjectView.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tacc/tup-components';
 import React from 'react';
 import { Outlet, useParams } from 'react-router-dom';
+import styles from './ProjectView.module.css';
 
 const ProjectView: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>();
@@ -13,11 +14,17 @@ const ProjectView: React.FC = () => {
 
   return (
     <RequireAuth>
-      <PageLayout
-        top={<ProjectHeader projectId={parseInt(projectId)} />}
-        left={<UserList projectId={parseInt(projectId)} />}
-        right={<Outlet />}
-      ></PageLayout>
+      <section className={styles['project-view']}>
+        <PageLayout
+          top={<ProjectHeader projectId={parseInt(projectId)} />}
+          left={<UserList projectId={parseInt(projectId)} />}
+          right={
+            <div>
+              <Outlet />
+            </div>
+          }
+        ></PageLayout>
+      </section>
     </RequireAuth>
   );
 };

--- a/apps/tup-ui/src/pages/Projects/Projects.module.css
+++ b/apps/tup-ui/src/pages/Projects/Projects.module.css
@@ -1,5 +1,16 @@
-.project-header {
-    font-size: 2.6rem;
-    border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--dark);
-    padding-bottom: 5px;
+.project-section {
+    display: grid;
+}
+
+.project-section > div > header {
+    padding-top: var(--global-space--section-top);
+    padding-left: var(--global-space--section-left);
+}
+
+.project-section nav {
+    margin-top: calc( -1 * var(--global-space--section-top));
+}
+
+.project-section > div > div {
+    padding: var(--global-space--section);
 }

--- a/apps/tup-ui/src/pages/Projects/Projects.module.css
+++ b/apps/tup-ui/src/pages/Projects/Projects.module.css
@@ -8,7 +8,7 @@
 }
 
 .project-section nav {
-    margin-top: calc( -1 * var(--global-space--section-top));
+    margin-top: -15px;
 }
 
 .project-section > div > div {

--- a/apps/tup-ui/src/pages/Projects/Projects.tsx
+++ b/apps/tup-ui/src/pages/Projects/Projects.tsx
@@ -7,14 +7,18 @@ import {
 } from '@tacc/tup-components';
 import { SectionHeader } from '@tacc/core-components';
 
+import styles from './Projects.module.css';
+
 const Layout: React.FC = () => {
   return (
     <RequireAuth>
-      <PageLayout
-        top={<SectionHeader>Projects & Allocations</SectionHeader>}
-        left={<ProjectsNavbar />}
-        right={<ProjectsListing />}
-      ></PageLayout>
+      <section className={styles['project-section']}>
+        <PageLayout
+          top={<SectionHeader>Projects & Allocations</SectionHeader>}
+          left={<ProjectsNavbar />}
+          right={<ProjectsListing />}
+        ></PageLayout>
+      </section>
     </RequireAuth>
   );
 };

--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -1,4 +1,5 @@
 .account-layout{
+    padding: var(--global-space--section);
     padding-right: 30px;
 }
 

--- a/libs/tup-components/src/accounts/ManageAccount.tsx
+++ b/libs/tup-components/src/accounts/ManageAccount.tsx
@@ -22,7 +22,7 @@ const ManageUser = () => (
       rel="noreferrer"
     >
       <Button className={styles['tap-button']} type="primary">
-        Go to TAP
+        Edit User Profile
       </Button>
     </a>
   </>
@@ -71,26 +71,28 @@ const ManagePassword = () => (
 const ManageAccount: React.FC = () => {
   const { data } = useProfile();
   return (
-    <article className={styles['account-layout']}>
-      <header className={styles['account-header']}>
-        <Icon name="user" />
-        <span>
-          {data?.firstName} {data?.lastName}
-        </span>
-      </header>
-      <div className={styles['account-body']}>
-        <section>
-          <ManageUser />
-          <ManagePassword />
-          <span />
-          <ManageDNs />
-        </section>
-        <span className={styles['tap-separator']} />
-        <section>
-          <AccountMfa />
-        </section>
-      </div>
-    </article>
+    <section>
+      <article className={styles['account-layout']}>
+        <header className={styles['account-header']}>
+          <Icon name="user" />
+          <span>
+            {data?.firstName} {data?.lastName}
+          </span>
+        </header>
+        <div className={styles['account-body']}>
+          <section>
+            <ManageUser />
+            <ManagePassword />
+            <span />
+            <ManageDNs />
+          </section>
+          <span className={styles['tap-separator']} />
+          <section>
+            <AccountMfa />
+          </section>
+        </div>
+      </article>
+    </section>
   );
 };
 

--- a/libs/tup-components/src/layout/PageLayout/PageLayout.module.css
+++ b/libs/tup-components/src/layout/PageLayout/PageLayout.module.css
@@ -26,7 +26,6 @@
 
   display: grid;
   grid-template-rows: 100%; /* to not let items overflow this container */
-  padding: var(--global-space--section);
 }
 
 .footer {

--- a/libs/tup-components/src/layout/Sidebar/Sidebar.module.css
+++ b/libs/tup-components/src/layout/Sidebar/Sidebar.module.css
@@ -1,5 +1,6 @@
 .root {
   overflow-y: auto;
+  min-width: 175px;
   height: 100%;
   background: #f4f4f4;
   border-right: 1px solid rgba(112, 112, 112, 0.25);

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.module.css
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.module.css
@@ -37,7 +37,7 @@
 
 .project-listing-row > * {
     width: 100%;
-    flex-grow: 1
+    flex-grow: 1;
 }
 
 /* Project summary */
@@ -66,11 +66,4 @@
 
 .projects-listing-navbar > a > div {
     padding-left: var(--global-space--section-left);
-}
-
-.project-navbar-spacer {
-    border-top: 1px solid #707070;
-    margin-top: 10px;
-    margin-left: var(--global-space--section-left); 
-    margin-right: 7px;
 }

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.module.css
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.module.css
@@ -59,6 +59,18 @@
 /* Project navbar */
 .projects-listing-navbar {
     height: 100%;
+    min-width: 175px;
+    padding-top: var(--global-space--section-top);
     border-right:var(--global-border-width--normal) solid var(--global-color-primary--light);
 }
 
+.projects-listing-navbar > a > div {
+    padding-left: var(--global-space--section-left);
+}
+
+.project-navbar-spacer {
+    border-top: 1px solid #707070;
+    margin-top: 10px;
+    margin-left: var(--global-space--section-left); 
+    margin-right: 7px;
+}

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsNavbar.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsNavbar.tsx
@@ -22,6 +22,7 @@ export const ProjectsNavbar: React.FC = () => {
       >
         <div>Inactive Projects</div>
       </QueryNavItem>
+      <div className={styles['project-navbar-spacer']} />
     </div>
   );
 };

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsNavbar.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsNavbar.tsx
@@ -22,7 +22,6 @@ export const ProjectsNavbar: React.FC = () => {
       >
         <div>Inactive Projects</div>
       </QueryNavItem>
-      <div className={styles['project-navbar-spacer']} />
     </div>
   );
 };

--- a/libs/tup-components/src/projects/details/ProjectDetails.module.css
+++ b/libs/tup-components/src/projects/details/ProjectDetails.module.css
@@ -53,6 +53,7 @@
 .pub-details-container {
     width: 60%;
     min-width: 500px;
+    margin: var(--global-space--section)
 }
 
 .listing-section > div {

--- a/libs/tup-components/src/projects/details/ProjectDetails.module.css
+++ b/libs/tup-components/src/projects/details/ProjectDetails.module.css
@@ -43,7 +43,7 @@
     justify-content: space-between;
 }
 .pub-grants-edit-link button {
-    min-width: fit-content
+    min-width: fit-content;
 }
 
 .pub-details-container h2 {
@@ -52,8 +52,8 @@
 
 .pub-details-container {
     width: 60%;
-    min-width: 500px;
-    margin: var(--global-space--section)
+    min-width: 545px;
+    padding: var(--global-space--section);
 }
 
 .listing-section > div {

--- a/libs/tup-components/src/projects/header/ProjectHeader/ProjectHeader.tsx
+++ b/libs/tup-components/src/projects/header/ProjectHeader/ProjectHeader.tsx
@@ -6,6 +6,7 @@ import {
   DescriptionList,
   InlineMessage,
   LoadingSpinner,
+  SectionHeader,
 } from '@tacc/core-components';
 
 const getPercentUsage = (total: number, used: number): string => {
@@ -84,8 +85,8 @@ export const ProjectHeader: React.FC<{ projectId: number }> = ({
     );
 
   return (
-    <>
-      <h3 className={styles['title']}>
+    <div className={styles['project-header']}>
+      <SectionHeader>
         {isActive && <Link to={'/projects?show=active'}>Active Projects </Link>}
         {!isActive && (
           <Link to={'/projects?show=inactive'}>Inactive Projects </Link>
@@ -97,8 +98,7 @@ export const ProjectHeader: React.FC<{ projectId: number }> = ({
             {`/ ${params.username}`}{' '}
           </>
         )}
-      </h3>
-      <div className={styles['separator']}></div>
+      </SectionHeader>
       <dl className={styles['group']}>
         <dl className={styles['project-heading']}>
           <div>
@@ -123,7 +123,7 @@ export const ProjectHeader: React.FC<{ projectId: number }> = ({
         </dl>
       </dl>
       <div className={styles['separator-bottom']}></div>
-    </>
+    </div>
   );
 };
 

--- a/libs/tup-components/src/projects/header/ProjectHeader/Projects.module.css
+++ b/libs/tup-components/src/projects/header/ProjectHeader/Projects.module.css
@@ -1,3 +1,8 @@
+.project-header {
+    padding-top: var(--global-space--section-top);
+    padding-left: var(--global-space--section-left);
+}
+
 .project-heading,
 .project-heading dd{
     align-self: baseline;
@@ -5,6 +10,7 @@
 }
 
 .group {
+    margin-top: -10px;
     display: inline-flex;
     flex-direction: row;;
     gap: 50px;
@@ -25,8 +31,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    padding-top: .5em;
-    padding-left: .5em;
 }
 .project-heading > * {
     display: flex;
@@ -37,28 +41,18 @@
     font-weight: var(--bold);
   }
 
-.title {
-    padding: .5em;
-}
-
 .usage dt {
     font-weight: normal;
 }
 .usage dd {
     font-weight: var(--bold)
 }
-.separator {
-    border-bottom: 1px solid #707070;
-    margin: .5em;
-}
+
 .separator-bottom {
     border-bottom: 1px solid #C7C7C7;
-    margin-top: .5em;
-    margin-left: .5em;
-    margin-right: .5em;
 
 }
 .loading-placeholder {
     height: 100%;
-    min-height: 107px;
+    min-height: 120px;
 }

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
@@ -1,7 +1,5 @@
 .user-detail-container {
     width: 60%;
-    margin-left: -25px;
-    margin-top: -20px;
 }
 
 .user-info-banner {

--- a/libs/tup-components/src/projects/users/UserList/UserList.module.css
+++ b/libs/tup-components/src/projects/users/UserList/UserList.module.css
@@ -1,10 +1,12 @@
 .user-list {
+    padding-top: 10px;
     min-height: 100%;
     border-right: 1px solid #C7C7C7;
 }
 
 .user-navitem > div {
     height: 25px;
+    padding-left: var(--global-space--section-left);
 }
 
 .separator {
@@ -18,9 +20,8 @@
 }
 
 .manage-team { 
-    padding-top: 10px;
-    margin-right: 10px;
-    margin-left: 5px;
+    padding-right: var(--global-space--section-right);
+    padding-left: var(--global-space--section-left)
 }
 .manage-team > :first-child {
     padding-bottom: 16px;

--- a/libs/tup-components/src/tickets/Tickets.module.css
+++ b/libs/tup-components/src/tickets/Tickets.module.css
@@ -1,0 +1,5 @@
+.tickets-section {
+    display: flex;
+    flex-direction: column;
+    padding: var(--global-space--section);
+}

--- a/libs/tup-components/src/tickets/Tickets.tsx
+++ b/libs/tup-components/src/tickets/Tickets.tsx
@@ -4,11 +4,12 @@ import { SectionHeader, SectionTableWrapper } from '@tacc/core-components';
 import { TicketsTable } from './TicketsTable';
 import { RequireAuth } from '../utils';
 import TicketCreateModal from './TicketCreateModal';
+import styles from './Tickets.module.css';
 
 const Tickets: React.FC = () => {
   return (
     <RequireAuth>
-      <section style={{ display: 'flex', flexDirection: 'column' }}>
+      <section className={styles['tickets-section']}>
         <SectionHeader
           actions={
             <TicketCreateModal display="secondary">


### PR DESCRIPTION
## Overview:
To match the mockups, we need a way for a layout's content to be flush with the sidebar and have borders run all the way to the bottom of the page. This isn't compatible with the setup of our `<PageLayout/>` component, which enforces default section padding on the contend div. Unfortunately there's no way to turn the padding off selectively because it's applied **upstream** of the content. The solution is to remove the padding, make the content flush with its surroundings by default, and have the content set its own padding.

## UI:
| before | after | 
| -- | -- | 
| <img width="1580" alt="image" src="https://user-images.githubusercontent.com/12601812/219412463-5156b05f-93d5-496f-ac1f-1c4f06383d42.png"> | <img width="1578" alt="image" src="https://user-images.githubusercontent.com/12601812/219412079-bdccb9be-bfde-4425-8f2b-f76dd029e644.png">|
| <img width="1582" alt="image" src="https://user-images.githubusercontent.com/12601812/219412541-a0dbefd8-4a94-4856-bcf9-5a861a1503db.png">| <img width="1583" alt="image" src="https://user-images.githubusercontent.com/12601812/219412353-1ff42824-6c1d-425e-b59d-e4ecb83505ed.png">| 


## Notes:
