### PR TITLE
docs(tup-cms): note core-cms image/commit used

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,3 +1,4 @@
+# TACC/Core-CMS#631 (which bubbles up to TACC/Core-CMS#581@9ff0f1e)
 FROM taccwma/core-cms:4bfdffa
 
 WORKDIR /code


### PR DESCRIPTION
## Overview

Document which Core-CMS image is currently being used.

<sup>Because it is a CMS commit within a branch (`django/2to3--tup-cms--tup-477`) off a branch (`django/2to3--tup-cms`) off a branch (`dev/tup-cms`) off of `main`.</sup>

## Related

- documents a change introduced in #225