### PR TITLE
task/TUP-468 (fix): Default to NOT passing a custom status when replying to tickets

### DIFF
--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketReplyForm.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketReplyForm.tsx
@@ -8,7 +8,7 @@ import {
 } from '@tacc/core-wrappers';
 import { FormGroup } from 'reactstrap';
 import { Button, InlineMessage } from '@tacc/core-components';
-import { useGetTicketDetails, useTicketReply } from '@tacc/tup-hooks';
+import { useTicketReply } from '@tacc/tup-hooks';
 import * as Yup from 'yup';
 import './TicketModal.global.css';
 
@@ -66,9 +66,7 @@ export const TicketReplyForm: React.FC<{ ticketId: string }> = ({
               required
             />
             <FormikSelect name="status" label="Status">
-              <option value="">
-                --
-              </option>
+              <option value="">--</option>
               <option value="new">New</option>
               <option value="resolved">Resolved</option>
               <option value="open">In Progress</option>

--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketReplyForm.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketReplyForm.tsx
@@ -27,12 +27,11 @@ export const TicketReplyForm: React.FC<{ ticketId: string }> = ({
 }) => {
   const mutation = useTicketReply(ticketId);
   const { mutate, isLoading, isError } = mutation;
-  const { data: ticketData } = useGetTicketDetails(ticketId);
 
   const defaultValues: TicketReplyFormValues = {
     text: '',
     files: [],
-    status: ticketData?.Status ?? 'open',
+    status: '',
   };
 
   const onSubmit = (
@@ -42,7 +41,7 @@ export const TicketReplyForm: React.FC<{ ticketId: string }> = ({
     const formData = new FormData();
     formData.append('text', values['text']);
     (values.files || []).forEach((file) => formData.append('files', file));
-    formData.append('status', values['status']);
+    if (values.status) formData.append('status', values.status);
     mutate(formData, {
       onSuccess: () => resetForm(),
     });
@@ -66,7 +65,10 @@ export const TicketReplyForm: React.FC<{ ticketId: string }> = ({
               style={{ maxWidth: '100%' }}
               required
             />
-            <FormikSelect name="status" label="Status" required>
+            <FormikSelect name="status" label="Status">
+              <option value="">
+                --
+              </option>
               <option value="new">New</option>
               <option value="resolved">Resolved</option>
               <option value="open">In Progress</option>


### PR DESCRIPTION
## Overview
Default to having RT set the status for tickets if the user doesn't make a selection. This restores the intended behavior of having replies to resolved tickets set the ticket status back to "open".
## Related

- [TUP-468](https://jira.tacc.utexas.edu/browse/TUP-468)

## UI
<img width="580" alt="image" src="https://github.com/TACC/tup-ui/assets/12601812/9667843a-cff5-4d44-b846-832c2dbfccc4">


