### PR TITLE
feat(tup-cms): new message styles

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:b803ee7
+FROM taccwma/core-cms:818972c
 
 WORKDIR /code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@nrwl/vite": "^15.6.3",
         "@nrwl/web": "15.6.3",
         "@nrwl/workspace": "15.6.3",
-        "@tacc/core-styles": "github:TACC/Core-Styles#e9d14e6",
+        "@tacc/core-styles": "github:TACC/Core-Styles#e15d256",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5704,8 +5704,8 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#e9d14e6c1c6225d2e22c89c6eefd21a2da4c5552",
+      "version": "2.0.1",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#e15d2562b48b6f2310a1a4b4f3d323cb8c3c11f2",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5724,7 +5724,7 @@
         "postcss": "^8.4.18",
         "postcss-banner": "^4.0.1",
         "postcss-cli": "^10.0.0",
-        "postcss-env-function": "4.0.6",
+        "postcss-env-function": "^4.0.6",
         "postcss-extend": "^1.0.5",
         "postcss-import": "^15.0.0",
         "postcss-preset-env": "^7.8.3",
@@ -29588,9 +29588,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#e9d14e6c1c6225d2e22c89c6eefd21a2da4c5552",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#e15d2562b48b6f2310a1a4b4f3d323cb8c3c11f2",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#e9d14e6",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#e15d256",
       "requires": {}
     },
     "@tanstack/query-core": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nrwl/vite": "^15.6.3",
     "@nrwl/web": "15.6.3",
     "@nrwl/workspace": "15.6.3",
-    "@tacc/core-styles": "github:TACC/Core-Styles#e9d14e6",
+    "@tacc/core-styles": "github:TACC/Core-Styles#e15d256",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## Overview

New CMS (and Docs) message styles. They will be ported to Portal later.

## Related

- https://github.com/TACC/Core-Styles/pull/131

## Changes

- new CMS image
- install core-styles at [merge commit of #131](https://github.com/TACC/Core-Styles/pull/131)

## Testing & UI

Compare these webpages to styles from screenshots in https://github.com/TACC/Core-Styles/pull/131:
- https://dev.tup.tacc.utexas.edu/static/ui/components/detail/admonition.html
- https://dev.tup.tacc.utexas.edu/static/ui/components/detail/c-message--type.html