### PR TITLE
fix(tup-ui): manage acct, add missing "Confirm Removal" text

### DIFF
--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -104,6 +104,7 @@ const RemoveUser: React.FC<{ projectId: number; user: ProjectUser }> = ({
   if (confirmState === 'CONFIRM')
     return (
       <>
+        Confirm Removal:&nbsp;
         <Button
           className={styles['link-button']}
           onClick={removeUserCallback}


### PR DESCRIPTION
## Overview / Changes

Add text that was in [design](https://xd.adobe.com/view/cc3dc245-2792-4e10-bdc1-50d2a7d32979-996e/screen/30a8fb69-771f-4f00-aa30-98902ca6d2be/specs/), but not in UI.

## Related

- [New TUP Testing Session 2 - User Group Feedback](https://confluence.tacc.utexas.edu/display/UP/New+TUP+Testing+Session+2+-+User+Group+Feedback)

## Testing & UI

https://user-images.githubusercontent.com/62723358/219503007-a0465f55-4a23-4b5a-acd5-7f6c01b31489.mov
