### PR TITLE
task/TUP-418: use correct attributes for calculating percent usage on allocations

### DIFF
--- a/libs/tup-components/src/projects/ProjectsListing/ProjectSummary.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectSummary.tsx
@@ -5,14 +5,17 @@ import styles from './ProjectsListing.module.css';
 export const ProjectSummary: React.FC<{
   project: ProjectsRawSystem;
 }> = ({ project }) => {
+  const allocations = (project.allocations ?? []).filter(
+    (a) => a.status === 'Active'
+  );
   const totalStorageRequested =
-    project.allocations?.reduce((acc, e) => acc + e.storageRequested, 0) ?? 0;
+    allocations?.reduce((acc, e) => acc + e.storageQuota, 0) ?? 0;
   const totalStorageUsed =
-    project.allocations?.reduce((acc, e) => acc + e.storageUsed, 0) ?? 0;
+    allocations?.reduce((acc, e) => acc + e.storageUsed, 0) ?? 0;
   const totalComputeRequested =
-    project.allocations?.reduce((acc, e) => acc + e.computeRequested, 0) ?? 0;
+    allocations?.reduce((acc, e) => acc + e.total, 0) ?? 0;
   const totalComputeUsed =
-    project.allocations?.reduce((acc, e) => acc + e.used, 0) ?? 0;
+    allocations?.reduce((acc, e) => acc + e.used, 0) ?? 0;
 
   return (
     <>
@@ -39,8 +42,10 @@ export const ProjectSummary: React.FC<{
         <span>
           {totalComputeUsed
             ? ' (' +
-              ((totalComputeUsed / totalComputeRequested) * 100).toFixed(0) +
-              '  % Used) '
+              Math.floor(
+                (totalComputeUsed / totalComputeRequested) * 100
+              ).toFixed(0) +
+              '% Used) '
             : ' (0% Used) '}
         </span>
         <span className={styles['compute-separator']}>|</span>


### PR DESCRIPTION
## Overview:
We were using "compute requested" instead of the actual compute in the allocation, which was causing projects to show up with >100% resource usage.
## Related:

- [TUP-418](https://jira.tacc.utexas.edu/browse/TUP-418)

