### PR TITLE
fix(tup-cms): let banner image "size-to-fit"

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup-cms/static/tup-cms/css/for-tup-cms/components/banner.css
+++ b/apps/tup-cms/src/taccsite_custom/tup-cms/static/tup-cms/css/for-tup-cms/components/banner.css
@@ -62,6 +62,7 @@
 [class*="banner-cell--"] figure:where([style*="height"], [style*="width"]) img {
   object-fit: cover;
   height: 100%;
+  width: 100%;
 }
 
 /* Components */


### PR DESCRIPTION
## Overview

Let main banner image fill full width available.

## Related

None

## Changes

- **added** back a style I should not have removed

## Testing

1. Verify top banner image on [home page](https://dev.tup.tacc.utexas.edu/) takes up full width of page.

## UI

| before | after |
| - | - |
| ![before](https://user-images.githubusercontent.com/62723358/231258006-aad0ac80-db9e-44e4-ab8c-ade654d967e7.png) | ![after](https://user-images.githubusercontent.com/62723358/231258451-6aced0b6-9823-4e9f-9fdb-3664b0cb78cb.png) |