### PR TITLE
Tweak: Stop tup-cms from overriding TUP_SERVICES_URL config

### DIFF
--- a/apps/tup-cms-react/imports.debug.html
+++ b/apps/tup-cms-react/imports.debug.html
@@ -1,8 +1,10 @@
 <script>
-  window.__TUP_CONFIG__ = {
-    // TODO: use custom context processor instead of hard-coding
-    baseUrl: 'https://dev.tup-services.tacc.utexas.edu',
-  };
+  if (!window.__TUP_CONFIG__) {
+    window.__TUP_CONFIG__ = {
+      // TODO: use custom context processor instead of hard-coding
+      baseUrl: 'https://dev.tup-services.tacc.utexas.edu',
+    };
+  }
 </script>
 <script type="module">
   import RefreshRuntime from 'http://localhost:4200/@react-refresh';

--- a/apps/tup-cms-react/imports.html
+++ b/apps/tup-cms-react/imports.html
@@ -1,7 +1,9 @@
 <script type="module" src="/src/main.tsx"></script>
 <script>
-  window.__TUP_CONFIG__ = {
-    // TODO: use custom context processor instead of hard-coding
-    baseUrl: 'https://tup-services.tacc.utexas.edu',
-  };
+  if (!window.__TUP_CONFIG__) {
+    window.__TUP_CONFIG__ = {
+      // TODO: use custom context processor instead of hard-coding
+      baseUrl: 'https://tup-services.tacc.utexas.edu',
+    };
+  }
 </script>


### PR DESCRIPTION
## Overview
The tup-cms-react templates were using a hard-coded tup-services URL that was overriding the configuration. This prevents them from doing so if the setting has already been loaded (e.g. inside of the portal).
