### PR TITLE
feat(tup-cms): TACC/Core-CMSv3.12.0-alpha.3

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#631 (which bubbles up to TACC/Core-CMS#581@9ff0f1e)
-FROM taccwma/core-cms:4bfdffa
+# TACC/Core-CMSv3.12.0-alpha.3
+FROM taccwma/core-cms:7b1b6cf
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-# TACC/Core-CMSv3.12.0-alpha.3
+# TACC/Core-CMS#v3.12.0-alpha.3 (via TACC/Core-CMS#581)
 FROM taccwma/core-cms:7b1b6cf
 
 WORKDIR /code

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.12.0-alpha.3 (via TACC/Core-CMS#581)
-FROM taccwma/core-cms:7b1b6cf
+# TACC/Core-CMS#v3.12.0-alpha.4 (via TACC/Core-CMS#581)
+FROM taccwma/core-cms:4fe44ca
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Install image gallery (and inherit Core-CMS v3.11 updates that should not affect TUP).

## Related

- [TUP-318](https://jira.tacc.utexas.edu/browse/TUP-318)
- https://github.com/TACC/Core-CMS/pull/654
- includes Core-CMS v3.11 code like #232

## Changes

- **changed** core-cms image tag

## Testing

1. Create a TACC: Image Gallery plugin instance on a page.
2. Create many Image plugins within the Image Gallery.
3. Refresh the page.
4. Verify image grid looks good and clicking on image opens [a lightGalleryJS instance](https://www.lightgalleryjs.com/demos/thumbnails/).

## UI

…