### PR TITLE
feat: support smaller windows

### DIFF
--- a/libs/tup-components/src/system_monitor/details/SystemDetails.module.css
+++ b/libs/tup-components/src/system_monitor/details/SystemDetails.module.css
@@ -1,13 +1,3 @@
-.listing-section > div {
-    display: flex;
-    flex-direction: column;
-    gap: 40px;
-}
-
-.root td {
-    vertical-align: middle;
-  }
-  
 /* systems navbar */
 .systems-listing-navbar {
   height: 100%;
@@ -19,7 +9,50 @@
 .systems-listing-navbar > a > div {
   padding-left: var(--global-space--section-left);
 }
-/* systems listing */
-.systems-listing {
-  margin-bottom: unset; /* undo core-styles.base.css */
+
+
+
+
+
+@import url('@tacc/core-styles/src/lib/_imports/tools/media-queries.css');
+
+.panels {
+  display: grid;
+
+  /* To reproduce complex layout of design doc */
+  @media (--wide-and-above) {
+    gap: 25px;
+    grid-template-columns: 0.5fr 0.5fr;
+    overflow: auto;
+    grid-template-areas:
+      "monitor_queue avgwait";
+  }
+  /* To reproduce simple layout of narrow screens like CEPv2 */
+  @media (--wide-and-below) {
+    row-gap: 25px;
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+      "monitor_queue"
+      "avgwait";
+  }
 }
+.panels > * {
+	overflow: auto; /* to force items to stay within their grid cells */
+}
+
+.monitor_queue-panel { grid-area: monitor_queue; }
+.avgwait-panel { grid-area: avgwait; }
+
+.monitor_queue-panel {
+  display: grid;
+  gap: 25px;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    "monitor"
+    "queue";
+}
+.monitor_queue-panel > * {
+  overflow: auto;
+}
+.monitor_queue-panel > :nth-child(1) { grid-area: monitor; }
+.monitor_queue-panel > :nth-child(2) { grid-area: queue; }

--- a/libs/tup-components/src/system_monitor/details/SystemDetails.tsx
+++ b/libs/tup-components/src/system_monitor/details/SystemDetails.tsx
@@ -56,7 +56,10 @@ const SystemQueueTable: React.FC<{
   if (isLoading) return <LoadingSpinner />;
 
   return (
-    <table {...getTableProps()} className={`${styles['systems-listing']} o-fixed-header-table`}>
+    <table
+      {...getTableProps()}
+      className={`${styles['systems-listing']} o-fixed-header-table`}
+    >
       <thead>
         {headerGroups.map((headerGroup) => (
           <tr {...headerGroup.getHeaderGroupProps()}>
@@ -117,9 +120,7 @@ const SystemDetails: React.FC<{
             <SystemQueueTable tas_name={`${tas_name}`} />
           </SectionTableWrapper>
         </div>
-        <div className={`${styles['avgwait-panel']}`}>
-          Avg. Wait Time
-        </div>
+        <div className={`${styles['avgwait-panel']}`}>Avg. Wait Time</div>
       </div>
     )
   );

--- a/libs/tup-components/src/system_monitor/details/SystemDetails.tsx
+++ b/libs/tup-components/src/system_monitor/details/SystemDetails.tsx
@@ -3,7 +3,6 @@ import { useTable, Column } from 'react-table';
 import { EmptyTablePlaceholder } from '../../utils';
 import {
   LoadingSpinner,
-  Section,
   SectionTableWrapper,
   Pill,
 } from '@tacc/core-components';
@@ -57,7 +56,7 @@ const SystemQueueTable: React.FC<{
   if (isLoading) return <LoadingSpinner />;
 
   return (
-    <table {...getTableProps()} className={`${styles['systems-listing']}`}>
+    <table {...getTableProps()} className={`${styles['systems-listing']} o-fixed-header-table`}>
       <thead>
         {headerGroups.map((headerGroup) => (
           <tr {...headerGroup.getHeaderGroupProps()}>
@@ -111,15 +110,17 @@ const SystemDetails: React.FC<{
 
   return (
     systemData && (
-      <Section
-        contentLayoutName="twoColumn"
-        content={
-          <SectionTableWrapper className={`${styles['listing-section']}`}>
-            <SystemMonitor tas_name={tas_name} />
+      <div className={styles['panels']}>
+        <div className={`${styles['monitor_queue-panel']}`}>
+          <SystemMonitor tas_name={tas_name} />
+          <SectionTableWrapper contentShouldScroll>
             <SystemQueueTable tas_name={`${tas_name}`} />
           </SectionTableWrapper>
-        }
-      />
+        </div>
+        <div className={`${styles['avgwait-panel']}`}>
+          Avg. Wait Time
+        </div>
+      </div>
     )
   );
 };


### PR DESCRIPTION
## Overview

Make new systems section accessible on small windows.

## Related

- tweaks #234

## Changes

- **removed** old `SystemDetails` CSS*
- **added** new `SystemDetails` CSS*†
- **changed** `SectionDetails` markup to:
    - wrap only the table that needs to scroll
    - make able to scroll the table that should scroll
    - use markup similar to Dashboard†

<sup>* The `SystemNavBar` CSS is untouched. It should be moved out to its own CSS file; I'll comment about this in #234.</sup>
<sup>† The `Dashboard` layout is most similar to the new design. I referenced its markup and CSS.</sup>

## Testing

1. Open http://localhost:8000/portal/system_status 
2. View layout on wide screen:
    1. All panels with content should stack vertically.
    2. _The panel without content should be on the fight side of those with content._
    3. All panels should have the same space between them.
3. View layout on narrow screen:
    1. All panels (with and without content) should stack vertically.
    2. _The panel without content should be on the bottom._
    3. All panels should have the same space between them.

## UI

| | inner grid | outer gird |
| - | - | - |
| narrow | ![narrow inner](https://github.com/TACC/tup-ui/assets/62723358/de2ebdca-41d3-4cd2-95a0-e40af9b027a1) | ![narrow outer](https://github.com/TACC/tup-ui/assets/62723358/2c928a89-8010-4c2b-8f45-cb06504f7cf3) |
| almost narrow | ![boundary inner](https://github.com/TACC/tup-ui/assets/62723358/a78e756e-f619-4487-a4fe-5f422dfda2d6) | ![boundary outer](https://github.com/TACC/tup-ui/assets/62723358/2e7f2596-4a54-4530-a611-a2ecf66c8f98) |
| wide | ![wide inner](https://github.com/TACC/tup-ui/assets/62723358/fe605c4e-6b7f-4055-b8bf-0c7936d4c36a) | ![wide outer](https://github.com/TACC/tup-ui/assets/62723358/23fcfd80-f319-4396-8497-12e56439827c) |

## Notes

1. This grid layout is too complex. If I simplify it now, the similarity with Dashboard grid is difficult to see and thus learn from. But if I don't simplify it, I set a precedent of copying overly complex grids. I'll probably simplify it…
2. The narrow screen shows extra space instead of "Avg. Wait Time" placeholder content.
2. The "Avg. Wait Time" should not be committed.