### PR TITLE
fix: tup-542 (4) unpair link to right → button underneath

### DIFF
--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -60,7 +60,5 @@
 }
 
 .mfa-options {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    /* no styles needed yet */
 }

--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -40,7 +40,7 @@ const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {
   };
   return (
     <>
-      <Button type="link" onClick={() => toggle()}>
+      <Button type="secondary" onClick={() => toggle()}>
         Unpair
       </Button>
       <Modal
@@ -156,9 +156,7 @@ export const AccountMfa: React.FC = () => {
       )}
       {hasPairing && data.token && (
         <div className={styles['mfa-options']}>
-          <span>
-            {TOKEN_TYPE[data.token.tokentype]} ({data.token.serial})
-          </span>
+          <p>{TOKEN_TYPE[data.token.tokentype]} ({data.token.serial})</p>
           <MfaUnpair pairing={data} />
         </div>
       )}

--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -156,7 +156,9 @@ export const AccountMfa: React.FC = () => {
       )}
       {hasPairing && data.token && (
         <div className={styles['mfa-options']}>
-          <p>{TOKEN_TYPE[data.token.tokentype]} ({data.token.serial})</p>
+          <p>
+            {TOKEN_TYPE[data.token.tokentype]} ({data.token.serial})
+          </p>
           <MfaUnpair pairing={data} />
         </div>
       )}


### PR DESCRIPTION
## Overview / Changes

4. Change "Unpair" link to the right of token status to be a button underneath token status.

## Related

- [TUP-542](https://jira.tacc.utexas.edu/browse/TUP-542)

## Testing / UI

| Before | After |
| - | - |
| ![4 before](https://github.com/TACC/tup-ui/assets/62723358/fbf9c878-ecc0-4ba0-a5cc-35f5f1a99abe) | ![4](https://github.com/TACC/tup-ui/assets/62723358/16004bea-ac80-4f48-9b3a-46b7b23818ac) |
