### PR TITLE
bug/TUP-570: Fix router history behavior in the Ticket Detail modal

### DIFF
--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Container, Row, Col, Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { useGetTicketDetails } from '@tacc/tup-hooks';
 import './TicketModal.global.css';
@@ -11,7 +11,14 @@ const TicketModal: React.FC<{ ticketId: string; baseRoute: string }> = ({
   baseRoute,
 }) => {
   const navigate = useNavigate();
-  const close = () => navigate(baseRoute);
+  const { state } = useLocation();
+  const close = () => {
+    if (state?.fromLink) return navigate(-1);
+
+    // If the user got here from outside the portal,
+    // navigate(-1) might take them somewhere unexpected.
+    return navigate(baseRoute, { replace: true });
+  };
   const modalAlwaysOpen = true;
   const { data } = useGetTicketDetails(ticketId);
 

--- a/libs/tup-components/src/tickets/TicketsTable.tsx
+++ b/libs/tup-components/src/tickets/TicketsTable.tsx
@@ -93,7 +93,10 @@ export const TicketsTable: React.FC<{ ticketsPath: string }> = ({
             >
               <td>{ticket.numerical_id}</td>
               <td>
-                <Link to={`${ticketsPath}/${ticket.numerical_id}`}>
+                <Link
+                  to={`${ticketsPath}/${ticket.numerical_id}`}
+                  state={{ fromLink: true }}
+                >
                   {ticket.Subject || '(No Subject)'}
                 </Link>{' '}
                 <AttachmentIndicator ticketId={ticket.numerical_id} />


### PR DESCRIPTION
## Overview
Fixes a small annoyance where closing the ticket detail modal then hitting the browser's "back" button would reopen the modal.

## Related

- [TUP-570](https://jira.tacc.utexas.edu/browse/TUP-570)

## Changes
Adds logic to the ticket detail modal to detect whether the user got there from the portal (by clicking a button in the ticket listing) or from outside the portal (by copying a link/opening in a new tab). If we know the user got there from our own link, we can safely navigate back with `navigate(-1)`, otherwise we have to use the `basePath` to navigate.

## Testing

1. Open and close the detail modal for multiple tickets, then hit the "back" button on your browser. You should immediately go back to wherever you were before navigating to the dashboard/ticket page, instead of having to hit the button multiple times.
2. Copy the URL for a specific ticket into another tab, then close that ticket. Check that you don't get navigated to the last entry in your browser's history.

## UI

## Notes
