### PR TITLE
fix(tup-components, tup-ui): tup-519 UserNews component UI

### DIFF
--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -45,6 +45,10 @@ h2 {
   font-size: var(--global-font-size--large);
   font-weight: var(--bold);
 }
+h3 {
+  font-size: var(--global-font-size--medium);
+  font-weight: var(--bold);
+}
 
 /* Tables */
 table {

--- a/apps/tup-ui/src/main.global.for-core-styles.css
+++ b/apps/tup-ui/src/main.global.for-core-styles.css
@@ -31,3 +31,13 @@ hr {
   width: 16px;
   height: 16px;
 }
+
+/* TODO: Remove this after:
+         0. attributes.css is migrated to Core-Styles
+         1. attributes.css is loaded by Portal */
+[data-prefix]::before {
+    display: inline-block;
+    content: attr(data-prefix);
+    margin-right: 0.25ch;
+    text-transform: none;
+}

--- a/apps/tup-ui/src/main.global.for-core-styles.css
+++ b/apps/tup-ui/src/main.global.for-core-styles.css
@@ -36,8 +36,8 @@ hr {
          0. attributes.css is migrated to Core-Styles
          1. attributes.css is loaded by Portal */
 [data-prefix]::before {
-    display: inline-block;
-    content: attr(data-prefix);
-    margin-right: 0.25ch;
-    text-transform: none;
+  display: inline-block;
+  content: attr(data-prefix);
+  margin-right: 0.25ch;
+  text-transform: none;
 }

--- a/libs/tup-components/src/news/UserNews.module.css
+++ b/libs/tup-components/src/news/UserNews.module.css
@@ -1,22 +1,22 @@
 .news-list {
-    font-size: var(--global-font-size--small);
+  font-size: var(--global-font-size--small);
 }
 
 .news-list-item {
-    padding-block: 10px;
-    border-top: var(--global-border-width--normal) solid var(--global-color-primary--dark);
+  padding-block: 10px;
+  border-top: var(--global-border-width--normal) solid var(--global-color-primary--dark);
 }
 
 .body {
-    composes: x-truncate--many-lines from '@tacc/core-styles/dist/tools/x-truncate.css';
+  composes: x-truncate--many-lines from '@tacc/core-styles/dist/tools/x-truncate.css';
 
-    margin-bottom: 1.15rem;
+  margin-bottom: 1.15rem;
 }
 
 .posted-date {
-    color: var(--global-color-accent--secondary);
-    font-weight: var(--medium);
-    text-transform: uppercase;
+  color: var(--global-color-accent--secondary);
+  font-weight: var(--medium);
+  text-transform: uppercase;
 }
 .posted-date .status-pill {
   text-transform: none;
@@ -26,25 +26,25 @@
 }
 
 .status-pill {
-    margin-left: 0.5ch;
-    vertical-align: middle;
+  margin-left: 0.5ch;
+  vertical-align: middle;
 
-    /* Mimics .c-pill font-size */
-    /* TODO: Update <Pill> to use .c-pill, then remove this */
-    font-size: var(--global-font-size--x-small);
+  /* Mimics .c-pill font-size */
+  /* TODO: Update <Pill> to use .c-pill, then remove this */
+  font-size: var(--global-font-size--x-small);
 }
 
 .title {
-    composes: x-truncate--many-lines from '@tacc/core-styles/dist/tools/x-truncate.css';
+  composes: x-truncate--many-lines from '@tacc/core-styles/dist/tools/x-truncate.css';
 
-    margin-top: 10px;
-    margin-bottom: 5px;
+  margin-top: 10px;
+  margin-bottom: 5px;
 }
 
 .news-error {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: var(--global-color-accent--normal);
-    padding: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--global-color-accent--normal);
+  padding: 30px;
 }

--- a/libs/tup-components/src/news/UserNews.module.css
+++ b/libs/tup-components/src/news/UserNews.module.css
@@ -1,38 +1,37 @@
 .news-list {
-    padding: 0px;
+    font-size: var(--global-font-size--small);
 }
 
 .news-list-item {
-    list-style: none;
-    border-top: 1px solid #707070;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-block: 10px;
+    border-top: var(--global-border-width--normal) solid var(--global-color-primary--dark);
 }
 
 .body {
-    display: -webkit-box;
-    font-size: 1rem;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+    composes: x-truncate--many-lines from '@tacc/core-styles/dist/tools/x-truncate.css';
+
+    margin-bottom: 1.15rem;
 }
 
 .posted-date {
-    font-size: 1rem;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+    color: var(--global-color-accent--secondary);
+    font-weight: var(--medium);
+    text-transform: uppercase;
 }
-
 .status-pill {
-    padding-bottom: 0px;
-    padding-top: 0px;
-    margin-left: 1rem;
+    margin-left: 0.5ch;
+    vertical-align: middle;
+
+    /* Mimics .c-pill font-size */
+    /* TODO: Update <Pill> to use .c-pill, then remove this */
+    font-size: var(--global-font-size--x-small);
 }
 
 .title {
-    font-size: 1.25rem;
-    font-weight: bolder;
+    composes: x-truncate--many-lines from '@tacc/core-styles/dist/tools/x-truncate.css';
+
+    margin-top: 10px;
+    margin-bottom: 5px;
 }
 
 .news-error {

--- a/libs/tup-components/src/news/UserNews.module.css
+++ b/libs/tup-components/src/news/UserNews.module.css
@@ -18,6 +18,13 @@
     font-weight: var(--medium);
     text-transform: uppercase;
 }
+.posted-date .status-pill {
+  text-transform: none;
+
+  vertical-align: middle;
+  transform: translateY(-0.125em);
+}
+
 .status-pill {
     margin-left: 0.5ch;
     vertical-align: middle;

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -48,7 +48,7 @@ const UserNews: React.FC = () => {
             <article className={styles['news-list-item']} key={newsItem.ID}>
               <time
                 className={styles['posted-date']}
-                data-prefix="Posted:"
+                data-prefix="Published:"
                 dateTime={formatDateTime(newsItem.PostedDate)}
               >
                 {formatDate(newsItem.PostedDate)}

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -9,8 +9,17 @@ import styles from './UserNews.module.css';
 
 const formatDate = (datestring: string): string => {
   const date = new Date(datestring);
-  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
 };
+const formatDateTime = (datestring: string): string => {
+  const date = new Date(datestring);
+  return date.toISOString();
+};
+
 const ViewAllUpdates = () => (
   <a
     href={`/news/user-updates/`}
@@ -31,31 +40,33 @@ const UserNews: React.FC = () => {
       headerActions={<ViewAllUpdates />}
       contentShouldScroll
     >
-      <ul className={styles['news-list']}>
+      <div className={styles['news-list']}>
         {data &&
           data.slice(0, 12).map((newsItem) => (
-            <li className={styles['news-list-item']} key={newsItem.ID}>
-              <div className={styles['posted-date']}>
-                <span>Posted {formatDate(newsItem.PostedDate)} </span>
-                {newsItem.Updates && (
-                  <Pill type="updated" className={styles['status-pill']}>
-                    Updated
-                  </Pill>
-                )}
-              </div>
-              <div className={styles['title']}>
+            <article className={styles['news-list-item']} key={newsItem.ID}>
+              <time className={styles['posted-date']}
+                    data-prefix="Posted:"
+                    dateTime={formatDateTime(newsItem.PostedDate)}>
+                {formatDate(newsItem.PostedDate)}
+              </time>
+              <h3 className={styles['title']}>
                 <a
                   href={`/news/user-updates/${newsItem.ID}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {newsItem.WebTitle}
+                  {newsItem.WebTitle.trim()}
                 </a>
-              </div>
-              <div className={styles['body']}>{newsItem.Content}</div>
-            </li>
+                {newsItem.Updates && (
+                  <Pill type="updated" className={styles['status-pill']}>
+                    Updated
+                  </Pill>
+                )}
+              </h3>
+              <p className={styles['body']}>{newsItem.Content}</p>
+            </article>
           ))}
-      </ul>
+      </div>
     </SectionTableWrapper>
   );
 };

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -33,6 +33,8 @@ const ViewAllUpdates = () => (
 
 const UserNews: React.FC = () => {
   const { data, isLoading } = useUserNews();
+  const maxItems = 5;
+
   if (isLoading) return <LoadingSpinner />;
   return (
     <SectionTableWrapper
@@ -42,7 +44,7 @@ const UserNews: React.FC = () => {
     >
       <div className={styles['news-list']}>
         {data &&
-          data.slice(0, 12).map((newsItem) => (
+          data.slice(0, maxItems).map((newsItem) => (
             <article className={styles['news-list-item']} key={newsItem.ID}>
               <time className={styles['posted-date']}
                     data-prefix="Posted:"

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -46,9 +46,11 @@ const UserNews: React.FC = () => {
         {data &&
           data.slice(0, maxItems).map((newsItem) => (
             <article className={styles['news-list-item']} key={newsItem.ID}>
-              <time className={styles['posted-date']}
-                    data-prefix="Posted:"
-                    dateTime={formatDateTime(newsItem.PostedDate)}>
+              <time
+                className={styles['posted-date']}
+                data-prefix="Posted:"
+                dateTime={formatDateTime(newsItem.PostedDate)}
+              >
                 {formatDate(newsItem.PostedDate)}
               </time>
               <h3 className={styles['title']}>

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -63,7 +63,7 @@ const UserNews: React.FC = () => {
                 </a>
                 {newsItem.Updates && (
                   <Pill type="updated" className={styles['status-pill']}>
-                    Updated
+                    Update
                   </Pill>
                 )}
               </h3>

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -52,6 +52,11 @@ const UserNews: React.FC = () => {
                 dateTime={formatDateTime(newsItem.PostedDate)}
               >
                 {formatDate(newsItem.PostedDate)}
+                {newsItem.Updates && (
+                  <Pill type="updated" className={styles['status-pill']}>
+                    Update
+                  </Pill>
+                )}
               </time>
               <h3 className={styles['title']}>
                 <a
@@ -61,11 +66,6 @@ const UserNews: React.FC = () => {
                 >
                   {newsItem.WebTitle.trim()}
                 </a>
-                {newsItem.Updates && (
-                  <Pill type="updated" className={styles['status-pill']}>
-                    Update
-                  </Pill>
-                )}
               </h3>
               <p className={styles['body']}>{newsItem.Content}</p>
             </article>


### PR DESCRIPTION
## Overview

Make "User Updates" more closely match CMS markup and styles.

<sup>Ideally, these lists use the same classes and even markup. Not yet. I'll do that in another PR.</sup>

## Related

- [**TUP-519**](https://jira.tacc.utexas.edu/browse/TUP-519)
- [TUP-532](https://jira.tacc.utexas.edu/browse/TUP-532)
- does **not** fix [TUP-490](https://jira.tacc.utexas.edu/browse/TUP-490) **nor** [TUP-422](https://jira.tacc.utexas.edu/browse/TUP-422)

## Changes

- **added** global `<h3>` styles
    <sup>(probably destined for core-styles)</sup>
- **added** global `[data-prefix]` styles
    <sup>(destined for core-styles)</sup>
- **changed** `UserNews.module.css`
    <sup>(to mimic `.c-feed-list` used by `user_news` app)</sup>
    <sup>(placeholder fixes until portal uses `.c-feed-list`)</sup>
- **changed** `UserNews.tsx`
    <sup>(to mimic markup from `user_news` app)</sup>
    <sup>(to mimic fixes from #249)</sup>
- **added** `maxItems` to store count of User Updates to show
- **changed** "Updated" pill to say "Update"
- **changed** "Posted" pill to say "Published"
- **removed** _inconsistent_ whitespace from title
- **added** _consistent_ whitespace from title

## Testing

1. Compare Portal "User Updates" to "User Updates" plugin (e.g. on [homepage halfway-down](https://tacc.utexas.edu/#user-updates)).
2. Verify only 5 User Updates are shown.
3. Verify date, title, summary, and any "Update" pill in Portal match CMS in:
    - font size
    - spacing
    - html tags
        <sup>(except article title `<h3>` vs. `<h4>` because of page hierarchy)</sup>
	- pill text
	    <sup>(but not pill size yet, because `<Pill>` does not use `c-pill` yet)</sup>
4. Verify space between "Update" pill and article title comes from CSS not whitespace character in title hyperlink.

## UI

| | cms | portal |
| - | - | - |
| date | ![cms - time](https://github.com/TACC/tup-ui/assets/62723358/e3f5f286-bac7-4de1-bbbd-bf05b5061015) | ![portal -date](https://github.com/TACC/tup-ui/assets/62723358/e7852b6b-69ad-49bb-84f8-209bd67b4b2a)
| title | ![cms - title](https://github.com/TACC/tup-ui/assets/62723358/e7cbe107-3622-4e6d-a7f9-7252d65c0e56) | ![portal -title](https://github.com/TACC/tup-ui/assets/62723358/f022d0d9-77ef-49fb-bd11-75e33a3b8780)
| pill | ![cms - pill](https://github.com/TACC/tup-ui/assets/62723358/789260a3-5b0d-4ca0-8146-5d2ba4e7df60) | ![portal -pill](https://github.com/TACC/tup-ui/assets/62723358/5b5f582e-244a-4e5c-bc94-993ed231b74a)
| summary | ![cms - summary](https://github.com/TACC/tup-ui/assets/62723358/543b5c40-f01a-4ac0-9365-4514bd220f1e) | ![portal -summary](https://github.com/TACC/tup-ui/assets/62723358/a8c1b235-483a-44a9-ad7e-4f9f9f37a0f4)

## Notes

1. Font in CMS is "Benton Sans". Font in Portal is "Roboto".
2. The "Update" pill in Portal is too small[^1]. Expect fix in [TUP-490](https://jira.tacc.utexas.edu/browse/TUP-490). 

[^1]: Because "Roboto" font is smaller than "Benton Sans" font.