### PR TITLE
fix(tup-cms): up-to-date cms search query param name image

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:2581ba6
+FROM taccwma/core-cms:b803ee7
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:831f541
+FROM taccwma/core-cms:c457eb3
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:c457eb3
+FROM taccwma/core-cms:2581ba6
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -87,6 +87,12 @@ LOGO = [
 ]
 
 ########################
+# TACC: SEARCH
+########################
+
+SEARCH_QUERY_PARAM_NAME = 'query_string'
+
+########################
 # DJANGO
 ########################
 
@@ -95,7 +101,7 @@ TUP_SERVICES_URL = "https://dev.tup-services.tacc.utexas.edu"
 LOGIN_URL = "/portal/login"
 
 ########################
-# NEWS / BLOG
+# TACC: NEWS/BLOG
 ########################
 
 from taccsite_cms.settings import INSTALLED_APPS

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -90,7 +90,7 @@ LOGO = [
 # TACC: SEARCH
 ########################
 
-SEARCH_QUERY_PARAM_NAME = 'query_string'
+SEARCH_QUERY_PARAM_NAME = 'q'
 
 ########################
 # DJANGO


### PR DESCRIPTION
## Overview

Use image off of `dev/tup-cms`, not `main`; i.e. fix https://github.com/TACC/tup-ui/pull/159#discussion_r1116342250.