### PR TITLE
task/TUP-430: Add indicator for tickets with attachments

### DIFF
--- a/libs/tup-components/src/tickets/TicketsTable.test.tsx
+++ b/libs/tup-components/src/tickets/TicketsTable.test.tsx
@@ -6,9 +6,8 @@ import { rest } from 'msw';
 
 describe('Tickets Table Component', () => {
   it('should render the loading spinner and then the tickets table', async () => {
-    const { getByText, getByTestId, getAllByRole } = testRender(
-      <TicketsTable />
-    );
+    const { getByText, getByTestId, findAllByTestId, getAllByRole } =
+      testRender(<TicketsTable />);
     expect(getByTestId('loading-spinner')).toBeDefined();
     await waitFor(() => getAllByRole('columnheader'));
     const columnHeaders: HTMLElement[] = getAllByRole('columnheader');
@@ -20,6 +19,7 @@ describe('Tickets Table Component', () => {
     expect(getByText('Feedback for CEP')).toBeDefined();
     expect(getByText('10/13/2022')).toBeDefined();
     expect(getByText('Resolved')).toBeDefined();
+    expect(await findAllByTestId('attachment-icon')).toHaveLength(2);
   });
   it('should render message when there are no tickets to show', async () => {
     server.use(

--- a/libs/tup-components/src/tickets/TicketsTable.tsx
+++ b/libs/tup-components/src/tickets/TicketsTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { InlineMessage, LoadingSpinner } from '@tacc/core-components';
-import { Ticket, useGetTickets } from '@tacc/tup-hooks';
+import { Icon, InlineMessage, LoadingSpinner } from '@tacc/core-components';
+import { Ticket, useGetTicketHistory, useGetTickets } from '@tacc/tup-hooks';
 import './TicketsTable.global.css';
 import { formatDate } from '../utils/timeFormat';
 
@@ -23,6 +23,18 @@ export const getStatusText = (status: string) => {
     default:
       return '--';
   }
+};
+
+const AttachmentIndicator: React.FC<{ ticketId: string }> = ({ ticketId }) => {
+  const { data } = useGetTicketHistory(ticketId);
+
+  if (
+    data?.some((ticket) =>
+      ticket.Attachments.some((att) => !att[1].startsWith('untitled'))
+    )
+  )
+    return <Icon dataTestid="attachment-icon" name="link"></Icon>;
+  return null;
 };
 
 export const TicketsTable: React.FC = () => {
@@ -77,7 +89,8 @@ export const TicketsTable: React.FC = () => {
               <td>
                 <Link to={`/tickets/${ticket.numerical_id}`}>
                   {ticket.Subject}
-                </Link>
+                </Link>{' '}
+                <AttachmentIndicator ticketId={ticket.numerical_id} />
               </td>
               <td>{formatDate(new Date(ticket.Created))}</td>
               <td>{getStatusText(ticket.Status)}</td>

--- a/libs/tup-testing/src/mocks/handlers.ts
+++ b/libs/tup-testing/src/mocks/handlers.ts
@@ -71,11 +71,14 @@ export const handlers = [
     // Respond with mock tickets output
     return res(ctx.json(mockProjectFieldOfScience));
   }),
-  rest.get('http://localhost:8001/tickets/85411/history', (req, res, ctx) => {
-    // Respond with mock ticket history output
-    return res(ctx.json(mockTicketHistory));
-  }),
-  rest.get('http://localhost:8001/tickets/85411', (req, res, ctx) => {
+  rest.get(
+    'http://localhost:8001/tickets/:ticketId/history',
+    (req, res, ctx) => {
+      // Respond with mock ticket history output
+      return res(ctx.json(mockTicketHistory));
+    }
+  ),
+  rest.get('http://localhost:8001/tickets/:ticketId', (req, res, ctx) => {
     // Respond with mock ticket details output
     return res(ctx.json(mockTicketDetails));
   }),


### PR DESCRIPTION
## Overview:
Add an attachment indicator to show which tickets have attachments.

## Related:

- [TUP-430](https://jira.tacc.utexas.edu/browse/TUP-430)

## Testing:

1. Make sure that you have at least 1 ticket with an attachment
2. Check that that ticket has the "link" icon next to it in the tickets table in the Tickets and Dashboard views.

## UI:
![image](https://user-images.githubusercontent.com/12601812/221082340-9ec7df45-f08f-4fe3-a6dc-bea07979a7a4.png)


## Notes:
