### PR TITLE
Fixes for CMD feedback items

### DIFF
--- a/apps/tup-ui/src/App.tsx
+++ b/apps/tup-ui/src/App.tsx
@@ -28,9 +28,17 @@ function App() {
     <Routes>
       <Route path="/" element={<AppLayout />}>
         <Route path="/" element={<Navigate to="/dashboard" />} />
-        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/dashboard" element={<Dashboard />}>
+          <Route
+            path="tickets/:ticketId"
+            element={<TicketDetail baseRoute="/dashboard" />}
+          />
+        </Route>
         <Route path="tickets" element={<Tickets />}>
-          <Route path=":ticketId" element={<TicketDetail />} />
+          <Route
+            path=":ticketId"
+            element={<TicketDetail baseRoute="/tickets" />}
+          />
         </Route>
         <Route path="projects" element={<Projects />}></Route>
         <Route path="projects/active" element={<Projects />}></Route>

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
@@ -10,7 +10,7 @@ import {
 
 import './Dashboard.css';
 import styles from './Dashboard.module.css';
-import { Link } from 'react-router-dom';
+import { Link, Outlet } from 'react-router-dom';
 
 const Layout: React.FC = () => {
   const bodyClassName = 'dashboard';
@@ -37,6 +37,7 @@ const Layout: React.FC = () => {
             <TicketsDashboard />
           </div>
         </main>
+        <Outlet />
       </section>
     </RequireAuth>
   );

--- a/apps/tup-ui/src/pages/Tickets/TicketDetail.tsx
+++ b/apps/tup-ui/src/pages/Tickets/TicketDetail.tsx
@@ -1,10 +1,11 @@
+import React from 'react';
 import { TicketModal } from '@tacc/tup-components';
 
 import { useParams } from 'react-router-dom';
 
-const TicketDetail = () => {
+const TicketDetail: React.FC<{ baseRoute: string }> = ({ baseRoute }) => {
   const ticketId = useParams().ticketId ?? '';
-  return <TicketModal ticketId={ticketId} />;
+  return <TicketModal ticketId={ticketId} baseRoute={baseRoute} />;
 };
 
 export default TicketDetail;

--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -50,6 +50,10 @@
     width: 200px;
 }
 
+.tap-href {
+    width: fit-content;
+}
+
 .tap-separator {
     border-right: 1px solid #707070;
     margin-top: 10px;

--- a/libs/tup-components/src/accounts/ManageAccount.tsx
+++ b/libs/tup-components/src/accounts/ManageAccount.tsx
@@ -20,6 +20,7 @@ const ManageUser = () => (
       href="https://accounts-dev.tacc.utexas.edu/profile"
       target="_blank"
       rel="noreferrer"
+      className={styles['tap-href']}
     >
       <Button className={styles['tap-button']} type="primary">
         Edit User Profile
@@ -40,6 +41,7 @@ const ManageDNs = () => (
       href="https://accounts-dev.tacc.utexas.edu/certificates"
       target="_blank"
       rel="noreferrer"
+      className={styles['tap-href']}
     >
       <Button className={styles['tap-button']} type="primary">
         Manage DNs
@@ -60,6 +62,7 @@ const ManagePassword = () => (
       href="https://accounts-dev.tacc.utexas.edu/change_password"
       target="_blank"
       rel="noreferrer"
+      className={styles['tap-href']}
     >
       <Button className={styles['tap-button']} type="primary">
         Change Password

--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -59,7 +59,7 @@ export const AccountMfa: React.FC = () => {
         <strong>MFA Pairing</strong>
       </div>
       {!hasPairing && (
-        <Link to="/mfa">
+        <Link to="/mfa" className={styles['tap-href']}>
           <Button type="primary">Pair Device</Button>
         </Link>
       )}

--- a/libs/tup-components/src/projects/details/ProjectEdit/ProjectEditModal.tsx
+++ b/libs/tup-components/src/projects/details/ProjectEdit/ProjectEditModal.tsx
@@ -22,7 +22,12 @@ const ProjectAbstractEditModal: React.FC<{
       <Button type="link" onClick={() => toggle()}>
         <strong>Edit Project</strong>
       </Button>
-      <Modal isOpen={isOpen} toggle={toggle} size="lg">
+      <Modal
+        isOpen={isOpen}
+        toggle={toggle}
+        size="lg"
+        className="modal-dialog-centered"
+      >
         <ModalHeader toggle={toggle} close={closeBtn}>
           <span>Edit Project</span>
         </ModalHeader>

--- a/libs/tup-components/src/projects/details/grants/ProjectGrantCreateModal.tsx
+++ b/libs/tup-components/src/projects/details/grants/ProjectGrantCreateModal.tsx
@@ -22,7 +22,12 @@ const ProjectGrantCreateModal: React.FC<{
       <Button type="link" onClick={() => toggle()}>
         <strong>+ Add Grant</strong>
       </Button>
-      <Modal isOpen={isOpen} toggle={toggle} size="lg">
+      <Modal
+        isOpen={isOpen}
+        toggle={toggle}
+        size="lg"
+        className="modal-dialog-centered"
+      >
         <ModalHeader toggle={toggle} close={closeBtn}>
           <span>Add Grant</span>
         </ModalHeader>

--- a/libs/tup-components/src/projects/details/grants/ProjectGrantEditModal.tsx
+++ b/libs/tup-components/src/projects/details/grants/ProjectGrantEditModal.tsx
@@ -23,7 +23,12 @@ const ProjectGrantEditModal: React.FC<{
       <Button type="link" onClick={() => toggle()}>
         Edit
       </Button>
-      <Modal isOpen={isOpen} toggle={toggle} size="lg">
+      <Modal
+        isOpen={isOpen}
+        toggle={toggle}
+        size="lg"
+        className="modal-dialog-centered"
+      >
         <ModalHeader toggle={toggle} close={closeBtn}>
           <span>Edit Grant</span>
         </ModalHeader>

--- a/libs/tup-components/src/projects/details/publications/ProjectPublicationCreateModal.tsx
+++ b/libs/tup-components/src/projects/details/publications/ProjectPublicationCreateModal.tsx
@@ -22,7 +22,12 @@ const ProjectPublicationCreateModal: React.FC<{
       <Button type="link" onClick={() => toggle()}>
         <strong> + Add Publication</strong>
       </Button>
-      <Modal isOpen={isOpen} toggle={toggle} size="md">
+      <Modal
+        isOpen={isOpen}
+        toggle={toggle}
+        size="md"
+        className="modal-dialog-centered"
+      >
         <ModalHeader toggle={toggle} close={closeBtn}>
           <span>Add Publication</span>
         </ModalHeader>

--- a/libs/tup-components/src/projects/details/publications/ProjectPublicationEditModal.tsx
+++ b/libs/tup-components/src/projects/details/publications/ProjectPublicationEditModal.tsx
@@ -23,7 +23,12 @@ const ProjectPublicationEditModal: React.FC<{
       <Button type="link" onClick={() => toggle()}>
         Edit
       </Button>
-      <Modal isOpen={isOpen} toggle={toggle} size="md">
+      <Modal
+        isOpen={isOpen}
+        toggle={toggle}
+        size="md"
+        className="modal-dialog-centered"
+      >
         <ModalHeader toggle={toggle} close={closeBtn}>
           <span>Edit Publication</span>
         </ModalHeader>

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
@@ -56,3 +56,7 @@
     padding: 1px;
 }
 
+.role-explainer {
+    padding-left: 20px;
+    font-style: italic;
+}

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -209,8 +209,8 @@ const UserDetail: React.FC<{ projectId: number; username: string }> = ({
         </div>
       </div>
       <div className={styles['role-explainer']}>
-        PI and Delegate can manage the project. <br /> Standard Users can only
-        view the project.
+        PI and Delegate Users can manage the project. <br /> Standard Users can
+        only view the project.
       </div>
       <UsageTable username={username} projectId={projectId} />
     </div>

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -209,6 +209,10 @@ const UserDetail: React.FC<{ projectId: number; username: string }> = ({
           <RemoveUser projectId={projectId} user={user} />
         </div>
       </div>
+      <div className={styles['role-explainer']}>
+        PI and Delegate can manage the project. <br /> Standard Users can only
+        view the project.
+      </div>
       <UsageTable username={username} projectId={projectId} />
     </div>
   );

--- a/libs/tup-components/src/projects/users/UserList/UserList.tsx
+++ b/libs/tup-components/src/projects/users/UserList/UserList.tsx
@@ -27,7 +27,8 @@ const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
           end
           className={styles['user-navitem']}
         >
-          PI: {pi.firstName} {pi.lastName} ({pi.username})
+          <span style={{ fontWeight: 'normal' }}>PI</span>: {pi.firstName}{' '}
+          {pi.lastName} ({pi.username})
         </NavItem>
       )}
       {delegate && (
@@ -36,8 +37,8 @@ const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
           end
           className={styles['user-navitem']}
         >
-          Delegate: {delegate?.firstName} {delegate?.lastName} (
-          {delegate.username})
+          <span style={{ fontWeight: 'normal' }}>Delegate</span>:{' '}
+          {delegate?.firstName} {delegate?.lastName} ({delegate.username})
         </NavItem>
       )}
       <div className={styles['separator']}></div>

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
@@ -25,7 +25,12 @@ const TicketCreateModal: React.FC<
       <Button type={display} onClick={() => toggle()}>
         {children}
       </Button>
-      <Modal isOpen={isOpen} toggle={toggle} size="lg">
+      <Modal
+        isOpen={isOpen}
+        toggle={toggle}
+        size="lg"
+        className="modal-dialog-centered"
+      >
         <ModalHeader
           toggle={toggle}
           close={closeBtn}

--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketHistory.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketHistory.tsx
@@ -45,10 +45,11 @@ const Attachments: React.FC<{
   );
 };
 
-const TicketHistoryCard: React.FC<{ history: TicketHistoryEntry }> = ({
-  history,
-}) => {
-  const [isOpen, setIsOpen] = useState(false);
+const TicketHistoryCard: React.FC<{
+  history: TicketHistoryEntry;
+  defaultOpen?: boolean;
+}> = ({ history, defaultOpen = false }) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
   const { data } = useProfile();
 
   const ticketHeaderClassName =
@@ -73,32 +74,32 @@ const TicketHistoryCard: React.FC<{ history: TicketHistoryEntry }> = ({
   return (
     <Card className="mt-1">
       <CardHeader tabIndex={0} onClick={onClick} onKeyDown={onKeyDown}>
-        <span className="ticket-history-header d-inline-block text-truncate">
-          <strong>
-            <span
-              className={ticketHeaderClassName}
-              id="TicketHeader"
-              role="button"
-              aria-expanded={isOpen}
-              aria-controls="CardBody"
-            >
-              {history.Creator} |{' '}
-              {`${formatDateTime(new Date(history.Created))}`}
+        <div
+          className="ticket-history-header"
+          id="TicketHeader"
+          role="button"
+          aria-expanded={isOpen}
+          aria-controls="CardBody"
+        >
+          <div className="text-truncate">
+            <span className={ticketHeaderClassName}>
+              <strong>{history.Creator}</strong>
             </span>
-            {!!attachmentTitles.length && (
-              <span>
-                {' '}
-                <Icon name="link" />{' '}
-              </span>
+            <span className="text-truncate">
+              {isOpen ? '' : ` | ${history.Content}`}
+            </span>
+          </div>
+          <div>
+            <span className="ticket-history-header-date">{`${formatDateTime(
+              new Date(history.Created)
+            )}`}</span>
+            {isOpen ? (
+              <Icon size="xs" name="icon-action icon-contract" />
+            ) : (
+              <Icon size="xs" name="icon-action icon-expand" />
             )}
-          </strong>{' '}
-          {isOpen ? '' : history.Content}
-        </span>
-        {isOpen ? (
-          <Icon name="icon-action icon-contract" />
-        ) : (
-          <Icon name="icon-action icon-expand" />
-        )}
+          </div>
+        </div>
       </CardHeader>
       <Collapse isOpen={isOpen}>
         <CardBody id="CardBody" role="region" aria-labelledby="TicketHeader">
@@ -133,8 +134,12 @@ export const TicketHistory: React.FC<{ ticketId: string }> = ({ ticketId }) => {
           Something went wrong.
         </InlineMessage>
       )}
-      {data?.map((history: TicketHistoryEntry) => (
-        <TicketHistoryCard key={history.id} history={history} />
+      {data?.map((history: TicketHistoryEntry, idx) => (
+        <TicketHistoryCard
+          key={history.id}
+          history={history}
+          defaultOpen={idx === data.length - 1}
+        />
       ))}
       <div ref={ticketHistoryEndRef} />
     </>

--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.global.css
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.global.css
@@ -8,7 +8,22 @@
 }
 
 .ticket-history-header {
-  padding-right: 1em;
+  display: inline-flex;
+  width: 100%;
+  justify-content: space-between;
+}
+.ticket-history-header > :nth-child(1) {
+  padding-right: 1rem;
+}
+.ticket-history-header > :nth-child(2) {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1rem;
+}
+.ticket-history-header-date {
+  padding-right: 0.5rem;
+  font-weight: bold;
+  white-space: nowrap;
 }
 
 .ticket-reply-form {

--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.test.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.test.tsx
@@ -16,7 +16,7 @@ describe('Ticket Modal', () => {
     );
     expect(getByTestId('loading-spinner')).toBeDefined();
     await waitFor(() =>
-      expect(getAllByText('test; please ignore').length).toEqual(2)
+      expect(getAllByText(/test; please ignore/).length).toEqual(4)
     );
     expect(getByText('testFile.txt (10b)')).toBeDefined();
   });

--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.tsx
@@ -6,9 +6,12 @@ import './TicketModal.global.css';
 import { TicketHistory } from './TicketHistory';
 import { TicketReplyForm } from './TicketReplyForm';
 
-const TicketModal: React.FC<{ ticketId: string }> = ({ ticketId }) => {
+const TicketModal: React.FC<{ ticketId: string; baseRoute: string }> = ({
+  ticketId,
+  baseRoute,
+}) => {
   const navigate = useNavigate();
-  const close = () => navigate('/tickets');
+  const close = () => navigate(baseRoute);
   const modalAlwaysOpen = true;
   const { data } = useGetTicketDetails(ticketId);
 
@@ -20,7 +23,7 @@ const TicketModal: React.FC<{ ticketId: string }> = ({ ticketId }) => {
 
   return (
     <Modal
-      className="ticket-model-content"
+      className="ticket-model-content modal-dialog-centered"
       size="xl"
       isOpen={modalAlwaysOpen}
       toggle={close}
@@ -29,7 +32,7 @@ const TicketModal: React.FC<{ ticketId: string }> = ({ ticketId }) => {
         <span className="ticket-id">Ticket {ticketId}</span>
         <span className="ticket-subject">{data?.Subject}</span>
       </ModalHeader>
-      <ModalBody>
+      <ModalBody style={{ minHeight: '70vh', maxHeight: 'fit-content' }}>
         <Container className="ticket-detailed-view-container">
           <Row className="ticket-detailed-view-row">
             <Col lg="7" className="ticket-history">

--- a/libs/tup-components/src/tickets/Tickets.tsx
+++ b/libs/tup-components/src/tickets/Tickets.tsx
@@ -20,7 +20,7 @@ const Tickets: React.FC = () => {
           Tickets
         </SectionHeader>
         <SectionTableWrapper contentShouldScroll className="ticket-container">
-          <TicketsTable />
+          <TicketsTable ticketsPath="/tickets" />
         </SectionTableWrapper>
         <Outlet />
       </section>

--- a/libs/tup-components/src/tickets/TicketsDashboard.tsx
+++ b/libs/tup-components/src/tickets/TicketsDashboard.tsx
@@ -12,7 +12,7 @@ const TicketsDashboard: React.FC = () => {
       }
       contentShouldScroll
     >
-      <TicketsTable />
+      <TicketsTable ticketsPath="/dashboard/tickets" />
     </SectionTableWrapper>
   );
 };

--- a/libs/tup-components/src/tickets/TicketsTable.tsx
+++ b/libs/tup-components/src/tickets/TicketsTable.tsx
@@ -25,7 +25,9 @@ export const getStatusText = (status: string) => {
   }
 };
 
-export const TicketsTable: React.FC = () => {
+export const TicketsTable: React.FC<{ ticketsPath: string }> = ({
+  ticketsPath,
+}) => {
   const { data, isLoading, isError } = useGetTickets();
   const pathname = useLocation().pathname;
   let ticketData: Array<Ticket> = [];
@@ -75,7 +77,7 @@ export const TicketsTable: React.FC = () => {
             >
               <td>{ticket.numerical_id}</td>
               <td>
-                <Link to={`/tickets/${ticket.numerical_id}`}>
+                <Link to={`${ticketsPath}/${ticket.numerical_id}`}>
                   {ticket.Subject}
                 </Link>
               </td>


### PR DESCRIPTION
## Overview:


## Changes:
Modals:
- Modals should be vertically centered. (This is common practice.)
- When clicking ticket, modal should open, but not go to tickets section.
- Modal height should open at a max height (~70vh), not change in height as content height changes.

Projects:
- Add explanatory text to user allocations panel.
- Highlight the special users (PI, Co-PI, Delegate) in the user list, and style their role distinct from their name

Tickets:
- Tickets Modal should open with most recent ticket unfurled by default.
- Change order of ticket reply header content, i.e. align timestamp to the right, e.g.:
name      content...     timestamp

Manage Account: 
- Buttons should not be clickable to the right of the button

## UI:
"PI"/"Delegate" styling (non-bolded like in the mockups).
![image](https://user-images.githubusercontent.com/12601812/221042761-f7b184ac-1f48-4e2f-9370-3222533955cd.png)
Project role explanations:
![image](https://user-images.githubusercontent.com/12601812/221043098-839cef35-b8b0-4ad7-8dcc-26e826e98b71.png)
Ticket history header rearrangement:
![image](https://user-images.githubusercontent.com/12601812/221042796-54de84f0-3c4c-4bb2-942a-5210e7698122.png)
Centered modals:
![image](https://user-images.githubusercontent.com/12601812/221042844-96e14194-5bdb-46b2-9a82-09fed4dec764.png)


## Notes:
