### PR TITLE
Better exception handling and date formatting for User News

### DIFF
--- a/apps/tup-cms/src/apps/user_news/utils.py
+++ b/apps/tup-cms/src/apps/user_news/utils.py
@@ -1,5 +1,7 @@
 import requests
 from datetime import datetime
+from dateutil.parser import isoparse
+from requests import HTTPError
 
 from django.conf import settings
 
@@ -13,10 +15,13 @@ if settings.DEBUG:
 
 def get_articles(sanitize = True):
   url = f'{service_url}/news?sanitize={sanitize}'
-  r = requests.get(url)
-  articles = r.json();
-
-  return articles
+  try:
+    r = requests.get(url)
+    r.raise_for_status()
+    articles = r.json()
+    return articles
+  except HTTPError:
+    return []
 
 def get_latest_articles(count = max_articles, sanitize = True):
   articles = get_articles(sanitize)
@@ -35,7 +40,7 @@ def get_article(id_, sanitize = True):
   return create_proxy_article(article)
 
 def get_datetime(str_):
-  return datetime.fromisoformat(str_)
+  return isoparse(str_)
 
 def format_date(datetime):
   return datetime.strftime('%B %d, %Y')


### PR DESCRIPTION
## Overview
- Add exception handling so that an API error from TUP-services can't crash the entire site.
- Use dateutil for more versatile date handling.

## Related

- [TUP-541](https://jira.tacc.utexas.edu/browse/TUP-541)

