### PR TITLE
Clarify that 'Add User' should use exact username

### DIFF
--- a/libs/tup-components/src/projects/users/UserList/ManageTeam.tsx
+++ b/libs/tup-components/src/projects/users/UserList/ManageTeam.tsx
@@ -35,7 +35,7 @@ const ManageTeam: React.FC<{ projectId: number }> = ({ projectId }) => {
           <strong>Manage Team</strong> ({users?.length} Users)
         </div>
         <form onSubmit={(e) => addUser(e)}>
-          <label htmlFor="add-user">Add New User</label>
+          <label htmlFor="add-user">Add New User</label> (use TACC username)
           <InputGroup>
             <div className="input-group-prepend">
               <Button outline type="submit" disabled={!userToAdd}>


### PR DESCRIPTION
## Overview:
Clarify that Users can only be added by exact username
## Related:

- [TUP-435](https://jira.tacc.utexas.edu/browse/TUP-435)

## Notes:
We should eventually implement the ability to search by username/name