### PR TITLE
Task/TUP-454: Upgrade to Django v4.2

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.12.0-beta.3
-FROM taccwma/core-cms:0992f47
+# TACC/Core-CMS#707 (v3.12.0-beta.4 candidate)
+FROM taccwma/core-cms:1f7b95d
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-# TACC/Core-CMS#707 (v3.12.0-beta.4 candidate)
+# TACC/Core-CMS#707 (sans commits irrelevant to TACC) (v3.12.0-beta.4 candidate)
 FROM taccwma/core-cms:1f7b95d
 
 WORKDIR /code

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
 # TACC/Core-CMS#v3.12.0-beta.3
-FROM taccwma/core-cms:aba079b
+FROM taccwma/core-cms:0992f47
 
 WORKDIR /code
 

--- a/apps/tup-cms/docker-compose.dev.yml
+++ b/apps/tup-cms/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
       - tup_cms_net
 
   postgres:
-    image: postgres:11.5
+    image: postgres:14.9
     environment:
       - POSTGRES_PASSWORD=taccforever
       - POSTGRES_USER=postgresadmin

--- a/apps/tup-cms/src/apps/user_news/cms_plugins.py
+++ b/apps/tup-cms/src/apps/user_news/cms_plugins.py
@@ -3,7 +3,7 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
 from django.utils.translation import gettext_lazy as _
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str as force_text
 
 from .defaults import max_articles, urls
 from .utils import get_latest_articles

--- a/apps/tup-cms/src/taccsite_cms/urls_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/urls_custom.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 
-from django.conf.urls import url
+from django.urls import re_path as url
 from apps.user_news.urls import urls as user_news_urls
 from django.views.generic.base import RedirectView
 


### PR DESCRIPTION
## Overview
Switch to a base CMS image running Django 4.2 and update imports.

## Related

- [TUP-454](https://jira.tacc.utexas.edu/browse/TUP-454)
- requires https://github.com/TACC/Core-CMS/pull/707

## Changes

## Testing

1. Run `docker volume rm tup-cms_tup_cms_postgres_data` to remove data created using Postgres v10
2. Spin up the site/portal as normal and run migrations.

## UI

## Notes
