### PR TITLE
feat: tup-615 my account header

### DIFF
--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -6,13 +6,12 @@
 .account-header {
     font-size: 2rem;
     border-bottom: 1px solid #707070;
-    padding: 10px;
+    padding: 10px 0;
 }
 .account-header > i {
-    font-size: 32px;
-    margin-bottom: -6px;
+    vertical-align: middle;
+    margin-top: -0.25em;
     margin-right: 0.5rem;
-
 }
 
 .account-body {


### PR DESCRIPTION
## Overview

Reduce size of icon in My Account section header.
<sub>Also, remove horizontal padding that is not in the [design](https://xd.adobe.com/view/cc3dc245-2792-4e10-bdc1-50d2a7d32979-996e/).</sub>

## Related

- [TUP-615](https://jira.tacc.utexas.edu/browse/TUP-615)

## Changes

- **removed** horizontal padding
- **changed** icon styles

## Testing

1. Open http://localhost:8000/portal/account.
2. Verify user icon in header is smaller and vertically-centered-ish with header text.

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/25ead2a5-2f0c-4a3b-b865-05a827e03478) | ![after](https://github.com/TACC/tup-ui/assets/62723358/cf568c1c-ae2c-460c-a584-c1ac834b7e05) |