### PR TITLE
UI for unpairing MFA via email

### DIFF
--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -54,7 +54,7 @@ const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {
           close={closeBtn}
           className={styles['modal-header']}
         >
-          <span>Unpair Muli-Factor Authentication</span>
+          <span>Unpair Multifactor Authentication</span>
         </ModalHeader>
         <form onSubmit={(e) => submit(e)}>
           <ModalBody>

--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -9,7 +9,6 @@ import {
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { TicketCreateModal } from '../tickets';
 import styles from './ManageAccount.module.css';
 
 const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {

--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -4,6 +4,7 @@ import {
   useMfa,
   useMfaDelete,
   useMfaChallenge,
+  useMfaEmailUnpair,
 } from '@tacc/tup-hooks';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import React, { useState } from 'react';
@@ -23,15 +24,17 @@ const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {
     </button>
   );
   const [currentToken, setCurrentToken] = useState('');
-  const { mutate, isError } = useMfaDelete();
+  const { mutate: unpairWithCode, isError } = useMfaDelete();
+  const { mutate: unpairWithEmail, isSuccess: emailSentSuccess } =
+    useMfaEmailUnpair();
   const { mutate: sendChallenge } = useMfaChallenge();
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setCurrentToken('');
-    console.log('form submitted');
-    mutate({
+
+    unpairWithCode({
       otpcode: currentToken,
     });
   };
@@ -86,14 +89,18 @@ const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {
               </p>
             )}
 
+            <p>If you lost your phone, you can unpair via email.</p>
             <p>
-              If you do not have access to the device you used for the initial
-              pairing, please{' '}
-              <TicketCreateModal display="link">
-                submit a ticket
-              </TicketCreateModal>
-              .
+              <Button onClick={() => unpairWithEmail(null)}>Send Email</Button>
             </p>
+            {emailSentSuccess && (
+              <p>
+                <SectionMessage type="info">
+                  An email has been sent to the address listed on your account.
+                  Follow its instructions to continue the unpairing.
+                </SectionMessage>
+              </p>
+            )}
           </ModalBody>
           <ModalFooter>
             <Button type="primary" attr="submit">

--- a/libs/tup-hooks/src/mfa/index.ts
+++ b/libs/tup-hooks/src/mfa/index.ts
@@ -44,4 +44,5 @@ export {
   useMfaVerify,
   useMfaDelete,
   useMfaChallenge,
+  useMfaEmailUnpair,
 } from './useMfa';

--- a/libs/tup-hooks/src/mfa/useMfa.tsx
+++ b/libs/tup-hooks/src/mfa/useMfa.tsx
@@ -55,3 +55,10 @@ export const useMfaDelete = () => {
   });
   return mutation;
 };
+
+export const useMfaEmailUnpair = () => {
+  const mutation = usePost<null, string>({
+    endpoint: '/mfa/unpair',
+  });
+  return mutation;
+};


### PR DESCRIPTION
## Overview
Add UI for unpairing MFA via email.

## Related

- [TUP-456](https://jira.tacc.utexas.edu/browse/TUP-456)

## Changes

## Testing
(with https://github.com/TACC/tup-services/pull/31 checked out/running and `TUP_SERVICES_URL = "http://localhost:8001"` in settings)
1. Navigate to the "Manage Account" page and click "Unpair" next to your MFA pairing.
2. Follow the instructions in the modal to send an email (this may only work in local dev for TACC emails).

## UI
<img width="504" alt="image" src="https://user-images.githubusercontent.com/12601812/233512477-264a7d81-7bdf-43c9-b282-70929641e8d1.png">
<img width="504" alt="image" src="https://user-images.githubusercontent.com/12601812/233512511-aaece020-7787-47e6-8b0a-01ec39782439.png">


## Notes
