### PR TITLE
feat(tup-cms): allow folder-level permissions

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -157,3 +157,10 @@ TACC_BLOG_SHOW_ABSTRACT_TAG = 'external'
 ########################
 
 TACC_CORE_STYLES_VERSION = 1
+
+########################
+# PLUGIN SETTINGS
+########################
+
+# https://github.com/django-cms/django-filer/blob/2.0.2/docs/permissions.rst
+FILER_ENABLE_PERMISSIONS = True


### PR DESCRIPTION
## Overview

Allow folder-level permissions in Django CMS.

## Related:

- learned during https://github.com/TACC/tup-ui/pull/171

## Changes

- add one setting, set to True

## Testing & UI

> @wesleyboar tested this on dev.tup via #171, on 2023-02-27 for groups "EPIC Newsletter Manager" and 2023-02-28 for "Media Editor (Basic)". The screenshots below record the latter test.

1. Create/Find group with relevant perms.
    ![1 group with relevant perms](https://user-images.githubusercontent.com/62723358/221932491-f833f9aa-86c0-46cb-a518-ae406cb5fa39.png)
2. Add/Find user in that group.
	![2 user in that group](https://user-images.githubusercontent.com/62723358/221932485-3bda2e88-341d-42d1-9cd5-43bd9122f604.png)
3. Set/Verify folder perms for that group.
	![3 folder perms for that group](https://user-images.githubusercontent.com/62723358/221932478-46a98849-80bc-40e4-8ce3-abcd23eaa0df.png)
4. Login as that user.
	![4 login as that user](https://user-images.githubusercontent.com/62723358/221932480-cbb5dfcb-dd8b-447a-88c0-7f50d59bf67e.png)
5. Verify "Filer" (file management app in CMS) only shows the folder user can read.
	![5 verify filer only shows the folder user can read](https://user-images.githubusercontent.com/62723358/221932483-a7a4e382-ab78-4748-8800-9586d46d40bd.png)
6. Verify user can read folder.
	![6 verify folder can be read by user](https://user-images.githubusercontent.com/62723358/221932467-4e6cfebf-d963-4c2f-bfca-a4f6d211caa6.png)
