### PR TITLE
fix: narrow screen, blog image must have max-width

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.blog.app.page.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.blog.app.page.css
@@ -1,3 +1,29 @@
+/* Media & Content - Alignment */
+
+
+
+/* ... */
+
+
+
+/* Media & Content - Alignment */
+
+/* To remove margin on narrow screens */
+/* To overwrite @tacc/core-styles/…/components/align.css */
+@media (max-width: 767px) {
+  /*
+  :--article-page .blog-content .align-center,
+  :--article-page .blog-content .align-right,
+  :--article-page .blog-content .align-left {
+  */
+  article.post-detail .blog-content .align-center,
+  article.post-detail .blog-content .align-left,
+  article.post-detail .blog-content .align-right {
+    max-width: 100%;
+  }
+
+  /* ... */
+}
 
 
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.blog.app.page.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.blog.app.page.css
@@ -9,7 +9,7 @@
 /* Media & Content - Alignment */
 
 /* To remove margin on narrow screens */
-/* To overwrite @tacc/core-styles/…/components/align.css */
+/* ... */
 @media (max-width: 767px) {
   /*
   :--article-page .blog-content .align-center,


### PR DESCRIPTION
## Overview

Do **not** let blog images on narrow screen exceed width of page.

> **Important**
> This change is applied to live site via [snippet #136](https://www.tacc.utexas.edu/admin/djangocms_snippet/snippet/136/change/). Delete that snippet after this code is deployed.

## Related

- fixes bug caused by https://github.com/TACC/Core-CMS#588

## Changes

- **changed** one CSS value in a stylesheet
	<sub>This stylesheet will be used in [TUP-463](https://jira.tacc.utexas.edu/browse/TUP-463) to overwrite Core-CMS styles.</sub>

## Testing

1. Open https://www.tacc.utexas.edu/news/latest-news/2023/09/13/ecep-connect-virtual-summit/.
2. Confirm article image does not overflow page / cause scrollbar at any screen width, especially 767px or less.
3. For good measure, if news editor is not working ons tory, test when image has a caption.
	<sub>To add a caption, edit Image plugin under its "Advanced settings", and add text in "Caption" field.)</sub>

## UI

### After (Narrow Screen) ✅

| Left | Center | Right |
| - | - | - |
| ![narrow left - fixed](https://github.com/TACC/tup-ui/assets/62723358/345477dd-e07f-4373-b6d0-6b4b5896de26) | ![narrow center - fixed](https://github.com/TACC/tup-ui/assets/62723358/204c1708-08e1-4b3d-9b11-3f456b677127) | ![narrow right - fixed](https://github.com/TACC/tup-ui/assets/62723358/95316d2b-04a1-452e-ac59-b94fb64a5316) |

### Before (Narrow Screen) ❌

| Left | Center | Right |
| - | - | - |
| ![narrow left](https://github.com/TACC/tup-ui/assets/62723358/d8ed96ce-2056-4ed5-9bf8-11070d9524ca) | ![narrow center](https://github.com/TACC/tup-ui/assets/62723358/51747470-ef53-4882-947a-08a32cb2184b) | ![narrow right](https://github.com/TACC/tup-ui/assets/62723358/44ecc9d7-4ba7-4ed1-9dc7-dc4254318f74) |

### Unchanged (Wide Screen)

| Left | Center | Right |
| - | - | - |
| ![wide left](https://github.com/TACC/tup-ui/assets/62723358/78f15593-3ca1-4793-baf1-6ce6c26d10a6) | ![wide center](https://github.com/TACC/tup-ui/assets/62723358/1506bc46-ffa8-4c91-ba66-1d830eb6c253) | ![wide right](https://github.com/TACC/tup-ui/assets/62723358/a6a1610b-d010-408b-8416-db3334f29dab) |

## Notes

To overwrite broken code in Core-CMS `django.cms.blog.app.page.css`.

Core-CMS says `max-width: unset`, but should say `max-width: 100%`.
- `max-width: unset` removes max width, thus image can overflow page
- `max-width: 100%` limits width to parent, thus image not overflow page