### PR TITLE
fix: github annotations

### DIFF
--- a/libs/tup-components/src/mfa/MfaValidationPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaValidationPanel.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useMfaVerify } from '@tacc/tup-hooks';
 import { Button, InlineMessage } from '@tacc/core-components';
-import TicketCreateModal from '../tickets/TicketCreateModal';
 import styles from './Mfa.module.css';
 
 const MfaValidationPanel: React.FC<{ tokenType: 'totp' | 'sms' }> = ({
@@ -20,33 +19,31 @@ const MfaValidationPanel: React.FC<{ tokenType: 'totp' | 'sms' }> = ({
   };
 
   return (
-    <>
-      <form
-        onSubmit={(e) => onSubmit(e)}
-        className={`${styles['mfa-form']} s-form`}
-      >
-        <div>
-          <label htmlFor="confirm-pairing">{pairingMessage[tokenType]}</label>
-          <input
-            required
-            id="confirm-pairing"
-            onChange={(e) => setTokenValue(e.target.value)}
-          />
-          {error && (
-            <InlineMessage
-              type="error"
-              tagName="small"
-              className={styles['field-error']}
-            >
-              Your token is invalid.
-            </InlineMessage>
-          )}
-        </div>
-        <Button type="primary" attr="submit" isLoading={isLoading}>
-          Confirm Pairing
-        </Button>
-      </form>
-    </>
+    <form
+      onSubmit={(e) => onSubmit(e)}
+      className={`${styles['mfa-form']} s-form`}
+    >
+      <div>
+        <label htmlFor="confirm-pairing">{pairingMessage[tokenType]}</label>
+        <input
+          required
+          id="confirm-pairing"
+          onChange={(e) => setTokenValue(e.target.value)}
+        />
+        {error && (
+          <InlineMessage
+            type="error"
+            tagName="small"
+            className={styles['field-error']}
+          >
+            Your token is invalid.
+          </InlineMessage>
+        )}
+      </div>
+      <Button type="primary" attr="submit" isLoading={isLoading}>
+        Confirm Pairing
+      </Button>
+    </form>
   );
 };
 

--- a/libs/tup-components/src/system-status/SystemMonitor.tsx
+++ b/libs/tup-components/src/system-status/SystemMonitor.tsx
@@ -58,7 +58,7 @@ export const SystemMonitorTable: React.FC<SystemDetailProps> = ({
         Header: 'Waiting Jobs',
       },
     ],
-    []
+    [useLinks, tas_name]
   );
 
   const { getTableProps, getTableBodyProps, rows, prepareRow, headerGroups } =


### PR DESCRIPTION
## Overview / Changes

- TicketCreateModal' is defined but never used
- Fragments should contain more than one child - otherwise, there’s no need for a Fragment at all
- React Hook useMemo has missing dependencies: 'tas_name' and 'useLinks'. Either include them or remove the dependency array

## Related

- as mentioned in #312

## Testing & UI

N/A