### PR TITLE
fix(tup-cms): pill size too large (on cms)

### DIFF
--- a/libs/core-components/src/lib/Pill/Pill.module.css
+++ b/libs/core-components/src/lib/Pill/Pill.module.css
@@ -2,6 +2,7 @@
 
 .root {
   font-weight: var(--medium);
+  font-size: var(--global-font-size--small);
 
   padding: 0.2em 0.5em; /* aim for ~23px height (19px design * 1.2 design-to-app ratio) */
   display: inline-block; /* FAQ: Supports `min/max-width` */


### PR DESCRIPTION
## Overview

Reduce pill size on CMS. (But not on Portal, yet.)

## Related

- [TUP-1234](https://jira.tacc.utexas.edu/browse/TUP-1234)

## Changes

- reduce pill size (only has visible effect on cms)

## Testing

0. `nx build tup-cms`, `nx serve tup-cms`, `nx serve tup-ui`
1. Verify font-size of pill is smaller on CMS. (Smaller font than table.)
2. Verify font-size of pill is unchanged on Portal. (Same size font as table.)

## UI

| cms | portal |
| - | - |
| ![cms](https://user-images.githubusercontent.com/62723358/225955549-a8468365-010f-4f0c-ab8c-ef92a6f73575.png) | ![portal](https://user-images.githubusercontent.com/62723358/225955543-84da5fe8-203f-4fb5-a0cd-559b325793cc.png) |

## Notes

Font size or pill is not small enough on portal, relative to table size. But table size on portal (matches core-styles.base) is smaller than CMS (overrides core-styles.base). So, to avoid too-tiny pill text on portal, I let it be the same size as table. When portal text size is increased, the inconsistency can be fixed.