### PR TITLE
fix: Show text for empty projects if user has inactive projects

### DIFF
--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListing.tsx
@@ -25,7 +25,7 @@ export const ProjectsListing: React.FC = () => {
     return (
       <InlineMessage type="warning">Unable to retrieve projects.</InlineMessage>
     );
-  if (!data?.length) {
+  if (!data?.filter(prjFilter).length) {
     return (
       <EmptyTablePlaceholder>
         No projects or allocations found. {''}

--- a/libs/tup-components/src/projects/ProjectsTable.tsx
+++ b/libs/tup-components/src/projects/ProjectsTable.tsx
@@ -41,7 +41,7 @@ export const ProjectsTable: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {!data?.length && (
+          {!projectData?.length && (
             <tr>
               <td colSpan={3}>
                 <EmptyTablePlaceholder>


### PR DESCRIPTION
## Overview
It was possible to get a totally blank projects listing if you had projects but they were all inactive. This PR makes it so that we always show at least the warning.

## UI
<img width="1589" alt="image" src="https://user-images.githubusercontent.com/12601812/232151717-a2090ff9-d909-4c12-bc31-329526d2d592.png">


## Notes
