### PR TITLE
Task/TUP-602: Improve exception handling in auth backend

### DIFF
--- a/apps/tup-cms/src/apps/portal/backend.py
+++ b/apps/tup-cms/src/apps/portal/backend.py
@@ -13,10 +13,12 @@ class TupServicesBackend(ModelBackend):
 
         profile_url = f"{service_url}/users/profile"
         headers = {"x-tup-token": token}
-
-        req = requests.get(profile_url, headers=headers)
-        if req.status_code != 200:
-            raise PermissionDenied
+        
+        try:
+            req = requests.get(profile_url, headers=headers, timeout=10)
+            req.raise_for_status()
+        except Exception as exc:
+            raise PermissionDenied from exc
 
         profile = req.json()
         username = profile['username']


### PR DESCRIPTION
## Overview
Add a timeout to the backend request made during authentication. Add more generic exception handling so that if TUP-services is unavailable for some reason, the site is still accessible.

## Related

- [TUP-602](https://jira.tacc.utexas.edu/browse/TUP-602)

## Changes

## Testing

1. In the `main` branch, set TUP_SERVICES_URL in the config to something that doesn't exist. Confirm the existing behavior, which is that failure to connect to tup-services will prevent the entire site from rendering.
2. Check out the PR branch and do the same thing. You should see the site render but be logged out if you were logged in before.

## UI

## Notes
