### PR TITLE
chore(core-styles): v2.6.1

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:6cb6668
+FROM taccwma/core-cms:f42cb52
 
 WORKDIR /code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@nrwl/vite": "^15.6.3",
         "@nrwl/web": "15.6.3",
         "@nrwl/workspace": "15.6.3",
-        "@tacc/core-styles": "github:TACC/Core-Styles#e34ea4d",
+        "@tacc/core-styles": "^2.6.1",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5704,10 +5704,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.5.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#e34ea4def2d7127ff1a51b343567349aee3d03b5",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.6.1.tgz",
+      "integrity": "sha512-tdwX4GiDqLWdfZNPb/zRNfs1MhMGStd4xfL5vSwwG117b5WugSZySkE3pfYwIK3ianemPFxzheuqfLTGlFYDVQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -29588,9 +29588,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#e34ea4def2d7127ff1a51b343567349aee3d03b5",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.6.1.tgz",
+      "integrity": "sha512-tdwX4GiDqLWdfZNPb/zRNfs1MhMGStd4xfL5vSwwG117b5WugSZySkE3pfYwIK3ianemPFxzheuqfLTGlFYDVQ==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#e34ea4d",
       "requires": {}
     },
     "@tanstack/query-core": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nrwl/vite": "^15.6.3",
     "@nrwl/web": "15.6.3",
     "@nrwl/workspace": "15.6.3",
-    "@tacc/core-styles": "github:TACC/Core-Styles#e34ea4d",
+    "@tacc/core-styles": "^2.6.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## Overview & Changes

**https://github.com/TACC/Core-Styles**
- [**v2.6.1**: core-styles.wysiwyg.css](https://github.com/TACC/Core-Styles/releases/tag/v2.6.1) [Latest](https://github.com/TACC/Core-Styles/releases/latest)
- [**v2.6.0**: c-tag & --global-font-size--xxx-large & c-island](https://github.com/TACC/Core-Styles/releases/tag/v2.6.0)

Expect no effect. Relevance is that it adds more patterns to `core-styles.base.css` that CMS will use.

## Related

- [TUP-1234](https://jira.tacc.utexas.edu/browse/TUP-1234)

## Testing & UI

https://user-images.githubusercontent.com/62723358/226769267-ef21cc80-7d03-4f1a-bb01-7c29a40362a7.mov