### PR TITLE
fix(tup-cms): full width template, avoid js error

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup-cms/static/tup-cms/js/modules/breadcrumbs.js
+++ b/apps/tup-cms/src/taccsite_custom/tup-cms/static/tup-cms/js/modules/breadcrumbs.js
@@ -1,5 +1,8 @@
-// TODO: Move to TACC/Core-CMS
-// TODO: Try to programmatically only perform if link is a redirect
+/* TODO: Try to programmatically only perform if link is a redirect */
+/* TODO: Integrate into Core-CMS (not Core-Styles):
+        - …/css/src/imports/trumps/s-breadcrumbs.css
+        - …/js/modules/breadcrumbs.js
+*/
 /**
  * To "disable" top-level CMS menu nav links in breadcrumbs
  * (because they all are always set to redirect to a child)
@@ -9,6 +12,6 @@ const link = document.querySelector(
 );
 const isAppropriatePage = window.location.pathname.search('/systems/') == -1;
 
-if (isAppropriatePage) {
+if (link && isAppropriatePage) {
   link.removeAttribute('href');
 }


### PR DESCRIPTION
## Overview

Fix innocuous JavaScript error (on Full Width template pages) while manipulating breadcrumbs.

## Related

- [TUP-1234](https://jira.tacc.utexas.edu/browse/TUP-1234)

## Changes

- **changed** condition to check whether link exists

## Testing

1. Open homepage (set to Full Width template).
2. Have console open.
3. Verify no error in `breadcrumbs.js`.
4. Open another page (set to Standard template).
5. Have console open.
6.  Verify no error in `breadcrumbs.js`.

## UI

Skipped.

## Notes

On a full width template, no breadcrumbs exist, thus no `link` exists from which to `removeAttribute`.