### PR TITLE
feat: small header action buttons & allow small primary buttons

### DIFF
--- a/apps/tup-ui/src/pages/Projects/Projects.tsx
+++ b/apps/tup-ui/src/pages/Projects/Projects.tsx
@@ -10,7 +10,7 @@ import styles from './Projects.module.css';
 
 const NewProject = () => (
   <a href="https://submit-tacc.xras.org/" target="_blank" rel="noreferrer">
-    <Button type="primary">+ New Project</Button>
+    <Button type="primary" size="small">+ New Project</Button>
   </a>
 );
 

--- a/libs/core-components/src/lib/Button/Button.tsx
+++ b/libs/core-components/src/lib/Button/Button.tsx
@@ -28,12 +28,8 @@ type ButtonTypeLinkSize = {
   type?: 'link';
   size?: never;
 };
-type ButtonTypePrimarySize = {
-  type?: 'primary';
-  size?: 'short' | 'medium' | 'long';
-};
 type ButtonTypeOtherSize = {
-  type?: 'secondary' | 'tertiary' | 'active';
+  type?: 'primary' | 'secondary' | 'tertiary' | 'active';
   size?: 'short' | 'medium' | 'long' | 'small';
 };
 
@@ -48,7 +44,7 @@ type ButtonProps = React.PropsWithChildren<{
   attr?: 'button' | 'submit' | 'reset';
   isLoading?: boolean;
 }> &
-  (ButtonTypeLinkSize | ButtonTypePrimarySize | ButtonTypeOtherSize);
+  (ButtonTypeLinkSize | ButtonTypeOtherSize);
 
 const Button: React.FC<ButtonProps> = ({
   children,

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateModal.tsx
@@ -6,7 +6,7 @@ import styles from './TicketCreateModal.module.css';
 
 const TicketCreateModal: React.FC<
   React.PropsWithChildren<{
-    display: 'secondary' | 'link';
+    display: 'secondary' | 'link' | 'primary';
     size?: 'small';
   }>
 > = ({ children, size, display }) => {
@@ -23,8 +23,8 @@ const TicketCreateModal: React.FC<
 
   return (
     <>
-      {display === 'secondary' && (
-        <Button onClick={() => toggle()} type="secondary" size={size}>
+      {display !== 'link' && (
+        <Button onClick={() => toggle()} type={display} size={size}>
           {children}
         </Button>
       )}

--- a/libs/tup-components/src/tickets/Tickets.tsx
+++ b/libs/tup-components/src/tickets/Tickets.tsx
@@ -12,7 +12,7 @@ const Tickets: React.FC = () => {
       <section className={styles['tickets-section']}>
         <SectionHeader
           actions={
-            <TicketCreateModal display="secondary">
+            <TicketCreateModal display="secondary" size="small">
               + New Ticket
             </TicketCreateModal>
           }


### PR DESCRIPTION
## Overview

All header actions are now small. Also, small primary buttons are allowed.

## Related

- [TUP-559 comment (see "1.")](https://jira.tacc.utexas.edu/browse/TUP-599?focusedId=28380&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28380)

## Changes

- allow small primary`<Button>`s
- header actions buttons are now all small
- allow primary tickets table button (even if not used)

## Testing

1. Load all sections.
2. Verify all header action buttons are small.

## UI

| dashboard | projects | tickets |
| - | - | - |
| ![dashboard](https://github.com/TACC/tup-ui/assets/62723358/fc6302b6-8062-42d7-b320-6662f0fc5fb3) | ![projects](https://github.com/TACC/tup-ui/assets/62723358/884bc870-1695-4abf-9e14-fa9ab54c49ea) | ![tickets](https://github.com/TACC/tup-ui/assets/62723358/b58d603c-8d12-4e09-b72a-887d6780d5d4) |