### PR TITLE
Task/tup 514 merging content layout system status - remove UI cruft

### DIFF
--- a/libs/tup-components/src/system-status/details/SystemNavBar.tsx
+++ b/libs/tup-components/src/system-status/details/SystemNavBar.tsx
@@ -11,31 +11,25 @@ export const SystemNavBar: React.FC<SystemDetailProps> = ({
   const { data, error, isLoading } = useSystemMonitor();
   if (error)
     return (
-      <div className={`nav-content`}>
-        <InlineMessage type="warning">
-          Unable to retrieve navigation bar.
-        </InlineMessage>
-      </div>
+      <InlineMessage type="warning">
+        Unable to retrieve navigation bar.
+      </InlineMessage>
     );
   if (isLoading)
     return (
-      <div className={`nav-content`}>
-        <LoadingSpinner />
-      </div>
-    );
+      <LoadingSpinner />
+  );
   return (
-    <div className={`nav-content`}>
-      {data &&
-        data.map((system) => (
-          <QueryNavItem
-            to={`/system-status/${system.tas_name}`}
-            key={`${system.tas_name}`}
-            // To set default system as active in navbar if no system selected.
-            active={tas_name === `${system.tas_name}`}
-          >
-            {system.display_name}
-          </QueryNavItem>
-        ))}
-    </div>
+    data &&
+    data.map((system) => (
+      <QueryNavItem
+        to={`/system-status/${system.tas_name}`}
+        key={`${system.tas_name}`}
+        // To set default system as active in navbar if no system selected.
+        active={tas_name === `${system.tas_name}`}
+      >
+        {system.display_name}
+      </QueryNavItem>
+    ))
   );
 };

--- a/libs/tup-components/src/system-status/details/SystemNavBar.tsx
+++ b/libs/tup-components/src/system-status/details/SystemNavBar.tsx
@@ -9,16 +9,15 @@ export const SystemNavBar: React.FC<SystemDetailProps> = ({
   tas_name = 'frontera',
 }) => {
   const { data, error, isLoading } = useSystemMonitor();
+
   if (error)
     return (
       <InlineMessage type="warning">
         Unable to retrieve navigation bar.
       </InlineMessage>
     );
-  if (isLoading)
-    return (
-      <LoadingSpinner />
-  );
+  if (isLoading) return <LoadingSpinner />;
+
   return (
     data &&
     data.map((system) => (


### PR DESCRIPTION
## Overview / Changes

Remove superfluous divs and unused classes.

Inspired by https://github.com/TACC/tup-ui/pull/266#discussion_r1262811191.

## Related

- polishes #266

## Testing

1. Verify loading, error, and success state for SystemNavBar are unchanged.*

<sup>* To test this, I changed corresponding `error` and `isLoading` to `true`.</sup>

## UI

| success | loading | error |
| - | - | - |
| <img width="775" alt="success" src="https://github.com/TACC/tup-ui/assets/62723358/b0bbff4f-535f-4526-8df7-f0efb0d3e627"> | <img width="775" alt="loading" src="https://github.com/TACC/tup-ui/assets/62723358/8dcea6c9-d6fe-4047-9584-beea9756f210"> | <img width="775" alt="error" src="https://github.com/TACC/tup-ui/assets/62723358/e5cb8139-b030-472e-96dd-d45824abd8d6"> |