### PR TITLE
fix: tup-542 (1) remove "to continue the pairing"

### DIFF
--- a/libs/tup-components/src/mfa/MfaValidationPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaValidationPanel.tsx
@@ -15,7 +15,7 @@ const MfaValidationPanel: React.FC<{ tokenType: 'totp' | 'sms' }> = ({
   };
 
   const pairingMessage = {
-    totp: 'Enter the token shown in the app to continue the pairing.',
+    totp: 'Enter the token shown in the app.',
     sms: 'Enter the token sent to your phone number.',
   };
 


### PR DESCRIPTION
## Overview / Changes

1. Remove "to continue the pairing" from MFA QR code pairing step 2.

## Related

- [TUP-542](https://jira.tacc.utexas.edu/browse/TUP-542)

## Testing / UI

| Before | After |
| - | - |
| ![1 before](https://github.com/TACC/tup-ui/assets/62723358/5c035339-c1be-4ede-a740-528330949770) | ![1](https://github.com/TACC/tup-ui/assets/62723358/21af4165-29d2-4c30-90d3-18906844a70d) |