### PR TITLE
chore: simplify <Button> type and size prop checks

### DIFF
--- a/libs/core-components/src/lib/Button/Button.test.jsx
+++ b/libs/core-components/src/lib/Button/Button.test.jsx
@@ -23,7 +23,6 @@ function isPropertyLimitation(type, size) {
 
   if (
     (type === 'primary' && size === 'small') ||
-    (type !== 'link' && !size) ||
     (type === 'link' && size)
   )
     isLimited = true;

--- a/libs/core-components/src/lib/Button/Button.tsx
+++ b/libs/core-components/src/lib/Button/Button.tsx
@@ -24,19 +24,6 @@ export const SIZES = [''].concat(Object.keys(SIZE_MAP));
 
 export const ATTRIBUTES = ['button', 'submit', 'reset'];
 
-type ButtonTypeLinkSize = {
-  type?: 'link';
-  size?: never;
-};
-type ButtonTypePrimarySize = {
-  type?: 'primary';
-  size?: 'short' | 'medium' | 'long';
-};
-type ButtonTypeOtherSize = {
-  type?: 'secondary' | 'tertiary' | 'active';
-  size?: 'short' | 'medium' | 'long' | 'small';
-};
-
 type ButtonProps = React.PropsWithChildren<{
   className?: string;
   iconNameBefore?: string;
@@ -47,8 +34,9 @@ type ButtonProps = React.PropsWithChildren<{
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   attr?: 'button' | 'submit' | 'reset';
   isLoading?: boolean;
-}> &
-  (ButtonTypeLinkSize | ButtonTypePrimarySize | ButtonTypeOtherSize);
+  type?: 'primary' | 'secondary' | 'tertiary' | 'active' | 'link';
+  size?: 'short' | 'medium' | 'long' | 'small';
+}>;
 
 const Button: React.FC<ButtonProps> = ({
   children,
@@ -64,6 +52,15 @@ const Button: React.FC<ButtonProps> = ({
   attr = 'button',
   isLoading = false,
 }) => {
+  if (size && type === 'link') {
+    console.error('<Button type="link"> must not set `size` prop.');
+    return;
+  }
+  if (size === 'small' && type === 'primary') {
+    console.error('<Button type="primary"> must not be `size="small"`.');
+    return;
+  }
+
   function onclick(e: React.MouseEvent<HTMLButtonElement>) {
     if (disabled) {
       e.preventDefault();


### PR DESCRIPTION
## Overview

Simplify checks for `<Button>` props: `type`, `size`.

> **Note**
> Now `<Button>` shows console errors, instead of TypeScript errors.

> **Warning**
> By doing this, debugging prop errors with `<Button>` can be slower.

## Related

- caused by https://github.com/TACC/tup-ui/pull/317
- simpler than https://github.com/TACC/tup-ui/pull/319
- simpler than https://github.com/TACC/tup-ui/pull/319

## Changes

- **removed** unnecessary `<Button>` test
- **changed** some `<Button>` prop checks to be console errors

## Testing

1. `npx nx test core-components`
2. `npx nx test tup-ui`
3. All tests should pass.

## UI

N/A