### PR TITLE
fix(tup-cms): tup-532 user_news plugin UI

### DIFF
--- a/apps/tup-cms/src/apps/user_news/defaults.py
+++ b/apps/tup-cms/src/apps/user_news/defaults.py
@@ -1,4 +1,4 @@
-max_articles = 3
+max_articles = 4 # HACK: for testing tup-ui#249, do not merge
 
 urls = {
   'base': 'news/user-updates/',

--- a/apps/tup-cms/src/apps/user_news/defaults.py
+++ b/apps/tup-cms/src/apps/user_news/defaults.py
@@ -1,4 +1,4 @@
-max_articles = 4 # HACK: for testing tup-ui#249, do not merge
+max_articles = 3
 
 urls = {
   'base': 'news/user-updates/',

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/item_data.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/item_data.html
@@ -13,6 +13,9 @@
         <time datetime="{{ article.postDateTime }}">
             {{ article.postDate }}
         </time>
+        {% if article.updates %}
+        <span class="c-pill c-pill--is-updated">Update</span>
+        {% endif %}
     </li>
     {% endif %}
 {% endspaceless %}</ul>

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/item_data.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/item_data.html
@@ -10,9 +10,7 @@
     {% if article.postDateTime %}
     <li class="c-news__date">
         <span>{% trans "Published" %}</span>&nbsp;
-        <time datetime="{{ article.postDateTime }}">
-            {{ article.postDate }}
-        </time>
+        <time datetime="{{ article.postDateTime }}">{{ article.postDate }}</time>
         {% if article.updates %}
         <span class="c-pill c-pill--is-updated">Update</span>
         {% endif %}

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item.html
@@ -9,9 +9,6 @@
             <a href="/{{ urls.base }}{{ urls.item_prefix }}{{ article.id }}">
                 {{ article.title }}
             </a>
-            {% if article.updates %}
-                <span class="c-pill c-pill--is-updated">Update</span>
-            {% endif %}
         </{{ title_tag|default:"h3" }}>
         {% if article.subtitle %}
         <{{ subtitle_tag|default:"h4" }} class="c-news__subtitle">

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item_for_plugin.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item_for_plugin.html
@@ -2,15 +2,15 @@
 
   <article class="{% if article.updates %}has-update{% endif %}">
     <time data-prefix="Published:" datetime="{{ article.postDateTime }}">
-      {{ article.postDate }}
+      <span>{{ article.postDate }}</span>
+      {% if article.updates %}
+        <span class="c-pill c-pill--is-updated">Update</span>
+      {% endif %}
     </time>
     <h4>
       <a href="/{{ urls.base }}{{ urls.item_prefix }}{{ article.id }}">
         {{ article.title }}
       </a>
-      {% if article.updates %}
-        <span class="c-pill c-pill--is-updated">Update</span>
-      {% endif %}
     </h4>
     {% if article.subttitle %}
     <h5>{{ article.subttitle }}</h5>

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item_for_plugin.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item_for_plugin.html
@@ -7,10 +7,10 @@
     <h4>
       <a href="/{{ urls.base }}{{ urls.item_prefix }}{{ article.id }}">
         {{ article.title }}
-        {% if article.updates %}
-          <span class="c-pill c-pill--is-updated">Update</span>
-        {% endif %}
       </a>
+      {% if article.updates %}
+        <span class="c-pill c-pill--is-updated">Update</span>
+      {% endif %}
     </h4>
     {% if article.subttitle %}
     <h5>{{ article.subttitle }}</h5>

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item_for_plugin.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item_for_plugin.html
@@ -1,7 +1,7 @@
 {% if article %}
 
   <article class="{% if article.updates %}has-update{% endif %}">
-    <time data-prefix="Posted:" datetime="{{ article.postDateTime }}">
+    <time data-prefix="Published:" datetime="{{ article.postDateTime }}">
       {{ article.postDate }}
     </time>
     <h4>

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item_for_plugin.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/list_item_for_plugin.html
@@ -1,6 +1,7 @@
 {% if article %}
 
   <article class="{% if article.updates %}has-update{% endif %}">
+  {% spaceless %}
     <time data-prefix="Published:" datetime="{{ article.postDateTime }}">
       <span>{{ article.postDate }}</span>
       {% if article.updates %}
@@ -20,6 +21,7 @@
     {% else %}
     <p>{{ article.content }}</p>
     {% endif %}
+  {% endspaceless %}
   </article>
 
 {% else %}

--- a/apps/tup-cms/src/apps/user_news/utils.py
+++ b/apps/tup-cms/src/apps/user_news/utils.py
@@ -66,7 +66,7 @@ def create_proxy_article(article):
 
   context_article = {
     'id': article['ID'],
-    'title': article['WebTitle'],
+    'title': article['WebTitle'].strip(),
     'content': article['Content'],
     'subtitle': article['Subtitle'],
     'author': article['Author'],

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -41,6 +41,7 @@
 
 /* To style "Update" pill in title */
 .c-feed-list :is(h1, h2, h3, h4, h5, h6) > .c-pill {
+  margin-left: 0.5ch;
   vertical-align: middle;
   transform: translateY(-0.125em);
 }

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -40,7 +40,7 @@
 }
 
 /* To style "Update" pill in title */
-.c-feed-list :is(h1, h2, h3, h4, h5, h6) > .c-pill {
+.c-feed-list .c-pill {
   margin-left: 0.5ch;
   vertical-align: middle;
   transform: translateY(-0.125em);

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -40,7 +40,7 @@
 }
 
 /* To style "Update" pill in title */
-.c-feed-list > :is(h1, h2, h3, h4, h5, h6) .c-pill {
+.c-feed-list :is(h1, h2, h3, h4, h5, h6) > .c-pill {
   vertical-align: middle;
   transform: translateY(-0.125em);
 }

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--list.css
@@ -144,6 +144,7 @@
 
 /* To style "Update" pill in title */
 .c-news .c-pill {
+  margin-left: 0.5ch;
   vertical-align: middle;
   transform: translateY(-0.125em);
 }

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--list.css
@@ -143,7 +143,7 @@
 }
 
 /* To style "Update" pill in title */
-.c-news__title .c-pill {
+.c-news .c-pill {
   vertical-align: middle;
   transform: translateY(-0.125em);
 }


### PR DESCRIPTION
## Overview

Fix "User Updates" plugin UI bugs (also in #248 for portal).

## Related

- [TUP-532](https://jira.tacc.utexas.edu/browse/TUP-532)
- found during #248

## Changes

- **changed** "Update" pill to be in date (not title)
- **changed** date to be prefixed by the text "Published: " (not "Posted: ")
- **removed** _inconsistent_ whitespace from title
- **added** _consistent_ whitespace from title

## Testing

1. Verify "Update" pill markup is moved from title to date.
2. Verify "Update" pill has no visual change compared to production.
3. Verify date is prefixed by the text "Published: " (not "Posted: ").
4. Verify space between "Update" pill and article title comes from CSS not whitespace character in title hyperlink.

## UI

| | html space<br /><sup>(none)</sup> | css space<br /><sup>(some)</sup> |
| - | - | - |
| p<br>l<br>u<br>g<br>i<br>n | ![plugin - html space](https://github.com/TACC/tup-ui/assets/62723358/ad143add-e1a3-4f38-9519-f79ec43409b7) | ![plugin - css space](https://github.com/TACC/tup-ui/assets/62723358/31758495-8f67-43af-9fc9-c6a29d88bf31) |
| p<br>a<br>g<br>e | ![news list - space html](https://github.com/TACC/tup-ui/assets/62723358/62cbf2f4-e92a-47bb-8142-9fa2c466caa4) | ![news list - space css](https://github.com/TACC/tup-ui/assets/62723358/f80a7d96-8249-4de9-98c7-bfd8b226af8c) |