### PR TITLE
fix(tup-cms): Dockerfile trumped core-cms template

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -10,4 +10,4 @@ COPY dist/apps/tup-ui/imports.html /code/taccsite_cms/templates/imports.html
 COPY dist/apps/tup-ui/assets/ /code/taccsite_cms/static/assets/
 
 COPY dist/apps/tup-cms-react/assets /code/taccsite_cms/static/cms-react/assets
-COPY /dist/apps/tup-cms-react/imports.html /code/taccsite_cms/templates/assets_custom_delayed.html
+COPY /dist/apps/tup-cms-react/imports.html /code/taccsite_cms/templates/tup-cms-react.html


### PR DESCRIPTION
## Overview

As we did not let docker compose file overwrite core-cms template, so should we not let Dockerfile overwrite that same template.

## Related

- follow-up to #181

## Changes

- **changed** Dockerfile to copy `tup-cms-react/imports.html` to `tup-cms-react.html`

## Testing & UI

See #181.