### PR TITLE
fix: tup-542 (3) unpair modal, drop excess text

### DIFF
--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -63,7 +63,6 @@ const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {
               account.
             </SectionMessage>
             <br />
-            <p>Enter your current MFA token to unpair your device.</p>
             {pairing.token?.tokentype === 'sms' && (
               <p>
                 <Button type="primary" onClick={() => sendChallenge(null)}>
@@ -72,7 +71,7 @@ const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {
               </p>
             )}
             <p>
-              <label htmlFor="current-mfa-token">Enter MFA Token:&nbsp;</label>
+              <label htmlFor="current-mfa-token">Enter MFA Token:</label>
               <input
                 value={currentToken}
                 autoComplete="off"


### PR DESCRIPTION
## Overview / Changes

3. From unpair modal, remove "Enter your current MFA token… paragraph.

## Related

- [TUP-542](https://jira.tacc.utexas.edu/browse/TUP-542)

## Testing / UI

| Before | After |
| - | - |
| ![3 before](https://github.com/TACC/tup-ui/assets/62723358/aa3c8137-c22c-470f-a3e0-271be0b91000) | ![3](https://github.com/TACC/tup-ui/assets/62723358/405e6762-f1ed-4a5d-89fb-ba960204c8dc) |
