### PR TITLE
chore: upgrade cms to v3.12.0-beta

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.12.0-alpha.9
-FROM taccwma/core-cms:afb6f21
+# TACC/Core-CMS#v3.12.0-beta.3 candidate
+FROM taccwma/core-cms:cbe7d71
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.12.0-beta.3 candidate
-FROM taccwma/core-cms:cbe7d71
+# TACC/Core-CMS#v3.12.0-beta.3
+FROM taccwma/core-cms:aba079b
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Update to Core CMS v3.12 Beta.

## Related

- requires https://github.com/TACC/Core-CMS/pull/706

## Changes

- **changed** core-cms image tag

## Testing

Most changes do not need testing, because these are all micro-releases with:
- minor changes
- non–user-facing changes
- changes that were in the TUP launch branch

I verified UI demo loads and news page headings are `<h1>`.

## UI

### https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-beta.3

- https://github.com/TACC/Core-CMS/pull/706

	Verify demo is accessible e.g. https://dev.tup.tacc.utexas.edu/static/ui/.

	| v3.12.0-beta.3 candidate | v3.12.0-beta.3  official |
	| - | - |
	| ![dev tup candidate test](https://github.com/TACC/tup-ui/assets/62723358/c10de83f-79e4-471f-a94a-6c5f7c5f14e4) | ![dev tup official deploy](https://github.com/TACC/tup-ui/assets/62723358/2145a001-73bd-486f-9898-31c5ece1de25) |

### https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.10

- https://github.com/TACC/Core-CMS/pull/674

	Verify page heading on News list and News article are `<h1>`.

	| news list | news detail |
	| - | - |
	| ![news list](https://github.com/TACC/tup-ui/assets/62723358/5300a3d6-fdbf-49d6-bdc2-638c7f6e9dc3) | ![news detail](https://github.com/TACC/tup-ui/assets/62723358/f9d45f80-ba30-4a30-9ff6-8c013426de98) |