### PR TITLE
fix: button text alignment, excess button markup & space

### DIFF
--- a/libs/core-components/src/lib/Button/Button.test.jsx
+++ b/libs/core-components/src/lib/Button/Button.test.jsx
@@ -15,7 +15,7 @@ function testClassnamesByType(type, size, getByRole, getByTestId) {
   expect(root.className).toMatch('root');
   expect(root.className).toMatch(new RegExp(typeClassName));
   expect(root.className).toMatch(new RegExp(sizeClassName));
-  expect(root.className).toMatch('text');
+  expect(root.textContent).toMatch(TEST_TEXT);
 }
 
 function isPropertyLimitation(type, size) {

--- a/libs/core-components/src/lib/Button/Button.test.jsx
+++ b/libs/core-components/src/lib/Button/Button.test.jsx
@@ -10,13 +10,12 @@ const TEST_SIZE = 'medium';
 
 function testClassnamesByType(type, size, getByRole, getByTestId) {
   const root = getByRole('button');
-  const text = getByTestId('text');
   const typeClassName = BTN.TYPE_MAP[type];
   const sizeClassName = BTN.SIZE_MAP[size];
   expect(root.className).toMatch('root');
   expect(root.className).toMatch(new RegExp(typeClassName));
   expect(root.className).toMatch(new RegExp(sizeClassName));
-  expect(text.className).toMatch('text');
+  expect(root.className).toMatch('text');
 }
 
 function isPropertyLimitation(type, size) {
@@ -34,8 +33,8 @@ function isPropertyLimitation(type, size) {
 
 describe('Button', () => {
   it('uses given text', () => {
-    const { getByTestId } = render(<Button>{TEST_TEXT}</Button>);
-    expect(getByTestId('text').textContent).toEqual(TEST_TEXT);
+    const { getByRole } = render(<Button>{TEST_TEXT}</Button>);
+    expect(getByRole('button').textContent).toEqual(TEST_TEXT);
   });
 
   describe('icons exist as expected when', () => {

--- a/libs/core-components/src/lib/Button/Button.tsx
+++ b/libs/core-components/src/lib/Button/Button.tsx
@@ -102,9 +102,7 @@ const Button: React.FC<ButtonProps> = ({
       ) : (
         ''
       )}
-      <span className="c-button__text" data-testid="text">
-        {children}
-      </span>
+      {children}
       {iconNameAfter && (
         <Icon
           name={iconNameAfter}

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.module.css
@@ -31,9 +31,6 @@
     justify-content: space-between;
 }
 
-.link-button > span {
-    vertical-align: baseline;
-}
 .link-button-delete {
     font-weight: bold;
 }


### PR DESCRIPTION
## Overview

Remove unnecessary `<span>` from `<Button>`.
<sup>This can fix edge case alignment issues, like in #270 or the style this PR outdates and removes.</sup>

## Related

- required by #270

## Changes

## Testing

1. Verify button bottom "padding" is a pixel or so less.
2. Verify `<UserDetail>` `link-button` is unaffected by change.
3. Check any UI you know may be adversely affected.

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/e32d90b8-2398-4574-b7eb-79367c679c96) | ![after](https://github.com/TACC/tup-ui/assets/62723358/04028945-8498-4d1a-96a7-b8ce08610c9b) |

https://github.com/TACC/tup-ui/assets/62723358/48c51559-52d5-4586-8b39-e6db88b1fdf8

https://github.com/TACC/tup-ui/assets/62723358/687d7d3f-4ed9-4a36-9049-bca891ea8e3e

## Notes

The `<span>` inside <Button> is unnecessary and can cause alignment bugs.

The CSS change removes some code I think was meant to fix an alignment issue.[^1]

[^1]: I could not see alignment issue. Regardless, the <span> is gone.