### PR TITLE
fix: invalid markup in mfa

### DIFF
--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -96,7 +96,7 @@ const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {
             {emailSentSuccess && (
               <SectionMessage type="info">
                 An email has been sent to the address listed on your account.
-                  Follow its instructions to continue the unpairing.
+                Follow its instructions to continue the unpairing.
               </SectionMessage>
             )}
           </ModalBody>

--- a/libs/tup-components/src/accounts/ManageAccountMfa.tsx
+++ b/libs/tup-components/src/accounts/ManageAccountMfa.tsx
@@ -94,12 +94,10 @@ const MfaUnpair: React.FC<{ pairing: MfaTokenResponse }> = ({ pairing }) => {
               <Button onClick={() => unpairWithEmail(null)}>Send Email</Button>
             </p>
             {emailSentSuccess && (
-              <p>
-                <SectionMessage type="info">
-                  An email has been sent to the address listed on your account.
+              <SectionMessage type="info">
+                An email has been sent to the address listed on your account.
                   Follow its instructions to continue the unpairing.
-                </SectionMessage>
-              </p>
+              </SectionMessage>
             )}
           </ModalBody>
           <ModalFooter>


### PR DESCRIPTION
## Overview

Do not nest a `<p>` within a `<p>`.

## Related

- [TUP-1234](https://jira.tacc.utexas.edu/browse/TUP-1234)

## Changes

- removed superfluous `<p>`

## Testing

1. Have MFA pairing.
2. Open modal to unpair MFA.

## UI

### Before

Rendered Markup:
![rendered markup](https://github.com/TACC/tup-ui/assets/62723358/44197941-0d43-416f-a223-6d1dc2f21917)

Logged Error:
![logged error](https://github.com/TACC/tup-ui/assets/62723358/2a31f85a-31a6-4b1b-ae28-cdb88bdaef58)

Source Markup:
![source markup](https://github.com/TACC/tup-ui/assets/62723358/5278ddbf-ed8e-4f21-a2e2-0f045c267796)

### After

No nested `<p>` tag, yet same UI:
![no nested p](https://github.com/TACC/tup-ui/assets/62723358/307d7084-7847-49ea-9168-ec867da1d5f0)