### PR TITLE
fix: ManageAccount header non-standard spacing

### DIFF
--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -19,6 +19,13 @@
   --global-space--section-bottom: 30px;
   --global-space--section-left: 20px;
   --global-space--section-right: 30px;
+  /* NOTE: Unexpectedly required */
+  /* HELP: Why isn't Core-Styles `--global-space--section` auto-updated? */
+  --global-space--section:
+    var(--global-space--section-top)
+    var(--global-space--section-right)
+    var(--global-space--section-bottom)
+    var(--global-space--section-left);
 }
 
 /* To stretch application height to available space */

--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -19,7 +19,7 @@
   --global-space--section-bottom: 30px;
   --global-space--section-left: 20px;
   --global-space--section-right: 30px;
-  /* NOTE: Unexpectedly required */
+  /* NOTE: Unexpectedly required to apply the above var changes */
   /* HELP: Why isn't Core-Styles `--global-space--section` auto-updated? */
   --global-space--section:
     var(--global-space--section-top)

--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -7,7 +7,7 @@
     font-size: 2rem;
     border-bottom: 1px solid #707070;
 }
-.account-header i {
+.account-header > i {
     vertical-align: middle;
     margin-top: -0.25em;
     margin-right: 0.5rem;

--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -8,7 +8,7 @@
     border-bottom: 1px solid #707070;
     padding: 10px 0;
 }
-.account-header > i {
+.account-header i {
     vertical-align: middle;
     margin-top: -0.25em;
     margin-right: 0.5rem;

--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -6,7 +6,6 @@
 .account-header {
     font-size: 2rem;
     border-bottom: 1px solid #707070;
-    padding: 10px 0;
 }
 .account-header i {
     vertical-align: middle;

--- a/libs/tup-components/src/accounts/ManageAccount.tsx
+++ b/libs/tup-components/src/accounts/ManageAccount.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Icon, Button } from '@tacc/core-components';
+import { Icon, Button, SectionHeader } from '@tacc/core-components';
 import { useProfile } from '@tacc/tup-hooks';
 import { AccountMfa } from './ManageAccountMfa';
 import styles from './ManageAccount.module.css';
@@ -92,14 +92,14 @@ const ManageUpload = () => (
 const ManageAccount: React.FC = () => {
   const { data } = useProfile();
   return (
-    <section>
-      <article className={styles['account-layout']}>
-        <header className={styles['account-header']}>
+    <section className={styles['account-layout']}>
+      <article>
+        <SectionHeader className={styles['account-header']} isNestedHeader>
           <Icon name="user" />
           <span>
             {data?.firstName} {data?.lastName}
           </span>
-        </header>
+        </SectionHeader>
         <div className={styles['account-body']}>
           <section>
             <ManageUser />

--- a/libs/tup-components/src/accounts/ManageAccount.tsx
+++ b/libs/tup-components/src/accounts/ManageAccount.tsx
@@ -92,8 +92,8 @@ const ManageUpload = () => (
 const ManageAccount: React.FC = () => {
   const { data } = useProfile();
   return (
-    <section className={styles['account-layout']}>
-      <article>
+    <section>
+      <article className={styles['account-layout']}>
         <SectionHeader className={styles['account-header']} isNestedHeader>
           <Icon name="user" />
           <span>

--- a/libs/tup-components/src/tickets/Tickets.module.css
+++ b/libs/tup-components/src/tickets/Tickets.module.css
@@ -2,4 +2,5 @@
     display: flex;
     flex-direction: column;
     padding: var(--global-space--section);
+    padding-bottom: 0px;
 }

--- a/libs/tup-components/src/tickets/Tickets.module.css
+++ b/libs/tup-components/src/tickets/Tickets.module.css
@@ -2,5 +2,4 @@
     display: flex;
     flex-direction: column;
     padding: var(--global-space--section);
-    padding-bottom: 0px;
 }


### PR DESCRIPTION
## Overview

Fix inconsistent header spacing.

## Related

- [TUP-599 comment (see "3.")](https://jira.tacc.utexas.edu/browse/TUP-599?focusedId=28380&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28380)

## Changes

- **fixed** `--global-space--section` not auto-updating
- **removed** extra heading space on `ManageAccount`
- **changed** `ManageAccount` to use `<SectionHeader>`

## Testing

1. Open each section except Dashboard.
2. Verify same header spacing (above, beside) on all sections.

## UI

| sections |
| - |
| ![proj alloc](https://github.com/TACC/tup-ui/assets/62723358/8fe04a4b-b0ec-4135-aea7-b1199c1f8091) |
| ![proj](https://github.com/TACC/tup-ui/assets/62723358/0fba8ebc-4ec3-488b-9f6a-a101b8160b58) |
| ![tickets](https://github.com/TACC/tup-ui/assets/62723358/acbde390-105b-4130-953c-5f315f888f2f) |
| ![system](https://github.com/TACC/tup-ui/assets/62723358/1590f143-9659-433a-9615-858e7a08afa9) |
| ![account](https://github.com/TACC/tup-ui/assets/62723358/6efd79a5-084a-49ae-b99f-c901c4418cc2) |
