### PR TITLE
task/TUP-467: Prevent ticket detail modal from overflowing the viewport

### DIFF
--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.tsx
@@ -32,7 +32,7 @@ const TicketModal: React.FC<{ ticketId: string; baseRoute: string }> = ({
         <span className="ticket-id">Ticket {ticketId}</span>
         <span className="ticket-subject">{data?.Subject}</span>
       </ModalHeader>
-      <ModalBody style={{ minHeight: '70vh', maxHeight: 'fit-content' }}>
+      <ModalBody style={{ height: '70vh' }}>
         <Container className="ticket-detailed-view-container">
           <Row className="ticket-detailed-view-row">
             <Col lg="7">


### PR DESCRIPTION
## Overview
Prevent ticket detail modal from overflowing the viewport by removing the `fit-content` css directive.

## Related

- [TUP-467](https://jira.tacc.utexas.edu/browse/TUP-467)

## Changes

## Testing

1. Open a ticket detail with a large reply chain or a large reply body (large enough to overflow the viewport
2. Make sure that you can scroll through the entire ticket reply chain.

