### PR TITLE
Use /portal and not /dashboard in routes… and CMS template ID

### DIFF
--- a/apps/tup-cms/src/apps/portal/templates/portal/portal.debug.html
+++ b/apps/tup-cms/src/apps/portal/templates/portal/portal.debug.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block html_page_id %}dashboard{% endblock %}
+{% block html_page_id %}portal{% endblock %}
 
 {% block assets_core_project %}
 {% include './assets.html' %}

--- a/apps/tup-cms/src/apps/portal/templates/portal/portal.html
+++ b/apps/tup-cms/src/apps/portal/templates/portal/portal.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block html_page_id %}dashboard{% endblock %}
+{% block html_page_id %}portal{% endblock %}
 
 {% block assets_core_project %}
 {% include './assets.html' %}


### PR DESCRIPTION
## Overview

Change template ID for Portal pages.

## Related

- https://github.com/TACC/tup-ui/pull/157

## Changes

## Testing

1. Confirm Portal and Login pages have `<html id="page-portal">`.
1. Confirm CMS pages do __not__ have `<html id="page-portal">`.

## UI

| portal, projects | portal, dashboard | portal, login | cms, home |
| - | - | - | - |
| ![projects](https://user-images.githubusercontent.com/62723358/220789476-e66c766c-6471-413f-840b-661cc9d5aa10.png) | ![dashboard](https://user-images.githubusercontent.com/62723358/220789477-c32ebbc2-f6f6-46db-9338-77b7b0a82808.png) | ![login](https://user-images.githubusercontent.com/62723358/220789478-370a1477-9fb5-4e0d-9652-72cd74c3d111.png) | ![cms](https://user-images.githubusercontent.com/62723358/220789479-0dd42e14-847c-4dc4-951b-f9d6e66edbdb.png) |

## Notes

http://dev.tup.tacc.utexas.edu/ CSS is already updated to support this change.