### PR TITLE
fix(tup-cms): use/set page title on app pages

### DIFF
--- a/apps/tup-cms/src/apps/portal/templates/portal/portal.debug.html
+++ b/apps/tup-cms/src/apps/portal/templates/portal/portal.debug.html
@@ -2,7 +2,7 @@
 
 {% block html_page_id %}portal{% endblock %}
 
-{% block title %}Portal{% endblock %}
+{% block title %}User Portal{% endblock %}
 
 {% block assets_core_project %}
 {% include './assets.html' %}

--- a/apps/tup-cms/src/apps/portal/templates/portal/portal.debug.html
+++ b/apps/tup-cms/src/apps/portal/templates/portal/portal.debug.html
@@ -2,6 +2,8 @@
 
 {% block html_page_id %}portal{% endblock %}
 
+{% block title %}Portal{% endblock %}
+
 {% block assets_core_project %}
 {% include './assets.html' %}
 {% endblock %}

--- a/apps/tup-cms/src/apps/portal/templates/portal/portal.html
+++ b/apps/tup-cms/src/apps/portal/templates/portal/portal.html
@@ -2,7 +2,7 @@
 
 {% block html_page_id %}portal{% endblock %}
 
-{% block title %}Portal{% endblock %}
+{% block title %}User Portal{% endblock %}
 
 {% block assets_core_project %}
 {% include './assets.html' %}

--- a/apps/tup-cms/src/apps/portal/templates/portal/portal.html
+++ b/apps/tup-cms/src/apps/portal/templates/portal/portal.html
@@ -2,6 +2,8 @@
 
 {% block html_page_id %}portal{% endblock %}
 
+{% block title %}Portal{% endblock %}
+
 {% block assets_core_project %}
 {% include './assets.html' %}
 {% endblock %}

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/list.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/list.html
@@ -1,12 +1,10 @@
-{% extends "base.html" %}
+{% extends "fullwidth.html" %}
 
 {% block content %}
-
 <section class="container">
   {% include "nav_cms_breadcrumbs.html" %}
   <h1>User Updates</h1>
   {% include './includes/content_styles.html' %}
   {% include './includes/list.html' %}
 </section>
-
 {% endblock content %}

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/read.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/read.html
@@ -1,11 +1,11 @@
-{% extends "base.html" %}
+{% extends "fullwidth.html" %}
+
+{% block title %}User Updates{% endblock %}
 
 {% block content %}
-
 <section class="container">
   {% include "./includes/list_item_breadcrumbs.html" with article=article urls=urls only %}
   {% include './includes/content_styles.html' %}
   {% include './includes/page_item.html' %}
 </section>
-
 {% endblock content %}


### PR DESCRIPTION
## Overview

Some apps fail to read from CMS page title (they show a URL, the CMS fallback).

## Related:

- [TUP-1234](https://jira.tacc.utexas.edu/browse/TUP-1234)

## Changes

- Set page title manually for pages that do **not** read from CMS:
    - portal
    - portal (debug)
- Use page title from CMS on pages that **can** read from CMS:
    - list
- Set page title manually for pages for which we can not re-create each child on CMS:
    - read
    - portal
    - portal (debug)

## Testing

Verify the following pages have titles:
- https://dev.tup.tacc.utexas.edu/portal/login
- https://dev.tup.tacc.utexas.edu/portal/
- https://dev.tup.tacc.utexas.edu/portal/tickets
- https://dev.tup.tacc.utexas.edu/news/user-updates

## UI

![user news list](https://user-images.githubusercontent.com/62723358/222525470-9e5bbae8-29a6-403a-ba3f-e61c29a49978.png)

![user news read](https://user-images.githubusercontent.com/62723358/222525476-1306eb32-8687-499a-a094-28099505f489.png)

Changed to "User Portal" after this screenshot was taken.
![login](https://user-images.githubusercontent.com/62723358/222525478-3bbc99b7-dfd4-4255-b3ac-c9490e790705.png)

Changed to "User Portal" after this screenshot was taken.
![portal](https://user-images.githubusercontent.com/62723358/222525480-aef3264b-0cab-4e70-9699-8c4ba576b3fa.png)

Changed to "User Portal" after this screenshot was taken.
![portal tickets](https://user-images.githubusercontent.com/62723358/222525483-2445bde3-8845-4e47-95a6-932041d0a6e3.png)
