### PR TITLE
task/TUP-511: Require superuser status to impersonate others

### DIFF
--- a/apps/tup-cms/src/apps/portal/views.py
+++ b/apps/tup-cms/src/apps/portal/views.py
@@ -34,7 +34,7 @@ def LogoutView(request):
 
 def ImpersonateView(request):
     resp = HttpResponseRedirect("/portal/dashboard")
-    if not request.user.is_staff:
+    if not request.user.is_superuser:
         return resp
 
     headers = {"x-tup-token": settings.TUP_SERVICES_ADMIN_JWT}

--- a/apps/tup-cms/src/apps/portal_nav/templates/portal_nav/nav_portal.raw.html
+++ b/apps/tup-cms/src/apps/portal_nav/templates/portal_nav/nav_portal.raw.html
@@ -39,7 +39,7 @@
     <a class="dropdown-item" href="/portal/account">
       <i class="icon icon-user"></i> Manage Account
     </a>
-    {% if user.is_staff %}
+    {% if user.is_superuser %}
     <a class="dropdown-item" href="/portal/impersonation">
       <i class="icon icon-user"></i> Impersonate User
     </a>


### PR DESCRIPTION
## Overview
Some users need "staff" status to edit CMS content but should NOT be allowed to impersonate users. Existing impersonators will be upgraded to "superuser" status and the impersonation endpoint will be changed to require that status. 
## Related

- [TUP-511](https://jira.tacc.utexas.edu/browse/TUP-511)

