### PR TITLE
Improve error handling for MFA

### DIFF
--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -7,6 +7,7 @@ import {
   useMfaEmailUnpair,
 } from '@tacc/tup-hooks';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import { TicketCreateModal } from '../tickets';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styles from './ManageAccount.module.css';
@@ -120,7 +121,23 @@ export const AccountMfa: React.FC = () => {
     sms: 'SMS Token',
     totp: 'TACC Token App',
   };
-  const { data, isLoading } = useMfa();
+  const { data, isLoading, isError } = useMfa();
+  if (isError) {
+    return (
+      <>
+        <div className={styles['tap-header']}>
+          <strong>MFA Pairing</strong>
+        </div>
+        <SectionMessage type="error">
+          There was an error retrieving your multifactor authentication status.
+          Your account may be in a non-valid state. if this error persists
+          please{' '}
+          <TicketCreateModal display="link">submit a ticket</TicketCreateModal>{' '}
+          with this information and TACC User Services will assist you.
+        </SectionMessage>
+      </>
+    );
+  }
   if (isLoading || !data) return <LoadingSpinner />;
   const hasPairing = data?.token?.rollout_state === 'enrolled';
   return (

--- a/libs/tup-components/src/mfa/Mfa.module.css
+++ b/libs/tup-components/src/mfa/Mfa.module.css
@@ -58,14 +58,12 @@
     height: 100%;
 }
 .qr-code-error {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    max-width: 200px;
 }
 
 .mfa-form {
     padding-top: 10px;
+    padding-bottom: 10px;
 }
 
 .submit-button {

--- a/libs/tup-components/src/mfa/MfaQRPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaQRPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useMfaPairTotp } from '@tacc/tup-hooks';
 import { Button, LoadingSpinner, SectionMessage } from '@tacc/core-components';
+import { TicketCreateModal } from '../tickets';
 import styles from './Mfa.module.css';
 
 const MfaQRPanel: React.FC = () => {
@@ -27,10 +28,12 @@ const MfaQRPanel: React.FC = () => {
       {!data && isError && (
         <SectionMessage type="error">
           <div className={styles['qr-code-error']}>
-            There was an error generating your QR code.{' '}
-            <Button type="primary" onClick={() => mutate(null)}>
-              Generate a new code
-            </Button>
+            There was an error generating your QR code. If this error persists,
+            please{' '}
+            <TicketCreateModal display="link">
+              submit a ticket
+            </TicketCreateModal>{' '}
+            and TACC User Services will assist you.
           </div>
         </SectionMessage>
       )}

--- a/libs/tup-components/src/mfa/MfaSmsPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaSmsPanel.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { useMfaPairSms } from '@tacc/tup-hooks';
-import { Button } from '@tacc/core-components';
+import { Button, SectionMessage } from '@tacc/core-components';
 import styles from './Mfa.module.css';
+import { TicketCreateModal } from '../tickets';
 
 const MfaSmsPanel: React.FC = () => {
   const smsMutation = useMfaPairSms();
@@ -31,6 +32,18 @@ const MfaSmsPanel: React.FC = () => {
           </Button>
         </div>
       </form>
+      {smsMutation.isError && (
+        <SectionMessage type="error">
+          <div className={styles['qr-code-error']}>
+            There was an error generating your SMS pairing. If this error
+            persists, please{' '}
+            <TicketCreateModal display="link">
+              submit a ticket
+            </TicketCreateModal>{' '}
+            and TACC User Services will assist you.
+          </div>
+        </SectionMessage>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Overview
Some pieces of the MFA pairing flow had poorly defined error handling. This PR makes it more explicit when the backend fails to create or retrieve a pairing, and directs the user to submit a ticket.

## Related

- [TUP-465](https://jira.tacc.utexas.edu/browse/TUP-465)

## Changes

## UI
![image](https://user-images.githubusercontent.com/12601812/234689631-c913ce80-5fc4-4573-b20e-c93fe7c44bce.png)
![image](https://user-images.githubusercontent.com/12601812/234689736-5c80dc1a-70a7-4b45-ae5c-bee9d1ed2f8a.png)
![image](https://user-images.githubusercontent.com/12601812/234690181-30c0980c-7089-43a9-ac39-4dff17289208.png)


## Notes
