### PR TITLE
fix: tup-571 mfa ui not responsive

### DIFF
--- a/libs/tup-components/src/mfa/Mfa.module.css
+++ b/libs/tup-components/src/mfa/Mfa.module.css
@@ -21,11 +21,6 @@
     margin-top: 30px; /* match .mfa-success-container button */
 }
 
-.mfa-message {
-    /* So OTP code copy field will not stretch to fill narrow-width screen */
-    width: max-content;
-}
-
 .field-error {
   /* So message with very little text still appears beneath input */
   display: flex;
@@ -113,6 +108,12 @@ label.qr-code-alt-label {
         );
 
         padding-bottom: var(--space-below-panel-for-message);
+    }
+
+    /* To not let message content stretch wider than necessary */
+    /* FAQ: A TextCopyField in a message would stretch as wide as possible */
+    .mfa-message {
+        width: max-content;
     }
 
     /* HACK: Position .mfa-message at the bottom and "outside" of the panels */

--- a/libs/tup-components/src/mfa/Mfa.module.css
+++ b/libs/tup-components/src/mfa/Mfa.module.css
@@ -2,9 +2,9 @@
 
 /* Layout styles */
 .pairing-container {
-    --extra-space-below-panel-for-message: 50px; /* text copy input height ++ */
+    composes: c-step-panels from '../../styles/c-step-panels.css';
 
-    composes: c-step-panels c-step-panels--has-scroll-parent from '../../styles/c-step-panels.css';
+    padding-bottom: var(--global-space--section-bottom);
 }
 
 .pairing-container > *:not(.pairing-separator) {
@@ -21,8 +21,13 @@
     margin-top: 30px; /* match .mfa-success-container button */
 }
 
+.mfa-message {
+    /* So OTP code copy field will not stretch to fill narrow-width screen */
+    width: max-content;
+}
+
 .field-error {
-  /* so message with very littel text still appears beneath input */
+  /* So message with very little text still appears beneath input */
   display: flex;
 }
 
@@ -59,17 +64,6 @@ label.qr-code-alt-label {
 }
 
 
