### PR TITLE
fix(tup-cms): hide byline on user updates

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup-cms/static/tup-cms/css/for-tup-cms/components/c-news.css
+++ b/apps/tup-cms/src/taccsite_custom/tup-cms/static/tup-cms/css/for-tup-cms/components/c-news.css
@@ -7,3 +7,8 @@
   border-bottom: unset;
   margin-bottom: 6.5rem;
 }
+
+/* To hide byline on User Updates */
+.c-news__byline:not(.app-blog *) {
+  display: none;
+}


### PR DESCRIPTION
## Overview

Hide byline on a "User Updates" article.

## Related

- fixes #191

## Changes

- **added** code to hide byline in "not blog app" context

## Testing

1. Verify that byline is not shown on [a User Updates article that has not been updated with more news](https://dev.tup.tacc.utexas.edu/news/user-updates/107446/).

## UI

| list | read |
| - | - |
| ![list](https://user-images.githubusercontent.com/62723358/231011237-bc717f30-56f3-4ae9-87e7-4399cf98245e.png) | ![read](https://user-images.githubusercontent.com/62723358/231011234-cd06eb7e-12f1-4085-b578-ec715869ecd1.png) |