### PR TITLE
task/TUP-516: Prevent users from getting locked into SMS pairing

### DIFF
--- a/libs/tup-components/src/mfa/MfaSelection.tsx
+++ b/libs/tup-components/src/mfa/MfaSelection.tsx
@@ -5,7 +5,6 @@ import { Link, Navigate } from 'react-router-dom';
 import { useMfa } from '@tacc/tup-hooks';
 
 const MfaSelector: React.FC = () => {
-
   return (
     <div className={styles['mfa-type-container']}>
       Select whether you want to use an MFA token app or SMS texting for

--- a/libs/tup-components/src/mfa/MfaSelection.tsx
+++ b/libs/tup-components/src/mfa/MfaSelection.tsx
@@ -5,16 +5,6 @@ import { Link, Navigate } from 'react-router-dom';
 import { useMfa } from '@tacc/tup-hooks';
 
 const MfaSelector: React.FC = () => {
-  const { data } = useMfa();
-
-  // If users have already generated a code with one method,
-  // they will need to complete registration with that method.
-  if (data?.token && data?.token.tokentype === 'sms') {
-    return <Navigate to="/mfa/sms" replace={true} />;
-  }
-  if (data?.token && data?.token.tokentype === 'totp') {
-    return <Navigate to="/mfa/totp" replace={true} />;
-  }
 
   return (
     <div className={styles['mfa-type-container']}>

--- a/libs/tup-components/src/mfa/MfaValidationPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaValidationPanel.tsx
@@ -14,8 +14,8 @@ const MfaValidationPanel: React.FC<{ tokenType: 'totp' | 'sms' }> = ({
   };
 
   const pairingMessage = {
-    sms: '2. Enter the token shown in the app to continue the pairing.',
-    totp: '2. Enter the token sent to your phone number.',
+    totp: '2. Enter the token shown in the app to continue the pairing.',
+    sms: '2. Enter the token sent to your phone number.',
   };
 
   return (


### PR DESCRIPTION
## Overview
Frontend component of TUP-516. Prevents users from being automatically redirected to the SMS pairing screen if they have previously generated an SMS token and backed out before verifying it.

## Related

- [TUP-516](https://jira.tacc.utexas.edu/browse/TUP-516)


## Testing

1. Unpair your current MFA token.
2. Click "pair device" and enter your phone number for SMS pairing, but DO NOT validate with the code.
3. Back out of MFA pairing and attempt to pair using a token app.

