### PR TITLE
task/TUP-512: remove Maverick2 from ticket creation form

### DIFF
--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -108,7 +108,6 @@ export const TicketCreateForm: React.FC = () => {
             <option>Jetstream(jetstream.tacc.utexas.edu)</option>
             <option>Lonestar6(lonestar6.tacc.utexas.edu)</option>
             <option>Longhorn(longhorn.tacc.utexas.edu)</option>
-            <option>Maverick2(maverick2.tacc.utexas.edu)</option>
             <option>Ranch(ranch.tacc.utexas.edu)</option>
             <option>Stampede2(stampede2.tacc.utexas.edu)</option>
             <option>Vislab(stallion.tacc.utexas.edu)</option>


### PR DESCRIPTION
## Overview
Maverick2 is being decommissioned, so this PR removes it from the "resources" dropdown when creating a ticket.
## Related

- [TUP-512](https://jira.tacc.utexas.edu/browse/TUP-512)

