### PR TITLE
bug/TUP-465: Handle null project title/description

### DIFF
--- a/libs/tup-components/src/projects/ProjectLayout.test.tsx
+++ b/libs/tup-components/src/projects/ProjectLayout.test.tsx
@@ -14,7 +14,7 @@ describe('Projects Layout Component', () => {
     expect(columnHeaders[0].textContent).toEqual('Project Title');
     expect(columnHeaders[1].textContent).toEqual('Principal Investigator');
     expect(columnHeaders[2].textContent).toEqual('Active Allocations');
-    expect(getByText('JAR TUP Development Project')).toBeDefined();
+    expect(getByText(/JAR TUP Development Project/)).toBeDefined();
     expect(getByText('Jake Rosenberg')).toBeDefined();
     expect(getByText('Lonestar6')).toBeDefined();
   });

--- a/libs/tup-components/src/projects/ProjectsListing/ProjectSummary.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectSummary.tsx
@@ -20,7 +20,7 @@ export const ProjectSummary: React.FC<{
   return (
     <>
       <Link to={`/projects/${project.id}`} className={styles['project-title']}>
-        {project.title}
+        {project.title ?? '(untitled)'}
       </Link>
       <div>
         {'Project Charge Code: '} <strong>{project.chargeCode}</strong>

--- a/libs/tup-components/src/projects/ProjectsTable.test.tsx
+++ b/libs/tup-components/src/projects/ProjectsTable.test.tsx
@@ -27,7 +27,7 @@ describe('Projects Table Component', () => {
     expect(columnHeaders[0].textContent).toEqual('Project Title');
     expect(columnHeaders[1].textContent).toEqual('Principal Investigator');
     expect(columnHeaders[2].textContent).toEqual('Active Allocations');
-    expect(getByText('JAR TUP Development Project')).toBeDefined();
+    expect(getByText(/JAR TUP Development Project/)).toBeDefined();
     expect(getByText('Jake Rosenberg')).toBeDefined();
     expect(getByText('Lonestar6')).toBeDefined();
   });

--- a/libs/tup-components/src/projects/ProjectsTable.tsx
+++ b/libs/tup-components/src/projects/ProjectsTable.tsx
@@ -60,7 +60,9 @@ export const ProjectsTable: React.FC = () => {
           {projectData?.map((project) => (
             <tr key={project.id}>
               <td style={{ width: '30%' }}>
-                <Link to={`/projects/${project.id}`}>{project.title}</Link>
+                <Link to={`/projects/${project.id}`}>
+                  {project.title ?? 'Untitled Project'} ({project.chargeCode})
+                </Link>
               </td>
               <td
                 style={{ width: '20%' }}

--- a/libs/tup-components/src/projects/details/ProjectDetails.tsx
+++ b/libs/tup-components/src/projects/details/ProjectDetails.tsx
@@ -175,7 +175,7 @@ const ProjectDetails: React.FC<{ projectId: number }> = ({ projectId }) => {
         header="Abstract/Grants"
         headerActions={canManage && <AbstractGrants />}
       >
-        {projectDetails?.description}
+        {projectDetails?.description ?? '(No description provided)'}
 
         <div className={styles['pub-abstract-grants']}>
           Your project and allocation information can be managed on the TXRAS

--- a/libs/tup-components/src/projects/header/ProjectHeader/ProjectHeader.tsx
+++ b/libs/tup-components/src/projects/header/ProjectHeader/ProjectHeader.tsx
@@ -91,10 +91,12 @@ export const ProjectHeader: React.FC<{ projectId: number }> = ({
         {!isActive && (
           <Link to={'/projects?show=inactive'}>Inactive Projects </Link>
         )}
-        {!params.username && `/ ${dataById?.title}`}
+        {!params.username && `/ ${dataById?.title ?? 'Untitled Project'}`}
         {params.username && (
           <>
-            <Link to={`/projects/${projectId}`}>{`/ ${dataById?.title}`} </Link>
+            <Link to={`/projects/${projectId}`}>
+              {`/ ${dataById?.title ?? 'Untitled Project'}`}{' '}
+            </Link>
             {`/ ${params.username}`}{' '}
           </>
         )}

--- a/libs/tup-hooks/src/projects/index.ts
+++ b/libs/tup-hooks/src/projects/index.ts
@@ -32,8 +32,8 @@ export type ProjectFieldOfScience = {
 
 export type ProjectsRawSystem = {
   id: number;
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   chargeCode: string;
   gid: number;
   source: string;
@@ -67,7 +67,7 @@ export type ProjectsRawSystem = {
     email: string;
     vislabTrained: boolean;
     staff: boolean;
-  };
+  }[];
 };
 
 export type ProjectEditBody = Pick<


### PR DESCRIPTION
## Overview
Handle cases where a project has no title/description in TAS. This can be the case for some very old projects.

## Related

- [TUP-465](https://jira.tacc.utexas.edu/browse/TUP-465)

## Changes
- Replace null title/descriptions with `Untitled Project`/`(No description provided)`.
- Add the charge code to the project listing in the dashboard.

## UI
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/12601812/235472700-550d944a-422a-4224-b0d8-30678cee5189.png">

## Notes
