### PR TITLE
chore: core-styles v2.16.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@nrwl/vite": "^15.6.3",
         "@nrwl/web": "15.6.3",
         "@nrwl/workspace": "15.6.3",
-        "@tacc/core-styles": "^2.16.2",
+        "@tacc/core-styles": "^2.16.3",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "13.4.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5703,9 +5703,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.16.2.tgz",
-      "integrity": "sha512-fRT1Fd6BVgT+ar+9FfE4FWAIRO+cpk4I8PGflTK4/yxbFwAMgFRvy+mH7UcZElGzX29kYYiQI1tQ9aYo5InYsA==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.16.3.tgz",
+      "integrity": "sha512-xudj4QACQ2qsNdEPiLsa5CpdKKHOeuRW6bQd94WmYl3/1cSbPrZCHWloDfDqGMvxjKgNjUeCMjPG5yK3G4Jeyg==",
       "dev": true,
       "bin": {
         "core-styles": "src/cli.js"
@@ -29561,9 +29561,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.16.2.tgz",
-      "integrity": "sha512-fRT1Fd6BVgT+ar+9FfE4FWAIRO+cpk4I8PGflTK4/yxbFwAMgFRvy+mH7UcZElGzX29kYYiQI1tQ9aYo5InYsA==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.16.3.tgz",
+      "integrity": "sha512-xudj4QACQ2qsNdEPiLsa5CpdKKHOeuRW6bQd94WmYl3/1cSbPrZCHWloDfDqGMvxjKgNjUeCMjPG5yK3G4Jeyg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@nrwl/vite": "^15.6.3",
     "@nrwl/web": "15.6.3",
     "@nrwl/workspace": "15.6.3",
-    "@tacc/core-styles": "^2.16.2",
+    "@tacc/core-styles": "^2.16.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.4.0",
     "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## Overview

Fix CSS build _warning_ about invalid syntax.

<details><summary>Warning</summary>

```
warnings when minifying css:
▲ [WARNING] Unexpected "not(" [css-syntax-error]

    <stdin>:2542:15:
      2542 │ fieldset:where(not(:last-child)){margin-bottom:3.5rem}
```

</details>

## Related

- warning began after #270
- warning fixed in https://github.com/TACC/Core-Styles/commit/97e59a9

## Changes

- installed Core-Styles v2.16.3

## Testing / UI / Notes

Skipped.

_The warning was very clear to me, the author of that line of CSS. The warning should not affect TUP, because TUP does not use `<fieldset>`'s._