### PR TITLE
feat(tup-cms): tup-437, search query param name

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:831f541
+FROM taccwma/core-cms:c457eb3
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:c457eb3
+FROM taccwma/core-cms:2581ba6
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -87,6 +87,12 @@ LOGO = [
 ]
 
 ########################
+# TACC: SEARCH
+########################
+
+SEARCH_QUERY_PARAM_NAME = 'query_string'
+
+########################
 # DJANGO
 ########################
 
@@ -95,7 +101,7 @@ TUP_SERVICES_URL = "https://dev.tup-services.tacc.utexas.edu"
 LOGIN_URL = "/portal/login"
 
 ########################
-# NEWS / BLOG
+# TACC: NEWS/BLOG
 ########################
 
 from taccsite_cms.settings import INSTALLED_APPS

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -90,7 +90,7 @@ LOGO = [
 # TACC: SEARCH
 ########################
 
-SEARCH_QUERY_PARAM_NAME = 'query_string'
+SEARCH_QUERY_PARAM_NAME = 'q'
 
 ########################
 # DJANGO


### PR DESCRIPTION
## Overview

Add and use new setting `SEARCH_QUERY_PARAM_NAME` so CMS search uses parameter that Google expects.

## Related

- [TUP-437](https://jira.tacc.utexas.edu/browse/TUP-437)
- requires https://github.com/TACC/Core-CMS/pull/604

## Changes

- added `SEARCH_QUERY_PARAM_NAME` setting with value "q"
- changed CMS Docker image to one with [TACC/Core-CMS#604](https://github.com/TACC/Core-CMS/pull/604)

## Testing

1. Ensure a Search page with Search Snippet exists, like:
     - dev.tup page: https://dev.tup.tacc.utexas.edu/search/
     - dev.tup snippet: https://dev.tup.tacc.utexas.edu/admin/djangocms_snippet/snippet/89/change/
2. Open any CMS page.
3. Verify search `<input>`'s `name` attribute equals `q` (not `query_search`).
4. Search for "test" using search box.
5. Verify search page returns results (because URL has `?q=test`).

## UI

| search box | search page |
| - | - |
| ![ search box](https://user-images.githubusercontent.com/62723358/221049018-0210172c-1dc4-4f1a-9ef2-0cbe8b456e50.png) | ![search page](https://user-images.githubusercontent.com/62723358/221049014-5cc7d397-a0a5-44bc-9464-6a7cbb65e1b6.png) |