### PR TITLE
test(tup-cms): turn off search bar

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:9380f9f
+FROM taccwma/core-cms:38934a4
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -109,6 +109,12 @@ TUP_SERVICES_URL = "https://dev.tup-services.tacc.utexas.edu"
 LOGIN_URL = "/portal/login"
 
 ########################
+# TACC: PORTAL
+########################
+
+INCLUDES_SEARCH_BAR = False
+
+########################
 # TACC: NEWS/BLOG
 ########################
 


### PR DESCRIPTION
## Overview

Turn off search bar (until Google re-indexes).

## Related

- requires https://github.com/TACC/Core-CMS/pull/614

## Changes

- **added** setting to disable search bar

## Testing

1. Verify search bar is not present.
2. Verify flexible horizontal space in header between CMS Nav and Portal Nav.

## UI

![tup ui no search bar](https://user-images.githubusercontent.com/62723358/227611549-3653a7b8-1a06-4737-8b45-bb825035fd41.png)

![dev tup no search bar](https://user-images.githubusercontent.com/62723358/227612515-6891f738-6acb-4b58-b11a-2a3a8619dd8f.png)