-/* Wide */
-@media screen and (--medium-and-above) {
-    .pairing-container {
-        composes: c-step-panels--horizontal from '../../styles/c-step-panels.css';
-    }
-    .mfa-message {
-        composes: c-step-panels__message from '../../styles/c-step-panels.css';
-    }
-}
-
-
 
 .mfa-form {
     composes: c-step-panels__content from '../../styles/c-step-panels.css';
@@ -89,4 +83,62 @@ label.qr-code-alt-label {
 }
 .mfa-success-container button {
     margin-top: 30px; /* match .mfa-type-selection */
+}
+
+
+
+/* Responsive layout */
+@media screen and (--medium-and-above) {
+    .pairing-container {
+        /* To layout items on one left-aligned row */
+        grid-auto-flow: column;
+        justify-content: start;
+
+        /* To support `position: absolute` child */
+        position: relative;
+        width: max-content; /* to not let wide child change parent width */
+    }
+
+    /* HACK: Add extra space to hold the .mfa-message "outside" of the panels */
+    .pairing-container {
+        --space-below-panel-before-message: var(--global-space--section-bottom);
+        --space-below-panel-for-form-field: 50px; /* text copy input height++ */
+
+        /* FAQ: body font-size * body line-height + button vert. border + … */
+        --space-below-panel-for-message: calc(
+            var(--global-font-size--small) * 1.4
+            + (var(--global-border-width--normal) * 2)
+            + var(--space-below-panel-for-form-field)
+            + var(--space-below-panel-before-message)
+        );
+
+        padding-bottom: var(--space-below-panel-for-message);
+    }
+
+    /* HACK: Position .mfa-message at the bottom and "outside" of the panels */
+    .pairing-container *:not(:only-child) .mfa-message {
+        /* To position message beneath both paring steps */
+        position: absolute;
+        top: calc(
+            100%
+            - var(--space-below-panel-for-message)
+            + var(--space-below-panel-before-message)
+        );
+
+        /* To not let message horizontally overflow .pairing-container */
+        max-width: calc(
+          100%
+          - var(--global-space--section-left)
+          - var(--global-space--section-right)
+        );
+
+        /* To horizontally center content (not text) */
+        left: 0;
+        right: 0;
+        margin-left: auto;
+        margin-right: auto;
+
+        /* To horizontally center text (not content) */
+        text-align: center;
+    }
 }

--- a/libs/tup-components/styles/c-step-panels.css
+++ b/libs/tup-components/styles/c-step-panels.css
@@ -3,30 +3,11 @@
 .c-step-panels {
     display: grid;
     padding-inline: var(--global-space--section-left);
-    padding-bottom: var(--global-space--section-bottom);
     gap: var(--global-space--section-left);
-
-    --space-below-panel-before-message: var(--global-space--section-bottom);
-    --extra-space: var(--extra-space-below-panel-for-message, 0px);
-
-    /* FAQ: body font-size * body line-height + button vert. border + extra … */
-    --space-below-panel-for-message: calc(
-        var(--global-font-size--small)
-        * 1.4
-        + (var(--global-border-width--normal) * 2)
-        + var(--extra-space)
-        + var(--space-below-panel-before-message)
-    )
 }
 ol.c-step-panels {
     margin-bottom: 0; /* overwrite core-styles.base.css */
 }
-/* HACK: Add space for c-step-panels__message to avoid causing scrollbar */
-.c-step-panels--has-scroll-parent {
-    padding-bottom: var(--space-below-panel-for-message);
-}
-
-
 
 
 
@@ -40,64 +21,12 @@ li.c-step-panels__separator {
 }
 
 /* To add space between "2." and separator */
-.c-step-panels__separator + li {
+.c-step-panels__separator {
     /* This assumes `list-style-position: outside` (browser default) */
-    margin-left: 1.25em;
+    margin-right: 1.25em;
 }
 
 .c-step-panels__content {
     padding-top: 10px;
     padding-bottom: 10px;
-}
-
-
-
-
-
-/* Modifiers */
-
-/* Modifiers: Vertical */
-
-.c-step-panels--vertical {
-    /* no extra styles required yet */
-}
-
-
-
-/* Modifiers: Horizontal */
-
-.c-step-panels--horizontal {
-    /* To layout items on one left-aligned row */
-    grid-auto-flow: column;
-    justify-content: start;
-
-    /* To support `position: absolute` child */
-    position: relative;
-    width: max-content; /* to not let wide child change parent width */
-}
-.c-step-panels--horizontal li:not(:only-child) .c-step-panels__message {
-    /* To position message beneath both paring steps */
-    position: absolute;
-    top: calc(
-        100%
-        - var(--space-below-panel-for-message)
-        + var(--space-below-panel-before-message)
-    );
-
-    /* To stretch content */
-    width: max-content;
-    max-width: calc(
-      100%
-      - var(--global-space--section-left)
-      - var(--global-space--section-right)
-    );
-
-    /* To horizontally center content (not text) */
-    left: 0;
-    right: 0;
-    margin-left: auto;
-    margin-right: auto;
-
-    /* To horizontally center text (not content) */
-    text-align: center;
 }


### PR DESCRIPTION
## Overview

Repair MFA responsive layout CSS so that narrow-screen layout is used.

## Related

- [TUP-571](https://jira.tacc.utexas.edu/browse/TUP-571)
- included in #312

## Changes

- **changed** MFA styles to directly use (**not** compose) responsive styles
- **changed** `c-step-panels` to **not** assume responsive layout

## Testing

1. Open MFA pairing (or unpairing) view.
2. Make message appear (e.g. click button to generate QR code).
3. <details><summary>On <strong>wide</strong> screen (<strong>992px</strong> or wider), layout should be "good".<br /><sup>(click for details)</sup></summary>

    1. Verify panels are **horizontal**.
    1. Verify message is **outside** first panel.
    1. Verify message is **centered** (line between panels is at center of message).
    1. Verify message can **not** exceed width of container.
    	<sup>To do so, live-edit message text to be long enough to wrap.</sup>
    1. Verify **all** content can be seen when scrolling _vertically_.
    	<sup>To do so, make window so short that scrollbar appears.</sup>

	</details>
4. <details><summary>On <strong>narrow</strong> screen (<strong>991px</strong> or narrower), layout should be "good".<br /><sup>(click for details)</sup></summary>

    1. Verify panels are **vertical**.
    1. Verify message is **within** first panel.
    1. Verify message is **left-aligned**.
    1. Verify message can **not** exceed width of container.
    	<sup>To do so, live-edit message text to be long enough to wrap.</sup>
    1. Verify **all** content can be seen when scrolling _vertically_.
    	<sup>To do so, make window so short that scrollbar appears.</sup>

	</details>

If you notice the horizontal scrollbar, then know that it is fixed in #315.

## UI

### Wide

| normal | long message* | vertical scroll |
| - | - | - |
| <img width="1199" alt="wide - normal" src="https://github.com/TACC/tup-ui/assets/62723358/fee9d098-c05d-402f-94c9-91c122e10cd0"> | <img width="1199" alt="wide - long message" src="https://github.com/TACC/tup-ui/assets/62723358/bdca7357-e8d0-4779-a5bc-949efc2cad57"> | <img width="1199" alt="wide - vert  scroll" src="https://github.com/TACC/tup-ui/assets/62723358/a814bf24-6e41-4728-bb30-e0e93a51eaca"> |

### Narrow

| normal* | long message* | vertical scroll* |
| - | - | - |
| <img width="991" alt="normal - normal" src="https://github.com/TACC/tup-ui/assets/62723358/d015f461-7a37-44d0-b1ee-ed3021c6f0ef"> | <img width="991" alt="narrow - long message" src="https://github.com/TACC/tup-ui/assets/62723358/baa83fa0-cd21-417c-96fc-9430eaf6fe34"> | <img width="991" alt="narrow - vert  scroll" src="https://github.com/TACC/tup-ui/assets/62723358/a3510680-ad72-49b2-a4b7-2458f4a01a0f"> |

<details><summary>* About the <code>&lt;TextFieldCopy&gt;</code> stretch…</summary>

_The `<TextFieldCopy>` will try to stretch to fill available space._

To avoid (subjectively) worst case scenario, wide-screen sets `width: max-content` on `.mfa-message` to prevent that, assuming normal-length message text, but with caveats:

1. A long message text stretches the message, thus giving `<TextFieldCopy>` opportunity to stretch on wide screen.
2. `<TextFieldCopy>` is allowed to stretch on a narrow screen, because were a narrow screen to use `width: max-content` on `.mfa-message`, long message text would stretch to fill entire width of screen (which just looked weird to me).

If this solution looks weird to anyone else, tell me and we can let designers decide what they want, which might change the challenge for the better.

_Another solution may be to change `<TextFieldCopy>` to **not** stretch. (That change can be performed independent of this PR.)_

</details>