### PR TITLE
bug/TUP-569: Remove ticket status options so users can only select 'resolved'

### DIFF
--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketReplyForm.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketReplyForm.tsx
@@ -67,11 +67,7 @@ export const TicketReplyForm: React.FC<{ ticketId: string }> = ({
             />
             <FormikSelect name="status" label="Status">
               <option value="">--</option>
-              <option value="new">New</option>
               <option value="resolved">Resolved</option>
-              <option value="open">In Progress</option>
-              <option value="user_wait">Reply Required</option>
-              <option value="internal_wait">Reply Sent</option>
             </FormikSelect>
             <FormikFileInput
               name="files"


### PR DESCRIPTION
## Overview
Remove ticket status options so users can only select 'resolved'. When users select other status options it interferes with User Services' workflows.

## Related

- [TUP-569](https://jira.tacc.utexas.edu/browse/TUP-569

