### PR TITLE
feat: `<Button>` support all `<button>` attributes

### DIFF
--- a/libs/core-components/src/lib/Button/Button.test.jsx
+++ b/libs/core-components/src/lib/Button/Button.test.jsx
@@ -7,6 +7,7 @@ import Button, * as BTN from './Button';
 const TEST_TEXT = '…';
 const TEST_TYPE = 'primary';
 const TEST_SIZE = 'medium';
+const TEST_LABEL = 'alt. button label';
 
 function testClassnamesByType(type, size, getByRole, getByTestId) {
   const root = getByRole('button');
@@ -35,6 +36,13 @@ describe('Button', () => {
   it('uses given text', () => {
     const { getByRole } = render(<Button>{TEST_TEXT}</Button>);
     expect(getByRole('button').textContent).toEqual(TEST_TEXT);
+  });
+
+  it('uses given aria-label', () => {
+    const { getByLabelText } = render(
+      <Button ariaLabel={TEST_LABEL}>{TEST_TEXT}</Button>
+    );
+    expect(getByLabelText(TEST_LABEL).textContent).toEqual(TEST_LABEL);
   });
 
   describe('icons exist as expected when', () => {

--- a/libs/core-components/src/lib/Button/Button.tsx
+++ b/libs/core-components/src/lib/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import Icon from '../Icon';
 import LoadingSpinner from '../LoadingSpinner';
 import styles from './Button.module.css';
@@ -43,10 +43,10 @@ type ButtonProps = React.PropsWithChildren<{
   iconNameAfter?: string;
   dataTestid?: string;
   disabled?: boolean;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   attr?: 'button' | 'submit' | 'reset';
   isLoading?: boolean;
 }> &
+  ButtonHTMLAttributes<HTMLButtonElement> &
   (ButtonTypeLinkSize | ButtonTypePrimarySize | ButtonTypeOtherSize);
 
 const Button: React.FC<ButtonProps> = ({
@@ -58,20 +58,10 @@ const Button: React.FC<ButtonProps> = ({
   size = '',
   dataTestid,
   disabled,
-  onClick,
   attr = 'button',
   isLoading = false,
+  ...props
 }) => {
-  function onclick(e: React.MouseEvent<HTMLButtonElement>) {
-    if (disabled) {
-      e.preventDefault();
-      return;
-    }
-    if (onClick) {
-      return onClick(e);
-    }
-  }
-
   return (
     <button
       className={`
@@ -84,8 +74,8 @@ const Button: React.FC<ButtonProps> = ({
       `}
       disabled={disabled || isLoading}
       type={attr}
-      onClick={onclick}
       data-testid={dataTestid}
+      {...props}
     >
       {isLoading && (
         <LoadingSpinner


### PR DESCRIPTION
## Status

Replaced by #278.