### PR TITLE
bug/TUP-572: Fix- Auth redirect ignores query strings

### DIFF
--- a/apps/tup-cms/src/apps/portal/decorators.py
+++ b/apps/tup-cms/src/apps/portal/decorators.py
@@ -1,5 +1,6 @@
 from functools import wraps
 from django.shortcuts import redirect
+import urllib
 from django.contrib.auth import authenticate, login
 
 def tup_login_required(login_url="/portal/login"):
@@ -14,7 +15,7 @@ def tup_login_required(login_url="/portal/login"):
             user = authenticate(request)
 
             if user is None:
-                from_path = request.path
+                from_path = urllib.parse.quote(request.get_full_path())
                 return redirect(f'{login_url}?from={from_path}')
 
             login(request, user)


### PR DESCRIPTION
## Overview
Our auth redirect decorator was using `request.path` to construct redirect paths, which ignores query strings. Since users might be following a link that includes a query string, the query should get passed along when the user is redirected after authenticating.

## Related

- [TUP-1234](https://jira.tacc.utexas.edu/browse/TUP-1234)


## Testing

1. Navigate to http://localhost:8000/portal/projects?show=inactive in an incognito/unauthenticated session. After logging in you should be looking at _inactive_ projects instead of the active listing.

## UI

## Notes
