### PR TITLE
task/TUP-218: Add resource/category to ticket body and choose queue based on category

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -12,6 +12,16 @@ if settings.DEBUG:
     service_url = service_url.replace("localhost", "host.docker.internal")
 
 
+QUEUE_MAP = {
+    "Allocations": "Accounting",
+    "Data Analytics or Storage Resources": "Data Intensive Computing",
+    "Login/Authentication Issue": "Accounting",
+    "Running Jobs or Using TACC Resources": "High Performance Computing",
+    "Security Incident": "NSO",
+    "Other": "High Performance Computing"
+}
+
+
 def submit_ticket(form_data):
     message_body = ""
     message_body += f"Category: {form_data['category']}\n"
@@ -22,7 +32,8 @@ def submit_ticket(form_data):
     ticket_data = {
         "email": form_data["email"],
         "subject": form_data["subject"],
-        "description": message_body
+        "description": message_body,
+        "queue": QUEUE_MAP.get(form_data['category'], 'Accounting')
     }
     logger.debug(ticket_data)
     requests.post(f"{service_url}/tickets/noauth", data=ticket_data, files=[])

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.test.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.test.tsx
@@ -8,6 +8,8 @@ describe('TicketCreateForm Component', () => {
   it('should display a success message after mutation', async () => {
     const user = userEvent.setup();
     testRender(<TicketCreateForm />);
+    const category = screen.getByLabelText(/Category/);
+    const resource = screen.getByLabelText(/System\/Resource/);
     const subject = screen.getByLabelText(/Subject/);
     const description = screen.getByLabelText(/Problem Description/);
 
@@ -15,6 +17,8 @@ describe('TicketCreateForm Component', () => {
 
     await user.type(subject, 'test');
     await user.type(description, 'test');
+    await user.selectOptions(category, 'Allocations');
+    await user.selectOptions(resource, 'Other');
 
     const submit = screen.getByRole('button', { name: /add ticket/i });
     expect(submit.getAttribute('disabled')).toBe(null);
@@ -35,12 +39,15 @@ describe('TicketCreateForm Component', () => {
     testRender(<TicketCreateForm />);
 
     expect(await screen.findByDisplayValue('mock')).toBeDefined();
-
+    const category = screen.getByLabelText(/Category/);
+    const resource = screen.getByLabelText(/System\/Resource/);
     const subject = screen.getByLabelText(/Subject/);
     const description = screen.getByLabelText(/Problem Description/);
 
     await user.type(subject, 'test');
     await user.type(description, 'test');
+    await user.selectOptions(category, 'Allocations');
+    await user.selectOptions(resource, 'Other');
 
     const submit = screen.getByRole('button', { name: /add ticket/i });
     expect(submit.getAttribute('disabled')).toBe(null);

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -6,11 +6,12 @@ import {
   FormikInput,
   FormikTextarea,
   FormikFileInput,
+  FormikSelect,
 } from '@tacc/core-wrappers';
 import * as Yup from 'yup';
 import { ModalFooter } from 'reactstrap';
 import { Button, SectionMessage } from '@tacc/core-components';
-import { CreateTicketFormValues } from '..';
+import { CreateTicketFormValues, QUEUE_MAP } from '..';
 import styles from './TicketCreateForm.module.css';
 
 const formShape = {
@@ -19,6 +20,8 @@ const formShape = {
   first_name: Yup.string().required('Required'),
   last_name: Yup.string().required('Required'),
   email: Yup.string().email('Invalid email').required('Required'),
+  category: Yup.string().required('Required'),
+  resource: Yup.string().required('Required'),
   cc: Yup.string().test('email', 'Invalid email', (emails) =>
     (emails ?? 'placeholder@x.y.z')
       .split(/[\s,]+/)
@@ -41,6 +44,8 @@ export const TicketCreateForm: React.FC = () => {
       email: email ?? '',
       cc: '',
       files: [],
+      category: '',
+      resource: '',
       // recaptchaResponse: '',
     }),
     [firstName, lastName, email]
@@ -53,11 +58,18 @@ export const TicketCreateForm: React.FC = () => {
     values: CreateTicketFormValues,
     { resetForm }: FormikHelpers<CreateTicketFormValues>
   ) => {
+    let messageBody = ``;
+    messageBody += `Category: ${values.category}\n`;
+    messageBody += `System/Resource: ${values.resource}\n`;
+    messageBody += `Requestor: ${values.first_name} ${values.last_name} (${values.email})\n\n`;
+    messageBody += `${values.description}`;
+
     const formData = new FormData();
     formData.append('email', values['email']);
     formData.append('subject', values['subject']);
-    formData.append('description', values['description']);
+    formData.append('description', messageBody);
     formData.append('cc', values['cc']);
+    formData.append('queue', values.category && QUEUE_MAP[values.category]);
     if (values.files) {
       values.files.forEach((file) => formData.append('files', file));
     }
@@ -78,6 +90,34 @@ export const TicketCreateForm: React.FC = () => {
     >
       {({ isValid }) => (
         <Form className={styles['ticket-create-form']} id="ticket-create-form">
+          <FormikSelect name="category" label="Category" required>
+            <option value="">Please Choose One</option>
+            <option>Allocations</option>
+            <option>Data Analytics or Storage Resources</option>
+            <option>Login/Authentication Issue</option>
+            <option>Running Jobs or Using TACC Resources</option>
+            <option>Security Incident</option>
+            <option>Other</option>
+          </FormikSelect>
+          <FormikSelect name="resource" label="System/Resource" required>
+            <option value="">Please Choose One</option>
+            <option>Corral (corral-login.tacc.utexas.edu)</option>
+            <option>Corral iRODS(icat.corral.tacc.utexas.edu)</option>
+            <option>Corral-Protected(corral-protected.tacc.utexas.edu)</option>
+            <option>Frontera(frontera.tacc.utexas.edu)</option>
+            <option>Jetstream(jetstream.tacc.utexas.edu)</option>
+            <option>Lonestar6(lonestar6.tacc.utexas.edu)</option>
+            <option>Longhorn(longhorn.tacc.utexas.edu)</option>
+            <option>Maverick2(maverick2.tacc.utexas.edu)</option>
+            <option>Ranch(ranch.tacc.utexas.edu)</option>
+            <option>Stampede2(stampede2.tacc.utexas.edu)</option>
+            <option>Vislab(stallion.tacc.utexas.edu)</option>
+            <option>Cyclone(cyclone.tacc.utexas.edu)</option>
+            <option>Cloud and Interactive Computing (Agave API)</option>
+            <option>Cloud and Interactive Computing (Abaco API)</option>
+            <option>Cloud and Interactive Computing (JupyterHub)</option>
+            <option>Other</option>
+          </FormikSelect>
           <FormikInput name="subject" label="Subject" required description="" />
           <FormikTextarea
             name="description"

--- a/libs/tup-components/src/tickets/index.ts
+++ b/libs/tup-components/src/tickets/index.ts
@@ -3,6 +3,15 @@ export { default as TicketCreateModal } from './TicketCreateModal';
 export { default as Tickets } from './Tickets';
 export { default as TicketModal } from './TicketDetailModal';
 
+export const QUEUE_MAP = {
+  Allocations: 'Accounting',
+  'Data Analytics or Storage Resources': 'Data Intensive Computing',
+  'Login/Authentication Issue': 'Accounting',
+  'Running Jobs or Using TACC Resources': 'High Performance Computing',
+  'Security Incident': 'NSO',
+  Other: 'High Performance Computing',
+};
+
 export type StatusDisplay = {
   text: string;
   unknownStatusText: boolean;
@@ -16,6 +25,8 @@ export type CreateTicketFormValues = {
   email: string;
   cc: string;
   files: File[];
+  category: '' | keyof typeof QUEUE_MAP;
+  resource: string;
 };
 
 export type historyCardParams = {


### PR DESCRIPTION
## Overview
Address concerns from User Services about routing/categorization of tickets.
## Related

- [TUP-218](https://jira.tacc.utexas.edu/browse/TUP-218)

## Changes
- Add Category and Resource as required fields in the Create Ticket form, and append them to the ticket body.
- Route tickets to different RT queues based on their category:
Data Analy > data
Login > accounting
Running Jobs > hpc
Security > nso
Other > hpc

## Testing

1. From the user portal, submit a ticket with some Category selected.
2. Confirm that the ticket appears in Consult under the correct queue as mapped above.

## UI
<img width="789" alt="image" src="https://user-images.githubusercontent.com/12601812/233470647-5e8859e0-4f81-4dc9-aad4-5167060734ed.png">

## Notes
