### PR TITLE
chore: save snippet "css-spacing-fixes"

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-spacing-fixes.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-spacing-fixes.html
@@ -1,10 +1,14 @@
 <style id="css-spacing-fixes">
+/* HELP: Is this ready for tup-cms CSS? */
+/* FAQ: It seems too messy for core-cms */
+
 /* FAQ: Columns that explcitely or automatically span 12, get margin bottom */
 .col-12:not(
   :last-child,
   [class*="banner-cell"],
   #page-scivis-gallery *,
   #page-all-systems *,
+  #page-stampede2 *, /* IMPORTANT: Added on 2023-10-13 */
   :has(h1:only-child) /* /research/tacc-software/, /use-tacc/software-list/ */
 ),
 .col:not(


### PR DESCRIPTION
## Overview

Save a snippet https://tacc.utexas.edu/admin/djangocms_snippet/snippet/104/change/.

## Related

None.

## Changes

- **added** comments
- **added** [Stampede2 page](https://tacc.utexas.edu/systems/stampede2/) use case

## Testing

N/A. Just saving code so it is in version control. Snippet is still in use.

## UI

| no excess space |
| - |
| <img width="705" alt="Screenshot 2023-10-18 at 4 28 02 PM" src="https://github.com/TACC/tup-ui/assets/62723358/5b8bd1f1-4038-4047-8c29-172283fc6ba6"> |