### PR TITLE
combine abstract/grants section, links to TXRAS

### DIFF
--- a/libs/tup-components/src/projects/details/ProjectDetails.module.css
+++ b/libs/tup-components/src/projects/details/ProjectDetails.module.css
@@ -30,13 +30,12 @@
 }
 
 .pub-grants-title {
-    font-size: 1.3rem;
+    font-weight: bold;
+    margin-right: 2rem;
 }
 
 .pub-grants-info {
-    margin-top:10px;
-    font-size: 1.3rem;
-    font-style: italic;
+    margin-right: 2rem;
 }
 
 .pub-grants-edit-link {
@@ -61,4 +60,10 @@
     display: flex;
     flex-direction: column;
     gap: 15px;
+}
+
+.pub-abstract-grants {
+    margin-top:10px;
+    font-size: 1.3rem;
+    font-style: italic;
 }

--- a/libs/tup-components/src/projects/details/ProjectDetails.module.css
+++ b/libs/tup-components/src/projects/details/ProjectDetails.module.css
@@ -30,7 +30,7 @@
 }
 
 .pub-grants-title {
-    margin-right: 2rem;
+    font-size: 1.3rem;
 }
 
 .pub-grants-info {

--- a/libs/tup-components/src/projects/details/ProjectDetails.module.css
+++ b/libs/tup-components/src/projects/details/ProjectDetails.module.css
@@ -30,11 +30,11 @@
 }
 
 .pub-grants-title {
-    font-weight: bold;
     margin-right: 2rem;
 }
 
 .pub-grants-info {
+    font-weight: bold;
     margin-right: 2rem;
 }
 

