### PR TITLE
Hotfix: Pull in djangocms-form fix for export bug

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#707 (sans commits irrelevant to TACC) (v3.12.0-beta.4 candidate)
-FROM taccwma/core-cms:77edfbc
+# TACC/Core-CMS#736 (cms-forms export hotfix)
+FROM taccwma/core-cms:5ceecdd
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
 # TACC/Core-CMS#707 (sans commits irrelevant to TACC) (v3.12.0-beta.4 candidate)
-FROM taccwma/core-cms:1f7b95d
+FROM taccwma/core-cms:5372168
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
 # TACC/Core-CMS#707 (sans commits irrelevant to TACC) (v3.12.0-beta.4 candidate)
-FROM taccwma/core-cms:5372168
+FROM taccwma/core-cms:77edfbc
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview
Django 4 broke our djangocms-form plugin by deprecating the `is_ajax()` method on requests. This PR pulls in a Core-CMS image with an updated dependency.

