### PR TITLE
test(tup-cms): disable elastic search 🧪

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:f2cfcd1
+FROM taccwma/core-cms:6df6487
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -52,6 +52,14 @@ RECAPTCHA_PRIVATE_KEY = ''
 RECAPTCHA_PUBLIC_KEY = ''
 
 ########################
+# TACC: SEARCH
+########################
+
+SEARCH_QUERY_PARAM_NAME = 'q'
+# SEE: https://github.com/TACC/Core-CMS/pull/621
+SEARCH_ENGINE = 'NOT_ELASTIC' # There is no Core-CMS support for 'GOOGLE'
+
+########################
 # TACC: BRANDING
 ########################
 
@@ -93,12 +101,6 @@ LOGO = [
     "anonymous",
     "True"
 ]
-
-########################
-# TACC: SEARCH
-########################
-
-SEARCH_QUERY_PARAM_NAME = 'q'
 
 ########################
 # DJANGO


### PR DESCRIPTION
## Overview

Disable Elasticsearch (in hopes of improving page publish speed).

## Related

- requires https://github.com/TACC/Core-CMS/pull/621

## Changes

- **changed** core-cms image to one that has [TACC/Core-CMS#621] code
- **added** setting `SEARCH_ENGINE` (set to **not** be `'ELASTIC'`)
- **moved** "TACC: SEARCH" settings (to match [TACC/Core-CMS#621])

## Testing

1. Deploy.
2. Check whether page publish is faster than before.

## UI

It does not appear to publish faster for me. I do not know if  https://github.com/TACC/Core-CMS/pull/621 is even working....

## Notes


[TACC/Core-CMS#621]: https://github.com/TACC/Core-CMS/pull/621