### PR TITLE
Fix/tup 599 dashboard tall header

### DIFF
--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
@@ -36,6 +36,7 @@
 
 .section {
   display: grid;
+  grid-template-rows: auto 1fr;
   padding: var(--global-space--section)
 }
 


### PR DESCRIPTION
## Overview

Remove excess space above Dashboard header text.

## Related

- [TUP-599 comment (see "4.")](https://jira.tacc.utexas.edu/browse/TUP-599?focusedId=28380&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28380)

## Changes

- **added** css to shrink header

## Testing

1. Open Dashboard.
2. Make window wide (≥1200px) and tall (≥980px).
3. Verify "Dashboard" header text only has 15px of space above it.

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/f69c469d-8288-4f62-84ba-ba347e237fdb) | ![after](https://github.com/TACC/tup-ui/assets/62723358/5ebb5866-de31-4981-b500-7da9a55b6338) |

<details>

![detail](https://github.com/TACC/tup-ui/assets/62723358/57038904-75c9-4d7f-997d-b50076b0a7ab)

</details>