### PR TITLE
fix(tup-cms): core-cms templates: picture, 404

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:c40787a
+FROM taccwma/core-cms:721adec
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:721adec
+FROM taccwma/core-cms:91760d2
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/templates/404.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/404.html
@@ -1,0 +1,16 @@
+{# TODO: Get styles from designers; if suitable for Core-CMS, then integrate #}
+{# https://github.com/TACC/Core-CMS/blob/c8844e1/taccsite_cms/templates/404.html #}
+{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block title %}404{% endblock title %}
+
+{# To remove breadcrumbs #}
+{% block content %}
+    <div class="container">
+      <section class="o-section">
+        <h1>404</h1>
+        <h2>Page Not Found</h2>
+      </section>
+    </div>
+{% endblock content %}


### PR DESCRIPTION
## Overview

1. Add manual **404** page (that overwrites a simpler one from Core-CMS).
2. Get `djangocms_picture` template bug fixes form Core-CMS.

## Related

- **[feat: minimal 404 error page](https://github.com/TACC/Core-CMS/commit/ea034fc) (https://github.com/TACC/Core-CMS/commit/ea034fc)**
- https://github.com/TACC/Core-CMS/pull/610
    - and [fix(djangocms_picture): missing "not" in if clause](https://github.com/TACC/Core-CMS/commit/0340445) (https://github.com/TACC/Core-CMS/commit/0340445)

## Changes

- **changed** Core-CMS image

## Testing

### 404 Page

1. On dev.tup.tacc.utexas.edu, visit a page that does not exist e.g. https://dev.tup.tacc.utexas.edu/sadf/.
2. **Verify a 404 status code.**
3. Verify 404 page has standard header and footer.

### `djangocms_picture`

Used in #182.

## UI

![404 on tup-cms](https://user-images.githubusercontent.com/62723358/225449243-52a5c4ec-3e98-421b-b12a-43ad28d8b87d.png)