### PR TITLE
Task/tup 533:  Remove duplicate Login option from ticket form

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -13,7 +13,9 @@ if settings.DEBUG:
 
 
 QUEUE_MAP = {
-    "Allocations": "Accounting",
+    "Allocations": "Allocations",
+    "Login Issues": "Accounts",
+    "Multi-factor Authentication": "MFA",
     "Data Analytics or Storage Resources": "Data Intensive Computing",
     "Login/Authentication Issue": "Accounting",
     "Running Jobs or Using TACC Resources": "High Performance Computing",

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -97,6 +97,8 @@ export const TicketCreateForm: React.FC = () => {
             <option>Login/Authentication Issue</option>
             <option>Running Jobs or Using TACC Resources</option>
             <option>Security Incident</option>
+            <option>Login Issues</option>
+            <option>Multi-factor Authentication</option>
             <option>Other</option>
           </FormikSelect>
           <FormikSelect name="resource" label="System/Resource" required>

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -94,7 +94,6 @@ export const TicketCreateForm: React.FC = () => {
             <option value="">Please Choose One</option>
             <option>Allocations</option>
             <option>Data Analytics or Storage Resources</option>
-            <option>Login/Authentication Issue</option>
             <option>Running Jobs or Using TACC Resources</option>
             <option>Security Incident</option>
             <option>Login Issues</option>

--- a/libs/tup-components/src/tickets/index.ts
+++ b/libs/tup-components/src/tickets/index.ts
@@ -4,7 +4,9 @@ export { default as Tickets } from './Tickets';
 export { default as TicketModal } from './TicketDetailModal';
 
 export const QUEUE_MAP = {
-  Allocations: 'Accounting',
+  Allocations: 'Allocations',
+  'Login Issues': 'Accounts',
+  'Multi-factor Authentication': 'MFA',
   'Data Analytics or Storage Resources': 'Data Intensive Computing',
   'Login/Authentication Issue': 'Accounting',
   'Running Jobs or Using TACC Resources': 'High Performance Computing',

--- a/libs/tup-components/src/tickets/index.ts
+++ b/libs/tup-components/src/tickets/index.ts
@@ -8,7 +8,6 @@ export const QUEUE_MAP = {
   'Login Issues': 'Accounts',
   'Multi-factor Authentication': 'MFA',
   'Data Analytics or Storage Resources': 'Data Intensive Computing',
-  'Login/Authentication Issue': 'Accounting',
   'Running Jobs or Using TACC Resources': 'High Performance Computing',
   'Security Incident': 'NSO',
   Other: 'High Performance Computing',


### PR DESCRIPTION
## Overview
Previously there was a Login/Authentication Issues option pointing  to the Accounting queue as well as a Login Issues option going to the Accounts queue. These are combined now and the Accounting queue has been deprecated.