### PR TITLE
feat/tup-630: Migrate django.cms.blog.app.item

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.blog.app.item.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.blog.app.item.css
@@ -1,6 +1,0 @@
-/* TODO: Share styles between c-news and c-feed-list (`time:not(…)`) */
-.blog-list article time:not(:is(h1, h2, h3, h4, h5, h6) *) {
-  color: var(--global-color-accent--secondary);
-  font-weight: var(--medium);
-  text-transform: uppercase;
-}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-cms.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-cms.css
@@ -15,7 +15,6 @@
 
 /* COMPONENTS */
 @import url("./for-core-cms/components/c-footer.css") layer(project);
-@import url("./for-core-cms/components/django.cms.blog.app.item.css") layer(project);
 @import url("./for-core-cms/components/django.cms.blog.app.page.css") layer(project);
 @import url("./for-core-cms/components/django.cms.picture.css") layer(project);
 @import url("./for-core-cms/components/lightgallery.css") layer(project);


### PR DESCRIPTION
## Overview
Migrated django.cms.blog.app.item to core-cms

## Related

- [TUP-630](https://jira.tacc.utexas.edu/browse/TUP-630)

## Changes

- Removed css from tup-ui and migrated to core-cms
- https://github.com/TACC/Core-CMS/pull/734

## Testing

https://www.tacc.utexas.edu/news/latest-news/

## UI

<img width="1451" alt="Screenshot 2023-10-18 at 4 27 19 PM" src="https://github.com/TACC/tup-ui/assets/63771558/4c4553ee-ef76-4ed5-90c5-b5d5f6fdd59d">


## Notes
