### PR TITLE
hotfix: set SESSION_COOKIE_SECURE = True

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -9,6 +9,15 @@ from django.utils.translation import gettext_lazy as _
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 ########################
+# CORE CMS SETTINGS
+# FAQ: These are in future versions of Core-CMS
+########################
+
+# NOTE: Already in Core-CMS v3.12.0-beta.2
+# whether the session cookie should be secure (https:// only)
+SESSION_COOKIE_SECURE = True
+
+########################
 # DJANGO CMS SETTINGS
 ########################
 


### PR DESCRIPTION
## Overview

New CMS image to mimic https://github.com/TACC/Core-CMS/pull/695 hotfix.

<details><summary>Why not use new CMS image?</summary>

Because the attempt in https://github.com/TACC/tup-ui/pull/301 broke the UI demo.

</details>

## Related

- mimics https://github.com/TACC/Core-CMS/pull/695
- alternative to https://github.com/TACC/tup-ui/pull/301

## Changes

## Testing

1. In Chrome/ium DevTools > Application > Cookies
2. Confirm "Secure" column for "sessionid" cookie is **checked**.

## UI

| Dev Before | Dev After |
| - | - |
| ![tup dev hotfix before](https://github.com/TACC/tup-ui/assets/62723358/1f4f6e84-ebf9-4d61-a3af-b94b8795a87a) | ![tup dev hotfix after](https://github.com/TACC/tup-ui/assets/62723358/cf3bc405-27bd-43e3-bc68-495090ea59c9) |

| Localhost After |
| - |
| ![tup hotfix after](https://github.com/TACC/tup-ui/assets/62723358/0cba4077-b343-411f-bdfb-54a3028c63c8) |