### PR TITLE
task/TUP-417: Show inactive allocations for inactive projects

### DIFF
--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListingAllocationTable.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListingAllocationTable.tsx
@@ -11,6 +11,8 @@ export const ProjectsListingAllocationTable: React.FC<{
   project: ProjectsRawSystem;
 }> = ({ project }) => {
   const allocations = project.allocations || [];
+  const isActive = allocations.some((a) => a.status === 'Active');
+
   return (
     <table className={styles['allocations-table']}>
       <thead>
@@ -23,7 +25,8 @@ export const ProjectsListingAllocationTable: React.FC<{
       </thead>
       <tbody>
         {allocations
-          .filter((a) => a.status === 'Active')
+          // Show expired allocations if the project is inactive.
+          .filter((a) => (isActive ? a.status === 'Active' : true))
           .map((allocation) => (
             <tr key={allocation.id}>
               <td>{allocation.resource}</td>


### PR DESCRIPTION
## Overview:
Right now all inactive projects have an empty allocations table. We got a comment that we should show inactive allocations for these, since they might be useful for historical purposes.
## Related:

- [TUP-417](https://jira.tacc.utexas.edu/browse/TUP-417)

## UI:
<img width="1482" alt="image" src="https://user-images.githubusercontent.com/12601812/219481691-07e077f2-91ae-4f70-9ffd-526ca38505ec.png">


## Notes:
