### PR TITLE
feat: tup-624: added generics/attributes to demo

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-button.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-button.css
@@ -9,11 +9,3 @@ main > .container   .c-button--is-active {
   /* FAQ: Design shows 10px font */
   font-size: var(--global-font-size--x-small);
 }
-
-/* TODO: Remove from c-button (once it becomes redundant there) */
-/* FAQ: This is now added in generics/attributes.css */
-/*
-[disabled] {
-  pointer-events: none;
-}
-*/

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/generics/attributes.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/generics/attributes.css
@@ -1,12 +1,3 @@
-/* To render data-prefix value as prefixed text */
-[data-prefix]::before {
-  display: inline-block;
-  content: attr(data-prefix);
-  margin-right: 0.25ch;
-
-  text-transform: none;
-}
-
 /* TODO: Remove from c-button in Core-Styles */
 [disabled] {
   pointer-events: none;

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/generics/attributes.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/generics/attributes.css
@@ -1,4 +1,0 @@
-/* TODO: Remove from c-button in Core-Styles */
-[disabled] {
-  pointer-events: none;
-}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-styles.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-styles.css
@@ -5,7 +5,7 @@
 /* … */
 
 /* GENERICS */
-@import url("./for-core-styles/generics/attributes.css") layer(base);
+/* … */
 
 /* ELEMENTS */
 /* … */

--- a/apps/tup-ui/src/main.global.for-core-styles.css
+++ b/apps/tup-ui/src/main.global.for-core-styles.css
@@ -45,16 +45,6 @@ hr {
 }
 
 /* TODO: Remove this after:
-         0. attributes.css is migrated to Core-Styles
-         1. attributes.css is loaded by Portal */
-[data-prefix]::before {
-  display: inline-block;
-  content: attr(data-prefix);
-  margin-right: 0.25ch;
-  text-transform: none;
-}
-
-/* TODO: Remove this after:
          0. CEP v2 colors are removed from Core-Styles settings/color--portal */
 #page-portal main /* i.e. global-safe :root */ {
   /* FAQ: The `!important` is only necessary for dev (and thus prod) server */


### PR DESCRIPTION
## Overview

Migrate generics/attributes to core-styles

## Related

- [TUP-624](https://jira.tacc.utexas.edu/browse/TUP-624)

## Changes

https://github.com/TACC/Core-Styles/pull/244

## Testing

We use data-prefix in the blog sections on the home screen and the portal screen

## UI

<img width="536" alt="Screenshot 2023-10-12 at 12 54 21 PM" src="https://github.com/TACC/tup-ui/assets/63771558/5198c119-35c9-4953-a64d-c3cadd68a16c">

<img width="483" alt="Screenshot 2023-10-12 at 12 54 10 PM" src="https://github.com/TACC/tup-ui/assets/63771558/6315b975-0feb-48dd-9e2a-6383a2203b0a">

## Notes
