### PR TITLE
disable real-time haystack indexing on cms content

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -47,6 +47,8 @@ CMS_CACHE_DURATIONS = {
 RECAPTCHA_PRIVATE_KEY = ''
 RECAPTCHA_PUBLIC_KEY = ''
 
+HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.BaseSignalProcessor'
+
 ########################
 # TACC: GOOGLE ANALYTICS
 ########################


### PR DESCRIPTION
Disable realtime Haystack indexing, since we're using Google as the search engine on the TACC site.
