### PR TITLE
Task/tup 429 user updates links dashboard

### DIFF
--- a/libs/tup-components/src/news/UserNews.module.css
+++ b/libs/tup-components/src/news/UserNews.module.css
@@ -32,4 +32,13 @@
 
 .title {
     font-size: 1.25rem;
+    font-weight: bolder;
+}
+
+.news-error {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--global-color-accent--normal);
+    padding: 30px;
 }

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -44,7 +44,11 @@ const UserNews: React.FC = () => {
                 )}
               </div>
               <div className={styles['title']}>
-                <a href={`/news/user-updates/${newsItem.ID}`} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={`/news/user-updates/${newsItem.ID}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   {newsItem.WebTitle}
                 </a>
               </div>

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -5,7 +5,6 @@ import {
   Pill,
   SectionTableWrapper,
   Button,
-  Icon,
 } from '@tacc/core-components';
 import styles from './UserNews.module.css';
 

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -14,7 +14,7 @@ const formatDate = (datestring: string): string => {
   return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
 };
 const ViewAllUpdates = () => (
-  <a href={`/news/user-updates/`} target="_blank">
+  <a href={`/news/user-updates/`} target="_blank" rel="noopener noreferrer">
     <Button type="link" iconNameBefore="icon icon-push-right">
       {' '}
       View All Updates
@@ -44,7 +44,7 @@ const UserNews: React.FC = () => {
                 )}
               </div>
               <div className={styles['title']}>
-                <a href={`/news/user-updates/${newsItem.ID}`} target="_blank">
+                <a href={`/news/user-updates/${newsItem.ID}`} target="_blank" rel="noopener noreferrer">
                   {newsItem.WebTitle}
                 </a>
               </div>

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -4,6 +4,8 @@ import {
   LoadingSpinner,
   Pill,
   SectionTableWrapper,
+  Button,
+  Icon,
 } from '@tacc/core-components';
 import styles from './UserNews.module.css';
 
@@ -11,12 +13,24 @@ const formatDate = (datestring: string): string => {
   const date = new Date(datestring);
   return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
 };
+const ViewAllUpdates = () => (
+  <a href={`/news/user-updates/`} target="_blank">
+    <Button type="link" iconNameBefore="icon icon-push-right">
+      {' '}
+      View All Updates
+    </Button>
+  </a>
+);
 
 const UserNews: React.FC = () => {
   const { data, isLoading } = useUserNews();
   if (isLoading) return <LoadingSpinner />;
   return (
-    <SectionTableWrapper header="User Updates" contentShouldScroll>
+    <SectionTableWrapper
+      header="User Updates"
+      headerActions={<ViewAllUpdates />}
+      contentShouldScroll
+    >
       <ul className={styles['news-list']}>
         {data &&
           data.slice(0, 12).map((newsItem) => (
@@ -30,7 +44,9 @@ const UserNews: React.FC = () => {
                 )}
               </div>
               <div className={styles['title']}>
-                <strong>{newsItem.WebTitle}</strong>
+                <a href={`/news/user-updates/${newsItem.ID}`} target="_blank">
+                  {newsItem.WebTitle}
+                </a>
               </div>
               <div className={styles['body']}>{newsItem.Content}</div>
             </li>


### PR DESCRIPTION
## Overview:
Make user news into links using ID
Add View all News that links to User Updates main page

## Related:

- [TUP-429](https://jira.tacc.utexas.edu/browse/TUP-429)

## Changes:

- Added new piece to User-News that adds link with icon according to [design spec](https://xd.adobe.com/view/cc3dc245-2792-4e10-bdc1-50d2a7d32979-996e/screen/872ac161-426b-40a1-90e6-f41c4c120590/?fullscreen) NOTE: most recent testing asked that the link be next to User Updates title at top
- Created links using ID for each title in the user update list of articles



## Testing:

1. Go to [http://localhost:8000/portal/dashboard](http://localhost:8000/portal/dashboard)
2. Make sure that all links work and look like the screenshot below

## UI:
<img width="642" alt="Screen Shot 2023-02-27 at 5 57 52 PM" src="https://user-images.githubusercontent.com/96220951/221716538-26d166b8-8613-4a5a-9faf-8642d245cafb.png">
