### PR TITLE
Task/TUP-564: Set the `secure` attribute on x-tup-token

### DIFF
--- a/apps/tup-cms/src/apps/portal/views.py
+++ b/apps/tup-cms/src/apps/portal/views.py
@@ -48,7 +48,7 @@ def ImpersonateView(request):
                                        headers=headers,
                                        json=data)
     user_jwt = impersonation_resp.json()['jwt']
-    resp.set_cookie("x-tup-token", user_jwt)
+    resp.set_cookie("x-tup-token", user_jwt, secure=True)
     return resp
 
 

--- a/libs/tup-hooks/src/auth/useAuth.ts
+++ b/libs/tup-hooks/src/auth/useAuth.ts
@@ -21,7 +21,10 @@ const useAuth = () => {
   const onSuccess = useCallback(
     (response: AuthResponse) => {
       const expirationDate = new Date(Date.now() + response.ttl * 1000);
-      Cookies.set('x-tup-token', response.jwt, { expires: expirationDate });
+      Cookies.set('x-tup-token', response.jwt, {
+        expires: expirationDate,
+        secure: true,
+      });
       // Invalidate the jwt query to trigger rerender of any component that uses it.
       queryClient.invalidateQueries(['jwt']);
     },


### PR DESCRIPTION
## Overview
Set the `secure` attribute on x-tup-token to reduce the risk of hijacking.

## Related

- [TUP-564](https://jira.tacc.utexas.edu/browse/TUP-564)

## UI
<img width="1592" alt="image" src="https://github.com/TACC/tup-ui/assets/12601812/11afbae5-23fe-4597-86a7-326edec5c6b8">

## Notes