--- a/libs/tup-components/src/projects/details/ProjectDetails.module.css
+++ b/libs/tup-components/src/projects/details/ProjectDetails.module.css
@@ -34,8 +34,9 @@
 }
 
 .pub-grants-info {
-    font-weight: bold;
-    margin-right: 2rem;
+    margin-top:10px;
+    font-size: 1.3rem;
+    font-style: italic;
 }
 
 .pub-grants-edit-link {

--- a/libs/tup-components/src/projects/details/ProjectDetails.test.tsx
+++ b/libs/tup-components/src/projects/details/ProjectDetails.test.tsx
@@ -1,21 +1,31 @@
 import ProjectDetails from './ProjectDetails';
 import { testRender } from '@tacc/tup-testing';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 
 describe('Project Details Component', () => {
   it('should display a spinner while loading', async () => {
     const { getByTestId } = testRender(<ProjectDetails projectId={59184} />);
     expect(getByTestId('loading-spinner')).toBeDefined();
-    await screen.findByText(
-      'Development project for testing PI-specific endpoints in the redesigned user portal.'
-    );
   });
-  it.skip('should display the projects description/abstract, publications, and grants', async () => {
-    testRender(<ProjectDetails projectId={59184} />);
-    await screen.findByText(
-      /Development project for testing PI-specific endpoints in the redesigned user portal./
+  it('should display the projects table', async () => {
+    const { getByText, getByTestId, getAllByRole } = testRender(
+      <ProjectDetails projectId={59184}  />
     );
+    expect(getByTestId('loading-spinner')).toBeDefined();
+    await waitFor(() => getAllByRole('columnheader'));
+    const columnHeaders: HTMLElement[] = getAllByRole('columnheader');
+    expect(columnHeaders[0].textContent).toEqual('Systems');
+    expect(columnHeaders[1].textContent).toEqual('Awarded');
+    expect(columnHeaders[2].textContent).toEqual('Used');
+    expect(columnHeaders[3].textContent).toEqual('Expires');
+    expect(getByText('Lonestar6')).toBeDefined();
+    expect(getByText('10 SU')).toBeDefined();
+    expect(getByText('0 SU')).toBeDefined();
+    expect(getByText('9/30/2023')).toBeDefined();
+  });
+  it.skip('should display the projects publications, and abstract/grants', async () => {
+    testRender(<ProjectDetails projectId={59184} />);
     await screen.findByText(/This project has no publications./);
-    await screen.findByText(/This project has no grants./);
+    await screen.findByText(/Your project and allocation information can be managed on the TXRAS portal./);
   });
 });

--- a/libs/tup-components/src/projects/details/ProjectDetails.test.tsx
+++ b/libs/tup-components/src/projects/details/ProjectDetails.test.tsx
@@ -9,7 +9,7 @@ describe('Project Details Component', () => {
   });
   it('should display the projects table', async () => {
     const { getByText, getByTestId, getAllByRole } = testRender(
-      <ProjectDetails projectId={59184}  />
+      <ProjectDetails projectId={59184} />
     );
     expect(getByTestId('loading-spinner')).toBeDefined();
     await waitFor(() => getAllByRole('columnheader'));
@@ -26,6 +26,8 @@ describe('Project Details Component', () => {
   it.skip('should display the projects publications, and abstract/grants', async () => {
     testRender(<ProjectDetails projectId={59184} />);
     await screen.findByText(/This project has no publications./);
-    await screen.findByText(/Your project and allocation information can be managed on the TXRAS portal./);
+    await screen.findByText(
+      /Your project and allocation information can be managed on the TXRAS portal./
+    );
   });
 });

--- a/libs/tup-components/src/projects/details/ProjectDetails.tsx
+++ b/libs/tup-components/src/projects/details/ProjectDetails.tsx
@@ -8,9 +8,7 @@ import {
 import {
   useProjects,
   usePublications,
-  useGrants,
   ProjectPublication,
-  ProjectGrant,
   useRoleForCurrentUser,
 } from '@tacc/tup-hooks';
 import styles from './ProjectDetails.module.css';
@@ -19,11 +17,8 @@ import {
   ProjectPublicationEditModal,
   ProjectPublicationCreateModal,
 } from './publications';
-import { ProjectGrantEditModal, ProjectGrantCreateModal } from './grants';
 import { ProjectsListingAllocationTable } from '../ProjectsListing/ProjectsListingAllocationTable';
-import { ProjectEditModal } from './ProjectEdit';
 import ProjectPublicationRemove from './publications/ProjectPublicationDelete';
-import ProjectGrantDelete from './grants/ProjectGrantDelete';
 
 const formatDate = (datestring: string): string => {
   const date = new Date(datestring);
@@ -108,7 +103,6 @@ const ProjectDetails: React.FC<{ projectId: number }> = ({ projectId }) => {
     (desc) => desc.id === projectId
   );
   const pub_data = usePublications(projectId).data ?? [];
-  const grant_data = useGrants(projectId).data ?? [];
   const currentUserRole = useRoleForCurrentUser(projectId);
   const canManage = currentUserRole
     ? ['PI', 'Delegate'].includes(currentUserRole)
@@ -175,7 +169,7 @@ const ProjectDetails: React.FC<{ projectId: number }> = ({ projectId }) => {
       >
         {projectDetails?.description}
 
-        <div className={styles['pub-grants-info']}>
+        <div className={styles['pub-abstract-grants']}>
           Your project and allocation information can be managed on the TXRAS
           portal.
         </div>

--- a/libs/tup-components/src/projects/details/ProjectDetails.tsx
+++ b/libs/tup-components/src/projects/details/ProjectDetails.tsx
@@ -173,7 +173,9 @@ const ProjectDetails: React.FC<{ projectId: number }> = ({ projectId }) => {
         header="Abstract/Grants"
         headerActions={canManage && <AbstractGrants />}
       >
-        <div className={styles['pub-grants-title']}>
+        {projectDetails?.description}
+
+        <div className={styles['pub-grants-info']}>
           Your project and allocation information can be managed on the TXRAS
           portal.
         </div>

--- a/libs/tup-components/src/projects/details/ProjectDetails.tsx
+++ b/libs/tup-components/src/projects/details/ProjectDetails.tsx
@@ -76,61 +76,6 @@ const Publication: React.FC<{
   );
 };
 
-const Grant: React.FC<{
-  grant: ProjectGrant;
-  projectId: number;
-  canManage: boolean;
-}> = ({ grant, projectId, canManage }) => {
-  return (
-    <div>
-      <div className={styles['pub-grants-edit-link']}>
-        <span style={{ fontSize: '1.5rem' }}>
-          <strong>{grant.title}</strong>
-        </span>
-        {canManage && (
-          <span>
-            <ProjectGrantEditModal projectId={projectId} grantId={grant.id} />
-            {' | '}
-            <ProjectGrantDelete projectId={projectId} grantId={grant.id} />
-          </span>
-        )}
-      </div>
-      <div className={styles['pub-grants-title']}>
-        Grant Number:{' '}
-        <span className={styles['pub-grants-info']}>{grant.id}</span>
-      </div>
-      <div className={styles['pub-grants-title']}>
-        Principal Investigator:{' '}
-        <span className={styles['pub-grants-info']}>{grant.piName}</span>
-      </div>
-      <div className={styles['pub-grants-title']}>
-        <strong>{grant.field}</strong>
-      </div>
-      <div className={styles['pub-grants-title']}>
-        Funding Agency:{' '}
-        <span className={styles['pub-grants-info']}>
-          {grant.fundingAgency ?? '(N/A)'}
-        </span>
-        Award Number:{' '}
-        <span className={styles['pub-grants-info']}>
-          {grant.awardNumber ?? '(N/A)'}
-        </span>
-        Award Amount:{' '}
-        <span className={styles['pub-grants-info']}>
-          {grant.awardAmount ?? '(N/A)'}
-        </span>
-      </div>
-      <div className={styles['pub-grants-title']}>
-        Award Dates:{' '}
-        <span className={styles['pub-grants-info']}>
-          {grant.start ? formatDate(grant.start) : '(N/A)'} -{' '}
-          {grant.end ? formatDate(grant.end) : '(N/A)'}
-        </span>
-      </div>
-    </div>
-  );
-};
-
 const NewAllocation = () => (
   <a href="https://submit-tacc.xras.org/" target="_blank" rel="noreferrer">
     <Button type="link">+ Add New Allocation</Button>
@@ -144,6 +89,16 @@ const IncreaseAllocation = () => (
     rel="noreferrer"
   >
     <Button type="link">Increase Existing Allocation</Button>
+  </a>
+);
+
+const AbstractGrants = () => (
+  <a
+    href="https://submit-tacc.xras.org/requests"
+    target="_blank"
+    rel="noreferrer"
+  >
+    <Button type="link">Edit Project</Button>
   </a>
 );
 
@@ -191,13 +146,6 @@ const ProjectDetails: React.FC<{ projectId: number }> = ({ projectId }) => {
         )}
       </SectionTableWrapper>
       <div className={styles['separator']}></div>
-      <SectionTableWrapper
-        header="Abstract"
-        headerActions={canManage && <ProjectEditModal projectId={projectId} />}
-      >
-        {projectDetails?.description}
-      </SectionTableWrapper>
-      <div className={styles['separator']}></div>
 
       <SectionTableWrapper
         header="Publications"
@@ -222,24 +170,13 @@ const ProjectDetails: React.FC<{ projectId: number }> = ({ projectId }) => {
       <div className={styles['separator']}></div>
 
       <SectionTableWrapper
-        header="Grants"
-        className={styles['listing-section']}
-        headerActions={
-          canManage && <ProjectGrantCreateModal projectId={projectId} />
-        }
+        header="Abstract/Grants"
+        headerActions={canManage && <AbstractGrants />}
       >
-        {grant_data.length === 0 ? (
-          <span>This project has no grants.</span>
-        ) : (
-          grant_data.map((grant) => (
-            <Grant
-              key={grant.id}
-              grant={grant}
-              projectId={projectId}
-              canManage={canManage}
-            />
-          ))
-        )}
+        <div className={styles['pub-grants-title']}>
+          Your project and allocation information can be managed on the TXRAS
+          portal.
+        </div>
       </SectionTableWrapper>
     </div>
   );


### PR DESCRIPTION
## Overview:
Changes to Project Page - abstract and grants go to TXRAS

## Related:

- [TUP-442](https://jira.tacc.utexas.edu/browse/TUP-442)

## Changes:
1. Move Publications to be below Allocations
2. Remove Abstract section
3. Remove Grants section
4. Make combined Abstract/Grants section that links to TXRAS (https://submit-tacc.xras.org/requests)

## Testing:
1. Dashboard --> Projects & Allocations (left-nav)
2. Select a project
3. Make sure the three main sections are Allocations, Publications, Abstract/Grants
4. Clicking Edit Project next to Abstract/Grants goes to TXRAS.

## UI:
BEFORE:
![Screen Shot 2023-03-09 at 1 44 44 PM](https://user-images.githubusercontent.com/35277477/224147933-d0678d69-530c-475e-ac81-9bdad1112692.png)

AFTER:
![Screen Shot 2023-03-09 at 3 22 06 PM](https://user-images.githubusercontent.com/35277477/224162750-4a4c222b-29c4-43e9-8416-1acad8986452.png)



## Notes:
