### PR TITLE
make changes to manage account through out site

### DIFF
--- a/apps/tup-cms/src/apps/portal_nav/templates/portal_nav/nav_portal.raw.html
+++ b/apps/tup-cms/src/apps/portal_nav/templates/portal_nav/nav_portal.raw.html
@@ -36,6 +36,9 @@
     <a class="dropdown-item" href="/portal">
       <i class="icon icon-dashboard"></i> My Dashboard
     </a>
+    <a class="dropdown-item" href="/portal/account">
+      <i class="icon icon-user"></i> Manage Account
+    </a>
     <a class="dropdown-item" href="/portal/logout">
       <i class="icon icon-exit"></i> Log Out
     </a>

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
@@ -26,9 +26,7 @@ const Layout: React.FC = () => {
   return (
     <RequireAuth>
       <section className={`c-page ${styles.section}`}>
-        <SectionHeader>
-          Dashboard
-        </SectionHeader>
+        <SectionHeader>Dashboard</SectionHeader>
         <main className={styles.panels}>
           <UserNews />
           <SystemMonitor />

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
@@ -26,7 +26,7 @@ const Layout: React.FC = () => {
   return (
     <RequireAuth>
       <section className={`c-page ${styles.section}`}>
-        <SectionHeader actions={<Link to="/account">Manage Account</Link>}>
+        <SectionHeader>
           Dashboard
         </SectionHeader>
         <main className={styles.panels}>

--- a/libs/tup-components/src/layout/Sidebar/Sidebar.tsx
+++ b/libs/tup-components/src/layout/Sidebar/Sidebar.tsx
@@ -17,11 +17,9 @@ const Sidebar: React.FC = () => {
         <NavItem icon="multiple-coversation" to={'/tickets'}>
           Tickets
         </NavItem>
-        {loggedIn && (
-          <AnchorNavItem icon="exit" to={'/portal/logout'}>
-            Log Out
-          </AnchorNavItem>
-        )}
+        <NavItem icon="icon-user" to={'/account'}>
+          Manage Account
+        </NavItem>
       </Navbar>
     </div>
   );


### PR DESCRIPTION
## Overview: Make changes to where Manage Account appears on the portal.

## Related:

- [TUP-434](https://jira.tacc.utexas.edu/browse/TUP-434)

## Changes:
1. Remove Manage Account from Dashboard top-right.
2. Remove Log Out from Left-Nav-Bar
3. Add Manage Account to Left-Nav-Bar
4. Add Manage Account to User Dropdown (top-right)

## Testing:

1. Dashboard -- confirm Manage Account is no longer there. 
2. Left-Nav -- confirm Log Out is no longer there.
3. Left-Nav -- confirm Manage Account is there with the correct 'user' icon and link to the correct page (portal/account)
4. Dropdown -- confirm Manage Account is there with the correct 'user' icon and link to the correct page (portal/account)

## UI:

![Screen Shot 2023-02-26 at 12 55 45 PM](https://user-images.githubusercontent.com/35277477/221431119-8531cab7-e0e8-4b87-b0f0-5743013c8572.png)

## Notes: