### PR TITLE
task/TUP-511: Use a specific Impersonator group to manage impersonation permissions.

### DIFF
--- a/apps/tup-cms/src/apps/portal/views.py
+++ b/apps/tup-cms/src/apps/portal/views.py
@@ -34,7 +34,7 @@ def LogoutView(request):
 
 def ImpersonateView(request):
     resp = HttpResponseRedirect("/portal/dashboard")
-    if not request.user.is_superuser:
+    if not request.user.groups.filter(name='Impersonator').exists():
         return resp
 
     headers = {"x-tup-token": settings.TUP_SERVICES_ADMIN_JWT}

--- a/apps/tup-cms/src/apps/portal/views.py
+++ b/apps/tup-cms/src/apps/portal/views.py
@@ -34,6 +34,10 @@ def LogoutView(request):
 
 def ImpersonateView(request):
     resp = HttpResponseRedirect("/portal/dashboard")
+
+    if not request.user:
+        return resp
+
     if not request.user.groups.filter(name='Impersonator').exists():
         return resp
 

--- a/apps/tup-cms/src/apps/portal_nav/templates/portal_nav/nav_portal.raw.html
+++ b/apps/tup-cms/src/apps/portal_nav/templates/portal_nav/nav_portal.raw.html
@@ -39,7 +39,7 @@
     <a class="dropdown-item" href="/portal/account">
       <i class="icon icon-user"></i> Manage Account
     </a>
-    {% if user.is_superuser %}
+    {% if show_impersonation %}
     <a class="dropdown-item" href="/portal/impersonation">
       <i class="icon icon-user"></i> Impersonate User
     </a>

--- a/apps/tup-cms/src/apps/portal_nav/views.py
+++ b/apps/tup-cms/src/apps/portal_nav/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import authenticate
 
 def PortalNavView(request):
     user = authenticate(request)
-    context = {'user': user}
+    is_impersonator = user.groups.filter(name='Impersonator').exists()
+    context = {'user': user, 'show_impersonation': is_impersonator}
     template = loader.get_template('portal_nav/nav_portal.raw.html')
     return HttpResponse(template.render(context, request))

--- a/apps/tup-cms/src/apps/portal_nav/views.py
+++ b/apps/tup-cms/src/apps/portal_nav/views.py
@@ -5,7 +5,9 @@ from django.contrib.auth import authenticate
 
 def PortalNavView(request):
     user = authenticate(request)
-    is_impersonator = user.groups.filter(name='Impersonator').exists()
+    is_impersonator = False
+    if user:
+        is_impersonator = user.groups.filter(name='Impersonator').exists()
     context = {'user': user, 'show_impersonation': is_impersonator}
     template = loader.get_template('portal_nav/nav_portal.raw.html')
     return HttpResponse(template.render(context, request))


### PR DESCRIPTION
## Overview
Use a specific Impersonator group to manage impersonation permissions.

## Related

- [TUP-511](https://jira.tacc.utexas.edu/browse/TUP-511)

## Changes

## Testing

1. Add yourself to the Impersonator group (create it if it doesn't exist)
2. Check that you can impersonate users via the nav dropdown.
3. Remove yourself from Impersonator and make sure your permissions are actually revoked.
