### PR TITLE
feat: increase portal font-size

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/settings/font--portal.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/settings/font--portal.css
@@ -1,0 +1,17 @@
+/* Mimic Core-Styles settings/font--docs.css */
+/* FAQ: Design wants to increase base font from 12px to 14px */
+/* FAQ: This change ALMOST gives clients consistent font size variables */
+/* NOTE:
+        - tup-ui <body> uses `--global-font-size--small` (is now 1.4rem)
+        - tup-cms <body> uses `--global-font-size--medium` (has been 1.4rem)
+        - tacc-docs <body> uses `--global-font-size--medium` (has been 1.6rem)
+*/
+:root {
+  --global-font-size--x-small: 1.2rem;
+  --global-font-size--small: 1.4rem;
+  --global-font-size--medium: 1.6rem;
+  --global-font-size--large: 1.8rem;
+  --global-font-size--x-large: 2.1rem;
+  --global-font-size--xx-large: 2.8rem;
+  --global-font-size--xxx-large: 3.2rem;
+}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-styles.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-styles.css
@@ -2,7 +2,7 @@
 /* SEE: https://confluence.tacc.utexas.edu/x/IAA9Cw */
 
 /* SETTINGS */
-/* ... */
+@import url("./for-core-styles/settings/font--portal.css") layer(base);
 
 /* GENERICS */
 @import url("./for-core-styles/generics/attributes.css") layer(base);

--- a/libs/tup-components/src/news/UserNews.module.css
+++ b/libs/tup-components/src/news/UserNews.module.css
@@ -1,5 +1,5 @@
 .news-list {
-  font-size: var(--global-font-size--small);
+  font-size: var(--global-font-size--x-small);
 }
 
 .news-list-item {
@@ -39,6 +39,8 @@
 
   margin-top: 10px;
   margin-bottom: 5px;
+
+  font-size: var(--global-font-size--small);
 }
 
 .news-error {


### PR DESCRIPTION
## Overview

Increase Portal UI font size, but ensure User News font size still matches CMS.

## Related

- [TUP-490](https://jira.tacc.utexas.edu/browse/TUP-490)

## Changes

- **changed** font-size variables for portal
- **added** new portal font-size variables for core-styles
- **changed** font sizes for User News
	- so size does not change
	- so size still matches CMS

## Testing

0. Open Portal.
1. In all sections, verify font size (besides `<h1>`) is slightly bigger (all `2px` larger).
2. In all sections, verify `<h1>` font size (e.g. "Dashboard") is slightly bigger (before `20px`, now `21px`).
3. In Dashboard, verify User News date, title, and summary font sizes match CMS.

## UI

