### PR TITLE
bug/TUP-544: Remove dependency on react-router from CMS sysmon

### DIFF
--- a/apps/tup-cms-react/src/Sysmon/Sysmon.tsx
+++ b/apps/tup-cms-react/src/Sysmon/Sysmon.tsx
@@ -1,5 +1,5 @@
 import { SystemMonitorTable } from '@tacc/tup-components';
 
-const Sysmon: React.FC = () => <SystemMonitorTable />;
+const Sysmon: React.FC = () => <SystemMonitorTable useLinks={false} />;
 
 export default Sysmon;

--- a/libs/tup-components/src/system-status/SystemMonitor.tsx
+++ b/libs/tup-components/src/system-status/SystemMonitor.tsx
@@ -5,7 +5,7 @@ import {
   InlineMessage,
   SectionTableWrapper,
 } from '@tacc/core-components';
-import { Display, Operational, Load } from './SystemMonitorCells';
+import { Display, Operational, Load, TextDisplay } from './SystemMonitorCells';
 import { SystemMonitorRawSystem, useSystemMonitor } from '@tacc/tup-hooks';
 import styles from './SystemMonitor.module.css';
 import { EmptyTablePlaceholder } from '../utils';
@@ -25,6 +25,7 @@ export const isSystemOnline = (rawSystem: SystemMonitorRawSystem): boolean => {
 
 export const SystemMonitorTable: React.FC<SystemDetailProps> = ({
   tas_name,
+  useLinks = true,
 }) => {
   const { data: systemMonitorData, isLoading, error } = useSystemMonitor();
   let data = systemMonitorData;
@@ -35,7 +36,7 @@ export const SystemMonitorTable: React.FC<SystemDetailProps> = ({
       {
         accessor: 'display_name',
         Header: 'System',
-        Cell: Display,
+        Cell: useLinks ? Display : TextDisplay,
       },
       {
         accessor: isSystemOnline,

--- a/libs/tup-components/src/system-status/SystemMonitorCells.tsx
+++ b/libs/tup-components/src/system-status/SystemMonitorCells.tsx
@@ -12,6 +12,12 @@ export const Display: React.FC<{
   </Link>
 );
 
+export const TextDisplay: React.FC<{
+  cell: Cell<SystemMonitorRawSystem, string>;
+}> = ({ cell: { row } }) => {
+  return row.original.display_name;
+};
+
 export const Operational: React.FC<{
   cell: Cell<SystemMonitorRawSystem, boolean>;
 }> = ({ cell: { value } }) => {

--- a/libs/tup-components/src/system-status/index.ts
+++ b/libs/tup-components/src/system-status/index.ts
@@ -1,5 +1,6 @@
 export type SystemDetailProps = {
   tas_name?: string;
+  useLinks?: boolean;
 };
 
 export { SystemMonitor, SystemMonitorTable } from './SystemMonitor';


### PR DESCRIPTION
## Overview
Make the react-router dependency optional for the sysmon table, fixing its rendering inside of CMS snippets.

## Related

- [TUP-544](https://jira.tacc.utexas.edu/browse/TUP-544)

## Changes
- add an optional `useLinks` prop (defaulting to true) that toggles whether the table displays system names as links (for the portal) or plain text (for the CMS component).

## Testing
- Render the `SystemMonitorTable` component with `useLinks={false}` and check that the component renders without react-router links.
