### PR TITLE
hotfix: update pills too large or missing

### DIFF
--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/read_item.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/read_item.html
@@ -18,7 +18,9 @@
     {% if article.updates %}
     {% include './updates.html' with updates=article.updates %}
     <header class="c-update__header">
-      <h3 class="c-update__title">{% trans "Original Message" %}</h3>
+      <h3 class="c-update__title">
+        <span class="c-pill">{% trans "Original Message" %}</span>
+      </h3>
       <span>{% trans "Published" %}</span>&nbsp;
       <time datetime="{{ article.postDateTime }}">
           {{ article.postDate }}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--list.css
@@ -142,11 +142,9 @@
   display: none;
 }
 
-/* To style "Update" pill in title */
-.c-news .c-pill {
+/* To style a pill (e.g. "Update" pill in a title) */
+.c-news--list .c-pill:not(:first-child) {
   margin-left: 0.5ch;
-  vertical-align: middle;
-  transform: translateY(-0.125em);
 }
 
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news.css
@@ -117,3 +117,9 @@
 .c-news__data address {
   display: inline;
 }
+
+/* To style a pill (e.g. "Update" pill in a title) */
+.c-news .c-pill {
+  vertical-align: middle;
+  transform: translateY(-0.125em);
+}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-update.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-update.css
@@ -3,6 +3,9 @@
   vertical-align: middle;
   transform: translateY(-0.125em);
 }
+.c-update__title .c-pill:not([class*="c-pill--"]) {
+  background-color: var(--global-color-primary--light);
+}
 
 /* To reduce space between "Original Update" and its content */
 .c-update__header + .c-news__content {

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-update.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-update.css
@@ -4,12 +4,6 @@
   transform: translateY(-0.125em);
 }
 
-/* To style "Update" pill in big article page title */
-.c-update__title .c-pill {
-  font-size: var(--global-font-size--large);
-  min-width: unset; /* overwrite .c-pill */
-}
-
 /* To reduce space between "Original Update" and its content */
 .c-update__header + .c-news__content {
   margin-top: unset; /* ovewrite c-news--read.css */


### PR DESCRIPTION
## Overview / Changes

- Don't let update pill be so large.
- Use a pill for "Original Message".
- Don't add margin-left on pills on an update page.

## Related

None

## Testing

1. Open https://www.tacc.utexas.edu/news/user-updates/107489/.
2. Verify pill is not so big.
3. Verify "Original Message" text is in a gray pill and same size as update pill.
4. ❗️ Verify, on an update **page**, "Update" and "Original Message" pills do **not** have `margin-left`.
5. ❗️ Verify, on an update **list**, "Update" **does** have `margin-left`.

## UI

## Update

| before | after |
| - | - |
| <img width="554" alt="before" src="https://github.com/TACC/tup-ui/assets/62723358/d354e134-acf4-45a8-a1d2-d068c3fc1a8c"> | <img width="554" alt="after" src="https://github.com/TACC/tup-ui/assets/62723358/e1c7df34-866f-46ea-88ca-36c66a1de4cb"> |

### Original Message

| before | after |
| - | - |
| <img width="554" alt="before" src="https://github.com/TACC/tup-ui/assets/62723358/d51164df-ef49-464c-a52f-39096944a28c"> | <img width="554" alt="after" src="https://github.com/TACC/tup-ui/assets/62723358/188b1fae-9ddd-4cae-b614-1a3d23ad1e4e"> |