### PR TITLE
feat: tup-612 isNestedHeader prop in <SectionHeader>

### DIFF
--- a/apps/tup-ui/src/pages/Projects/Projects.tsx
+++ b/apps/tup-ui/src/pages/Projects/Projects.tsx
@@ -20,7 +20,7 @@ const Layout: React.FC = () => {
       <section className={styles['project-section']}>
         <PageLayout
           top={
-            <SectionHeader actions={<NewProject />}>
+            <SectionHeader actions={<NewProject />} isNestedHeader>
               Projects & Allocations
             </SectionHeader>
           }

--- a/libs/core-components/src/lib/SectionHeader/SectionHeader.jsx
+++ b/libs/core-components/src/lib/SectionHeader/SectionHeader.jsx
@@ -42,9 +42,11 @@ function SectionHeader({
   isForForm,
   isForTable,
   isForList,
+  isNestedHeader,
 }) {
   let styleName = '';
   const styleNameList = [styles['root']];
+  const HeaderTagName = isNestedHeader ? 'div' : 'header';
   const HeadingTagName = isForForm || isForTable || isForList ? 'h2' : 'h1';
 
   if (isForForm) styleNameList.push(styles['for-form']);
@@ -55,14 +57,14 @@ function SectionHeader({
   styleName = styleNameList.join(' ');
 
   return (
-    <header className={`${className} ${styleName}`}>
+    <HeaderTagName className={`${className} ${styleName}`}>
       {children && (
         <HeadingTagName className={styles['heading']}>
           {children}
         </HeadingTagName>
       )}
       {actions}
-    </header>
+    </HeaderTagName>
   );
 }
 SectionHeader.propTypes = {

--- a/libs/tup-components/src/projects/header/ProjectHeader/ProjectHeader.tsx
+++ b/libs/tup-components/src/projects/header/ProjectHeader/ProjectHeader.tsx
@@ -86,7 +86,7 @@ export const ProjectHeader: React.FC<{ projectId: number }> = ({
 
   return (
     <div className={styles['project-header']}>
-      <SectionHeader>
+      <SectionHeader isNestedHeader>
         {isActive && <Link to={'/projects?show=active'}>Active Projects </Link>}
         {!isActive && (
           <Link to={'/projects?show=inactive'}>Inactive Projects </Link>

--- a/libs/tup-components/src/system-status/details/SystemStatusHeader.tsx
+++ b/libs/tup-components/src/system-status/details/SystemStatusHeader.tsx
@@ -17,7 +17,7 @@ export const SystemStatusHeader: React.FC<SystemDetailProps> = ({
 
   if (error)
     return (
-      <SectionHeader>
+      <SectionHeader isNestedHeader>
         <InlineMessage type="warn">
           System Status / Unable to retrieve system name
         </InlineMessage>
@@ -25,6 +25,8 @@ export const SystemStatusHeader: React.FC<SystemDetailProps> = ({
     );
 
   return (
-    <SectionHeader>System Status / {dataBySystem?.display_name}</SectionHeader>
+    <SectionHeader isNestedHeader>
+      System Status / {dataBySystem?.display_name}
+    </SectionHeader>
   );
 };


### PR DESCRIPTION
## Overview

Do **not** nest `<header>` tags.

## Related

- [TUP-612](https://jira.tacc.utexas.edu/browse/TUP-612)

## Changes

## Testing

1. Open each section.
2. Inspect elements of the section header.
3. Verify only one `<header>` tag is used for the section header.

## UI

| | before | after |
| - | - | - |
| Projects | ![proj alloc - before](https://github.com/TACC/tup-ui/assets/62723358/34e7c0c5-282f-4a09-81cc-d648346ef668) |  ![proj alloc - after](https://github.com/TACC/tup-ui/assets/62723358/13b1d90e-e56c-4d58-8296-bcba769630d9)
| Project | ![project - before](https://github.com/TACC/tup-ui/assets/62723358/2b868f7d-d426-4db6-85c1-55c9669d4570) | ![project - after](https://github.com/TACC/tup-ui/assets/62723358/c814e2e7-61c5-43ff-a286-cdac77cd33bb) |
| System | ![sys status - before](https://github.com/TACC/tup-ui/assets/62723358/8959476e-26d7-4979-83a0-46f424d04b1d) | ![sys status - after](https://github.com/TACC/tup-ui/assets/62723358/addb05b3-c6c1-4be2-aad3-23e840fcd07e) |

<details><summary>Unchanged</summary>

| dashboard | account | tickets |
| - | - | - |
| ![dashboard - before](https://github.com/TACC/tup-ui/assets/62723358/298d9d3d-7310-4a0f-a866-7c5c0791a4a3) | ![mng acct - before](https://github.com/TACC/tup-ui/assets/62723358/53d27bd0-ea5a-48b1-afd0-013dac00c1b9) | ![tickets - before](https://github.com/TACC/tup-ui/assets/62723358/9fb09748-f4d0-4764-bae7-140370c9b6c8) |

</details>

## Notes

Were `<Section>` used, this prop would not be necessary. But instead `<PageLayout>` and `<SectionHeader>` are used independently, allowing developers the freedom to make inconsistent layouts.

I welcome ideas for other solutions (to [TUP-612](https://jira.tacc.utexas.edu/browse/TUP-612)). But, try to avoid suggestions that result in more wrapper elements than the app already (and inconsistently) suffers.