### PR TITLE
chore(tup-ui): no repetition of table width 100%

### DIFF
--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -45,3 +45,8 @@ h2 {
   font-size: var(--global-font-size--large);
   font-weight: var(--bold);
 }
+
+/* Tables */
+table {
+  width: 100%;
+}

--- a/libs/core-components/src/lib/InfiniteScrollTable/InfiniteScrollTable.css
+++ b/libs/core-components/src/lib/InfiniteScrollTable/InfiniteScrollTable.css
@@ -7,7 +7,6 @@
   /* CAVEAT: All tables' column widths must be % values whose sum is 100% */
   /* SEE: https://stackoverflow.com/a/6601257 */
   table-layout: fixed;
-  width: 100%;
 
   max-height: inherit; /* inherit max-height from parent wrapper */
 

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.module.css
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.module.css
@@ -1,6 +1,3 @@
-.allocations-table {
-    width: 100%;
-}
 .allocations-table tr > td:nth-child(1) {
     width: 30%;
 }

--- a/libs/tup-components/src/projects/ProjectsTable.tsx
+++ b/libs/tup-components/src/projects/ProjectsTable.tsx
@@ -31,7 +31,7 @@ export const ProjectsTable: React.FC = () => {
   }
   return (
     <div className="o-fixed-header-table">
-      <table style={{ width: '100%' }}>
+      <table>
         <thead>
           <tr>
             <th>Project Title</th>

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
@@ -40,7 +40,6 @@
 
 
 .usage-table {
-    width: 100%;
     padding: 20px;
 }
 

--- a/libs/tup-components/src/system_monitor/SystemMonitor.module.css
+++ b/libs/tup-components/src/system_monitor/SystemMonitor.module.css
@@ -2,7 +2,6 @@
   --table-border: 1px solid black;
 
   margin: 0;
-  width: 100%;
 }
 
 .rows tr:nth-child(even) {

--- a/libs/tup-components/src/tickets/TicketsTable.tsx
+++ b/libs/tup-components/src/tickets/TicketsTable.tsx
@@ -70,7 +70,7 @@ export const TicketsTable: React.FC<{ ticketsPath: string }> = ({
 
   return (
     <div className="o-fixed-header-table">
-      <table style={{ width: '100%' }}>
+      <table>
         <thead>
           <tr>
             <th>Ticket Number</th>


### PR DESCRIPTION
## Overview

Avoid repeating `width: 100%` on every table.

## Related

None.

## Changes

- **removed** table width 100% instances
- **added** one table width 100% definition

## Testing

1. Open Dashboard, Projects, and Tickets.
2. Verify all tables are still 100% width.

## UI

| many table width 100% (before) | no table width 100% (during) | one table width 100% (after) |
| - | - | - |
| ![many table widths 1](https://user-images.githubusercontent.com/62723358/225147313-9475965d-b5f1-4150-97c4-6abd306da491.png) | ![remove table widths 1](https://user-images.githubusercontent.com/62723358/225147317-27ae02e8-26ab-4119-b124-844d780db8f3.png) | ![add global table width 1](https://user-images.githubusercontent.com/62723358/225147319-0c599148-b412-4e60-90bc-06191cf2eb7d.png) |
| ![many table widths 2](https://user-images.githubusercontent.com/62723358/225147362-e71df4ef-c524-41f9-877e-e6fa90bf108c.png) | ![remove table widths 2](https://user-images.githubusercontent.com/62723358/225147364-54e8faec-ee81-4f9a-8e7b-032675fc5b09.png) | ![add global table width 2](https://user-images.githubusercontent.com/62723358/225147368-fe830c1f-7285-48fc-816d-8498e7f63204.png) |
| ![many table widths 3](https://user-images.githubusercontent.com/62723358/225147417-b0f71e30-b378-4485-b79b-032f86c9355a.png) | ![remove table widths 3](https://user-images.githubusercontent.com/62723358/225147419-8964deee-73cd-44d4-8e46-29c79fe8bb3a.png) | ![add global table width 3](https://user-images.githubusercontent.com/62723358/225147420-4d304ba7-bccc-4022-bd70-0a1837dbc3f1.png) |
