### PR TITLE
Bug/TUP-563: fix 500 error in user news

### DIFF
--- a/apps/tup-cms/src/apps/user_news/utils.py
+++ b/apps/tup-cms/src/apps/user_news/utils.py
@@ -34,7 +34,7 @@ def get_latest_articles(count = max_articles, sanitize = True):
 
 def get_article(id_, sanitize = True):
   articles = get_articles(sanitize)
-  filtered_articles = filter(lambda article: article['ID'] == int(id_), articles)
+  filtered_articles = filter(lambda article: str(article['ID']) == str(id_), articles)
   article = list(filtered_articles)[0]
 
   return create_proxy_article(article)


### PR DESCRIPTION
## Overview
Fix a type error that was preventing display of User News stories.

## Related

- [TUP-563](https://jira.tacc.utexas.edu/browse/TUP-563)

