### PR TITLE
Task/TUP-457/TUP-514 Add System Queue Details - content layout - phase 2

### DIFF
--- a/libs/tup-components/src/system_monitor/details/SystemDetails.module.css
+++ b/libs/tup-components/src/system_monitor/details/SystemDetails.module.css
@@ -24,36 +24,30 @@
   @media (--wide-and-above) {
     gap: 25px;
     grid-template-columns: 0.5fr 0.5fr;
-    overflow: auto;
+    grid-template-rows: auto 1fr;
     grid-template-areas:
-      "monitor_queue avgwait";
+      "monitor avgwait"
+      "queue avgwait";
   }
   /* To reproduce simple layout of narrow screens like CEPv2 */
   @media (--wide-and-below) {
     row-gap: 25px;
     grid-template-rows: auto 1fr;
     grid-template-areas:
-      "monitor_queue"
+      "monitor"
+      "queue";
+    /* TODO: When avgwait table exists, show it using something like this: *//*
+    grid-template-rows: auto 1fr 1fr;
+    grid-template-areas:
+      "monitor"
+      "queue"
       "avgwait";
+    */
   }
 }
 .panels > * {
 	overflow: auto; /* to force items to stay within their grid cells */
 }
-
-.monitor_queue-panel { grid-area: monitor_queue; }
-.avgwait-panel { grid-area: avgwait; }
-
-.monitor_queue-panel {
-  display: grid;
-  gap: 25px;
-  grid-template-rows: auto 1fr;
-  grid-template-areas:
-    "monitor"
-    "queue";
-}
-.monitor_queue-panel > * {
-  overflow: auto;
-}
-.monitor_queue-panel > :nth-child(1) { grid-area: monitor; }
-.monitor_queue-panel > :nth-child(2) { grid-area: queue; }
+.panels > :nth-child(1) { grid-area: monitor; }
+.panels > :nth-child(2) { grid-area: queue; }
+.panels > :nth-child(3) { grid-area: avgwait; }

--- a/libs/tup-components/src/system_monitor/details/SystemDetails.module.css
+++ b/libs/tup-components/src/system_monitor/details/SystemDetails.module.css
@@ -1,3 +1,4 @@
+
 /* systems navbar */
 .systems-listing-navbar {
   height: 100%;

--- a/libs/tup-components/src/system_monitor/details/SystemDetails.tsx
+++ b/libs/tup-components/src/system_monitor/details/SystemDetails.tsx
@@ -114,13 +114,12 @@ const SystemDetails: React.FC<{
   return (
     systemData && (
       <div className={styles['panels']}>
-        <div className={`${styles['monitor_queue-panel']}`}>
-          <SystemMonitor tas_name={tas_name} />
-          <SectionTableWrapper contentShouldScroll>
-            <SystemQueueTable tas_name={`${tas_name}`} />
-          </SectionTableWrapper>
-        </div>
-        <div className={`${styles['avgwait-panel']}`}>Avg. Wait Time</div>
+        <SystemMonitor tas_name={tas_name} />
+        <SectionTableWrapper contentShouldScroll>
+          <SystemQueueTable tas_name={`${tas_name}`} />
+        </SectionTableWrapper>
+        {/* TODO: When avgwait table exists, update CSS grid to show it */}
+        {/* <div>Avg. Wait Time</div> */}
       </div>
     )
   );


### PR DESCRIPTION
## Overview

Simplify system section layout code.

## Related

- tweaks #234
    <sup>(via #257)</sup>
- follow up to #256

## Changes

- **changed** `SystemDetails` grid layout to not use a nested grid

## Testing

1. Open http://localhost:8000/portal/system_status 
2. View layout on wide screen:
    1. All panels with content should stack vertically.
    2. _The panel without content must be on the fight side of those with content._
    3. All panels must have the same space between them.
    4. Extra space must not exist.*
3. View layout on narrow screen:
    1. All panels (with and without content) should stack vertically.
    2. _The panel without content must be on the bottom._
    3. All panels must have the same space between them.
    4. Extra space must not exist.*
    5. Panel with more rows than can be shown must have scroll bar.

## UI

| | short | tall |
| - | - | - |
| narrow | ![narrow + short](https://github.com/TACC/tup-ui/assets/62723358/95e70f30-400b-4f2c-a918-f07378e968f3) | ![narrow + tall](https://github.com/TACC/tup-ui/assets/62723358/90ed85f6-167b-4e48-b271-1b5d989b41d0) |
| wide | ![wide + short](https://github.com/TACC/tup-ui/assets/62723358/23d9a405-7029-4cc4-b884-e73ab525071e) | ![wide + tall](https://github.com/TACC/tup-ui/assets/62723358/25b004c4-9e3d-46cc-b9c3-7e80ec7e579f) |
| x. wide | ![extra wide + short](https://github.com/TACC/tup-ui/assets/62723358/a01ebbec-b5a9-4e2d-9c30-581b6d614a9e) | ![extra wide + tall](https://github.com/TACC/tup-ui/assets/62723358/692ab07a-aa3b-4402-8d33-9662cc65448a) |
