### PR TITLE
fix: tup-542 (5) show sms pair help msg only after submit

### DIFF
--- a/libs/tup-components/src/mfa/MfaSmsPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaSmsPanel.tsx
@@ -7,36 +7,46 @@ import { TicketCreateModal } from '../tickets';
 const MfaSmsPanel: React.FC = () => {
   const smsMutation = useMfaPairSms();
   const [phoneNumber, setPhoneNumber] = useState<string>('');
+  const [hasAttemptedSMS, setHasAttemptedSMS] = useState<boolean>('');
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setHasAttemptedSMS(true);
     smsMutation.mutate({ phoneNumber });
   };
   return (
-    <form
-      onSubmit={(e) => onSubmit(e)}
-      className={`${styles['mfa-form']} s-form`}
-    >
-      <div>
-        <label htmlFor="mfa-phone-number">Enter your Phone Number:</label>
-        <input
-          required
-          id="mfa-phone-number"
-          onChange={(e) => setPhoneNumber(e.target.value)}
-        />
-        {smsMutation.isError && (
-          <InlineMessage type="error" tagName="small">
-            Unable to pair via SMS. If this error persists,{' '}
-            <TicketCreateModal display="link">
-              submit a ticket
-            </TicketCreateModal>
-            .
-          </InlineMessage>
-        )}
-      </div>
-      <Button type="primary" attr="submit" isLoading={smsMutation.isLoading}>
-        Send Token
-      </Button>
-    </form>
+    <>
+      <form
+        onSubmit={(e) => onSubmit(e)}
+        className={`${styles['mfa-form']} s-form`}
+      >
+        <div>
+          <label htmlFor="mfa-phone-number">Enter your Phone Number:</label>
+          <input
+            required
+            id="mfa-phone-number"
+            onChange={(e) => setPhoneNumber(e.target.value)}
+          />
+          {smsMutation.isError && (
+            <InlineMessage type="error" tagName="small">
+              Unable to pair via SMS. If this error persists,{' '}
+              <TicketCreateModal display="link">
+                submit a ticket
+              </TicketCreateModal>
+              .
+            </InlineMessage>
+          )}
+        </div>
+        <Button type="primary" attr="submit" isLoading={smsMutation.isLoading}>
+          Send Token
+        </Button>
+      </form>
+      {hasAttemptedSMS && (
+        <p className={styles['mfa-message']}>
+          Didn't receive a message within 5 minutes?{' '}
+          <TicketCreateModal display="link">Get Help</TicketCreateModal>
+        </p>
+      )}
+    </>
   );
 };
 

--- a/libs/tup-components/src/mfa/MfaSmsPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaSmsPanel.tsx
@@ -7,7 +7,7 @@ import { TicketCreateModal } from '../tickets';
 const MfaSmsPanel: React.FC = () => {
   const smsMutation = useMfaPairSms();
   const [phoneNumber, setPhoneNumber] = useState<string>('');
-  const [hasAttemptedSMS, setHasAttemptedSMS] = useState<boolean>('');
+  const [hasAttemptedSMS, setHasAttemptedSMS] = useState<boolean>(false);
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setHasAttemptedSMS(true);

--- a/libs/tup-components/src/mfa/MfaSmsPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaSmsPanel.tsx
@@ -40,7 +40,7 @@ const MfaSmsPanel: React.FC = () => {
           Send Token
         </Button>
       </form>
-      {hasAttemptedSMS && (
+      {(smsMutation.data || smsMutation.isLoading) && (
         <p className={styles['mfa-message']}>
           Didn't receive a message within 5 minutes?{' '}
           <TicketCreateModal display="link">Get Help</TicketCreateModal>

--- a/libs/tup-components/src/mfa/MfaSmsPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaSmsPanel.tsx
@@ -7,10 +7,8 @@ import { TicketCreateModal } from '../tickets';
 const MfaSmsPanel: React.FC = () => {
   const smsMutation = useMfaPairSms();
   const [phoneNumber, setPhoneNumber] = useState<string>('');
-  const [hasAttemptedSMS, setHasAttemptedSMS] = useState<boolean>(false);
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setHasAttemptedSMS(true);
     smsMutation.mutate({ phoneNumber });
   };
   return (

--- a/libs/tup-components/src/mfa/MfaValidationPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaValidationPanel.tsx
@@ -42,12 +42,6 @@ const MfaValidationPanel: React.FC<{ tokenType: 'totp' | 'sms' }> = ({
           Confirm Pairing
         </Button>
       </form>
-      {tokenType === 'sms' && (
-        <p className={styles['mfa-message']}>
-          Didn't receive a message within 5 minutes?{' '}
-          <TicketCreateModal display="link">Get Help</TicketCreateModal>
-        </p>
-      )}
     </>
   );
 };


### PR DESCRIPTION
## Overview / Changes

5. Change SMS pairing step 1 message "Didn't receive […] [Get help.](https://example.com/)" to only show after submitting token to send.


## Related

- [TUP-542](https://jira.tacc.utexas.edu/browse/TUP-542)


## Testing / UI

### Before

https://github.com/TACC/tup-ui/assets/62723358/1e4722d7-d98e-4060-a31b-4f66e2c1c1ff

### After

https://github.com/TACC/tup-ui/assets/62723358/60c60214-6f9d-443b-a7eb-f84b1273affb