### PR TITLE
feat/tup-632: Migrate django.cms.picture.css to core-cms

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.picture.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.picture.css
@@ -1,8 +1,0 @@
-/* HELP: Why/How do I need to add these styles? */
-/* NOTE: There are Core Styles and Core CMS styles for image alignment. */
-/* SEE: https://www.tacc.utexas.edu/news/latest-news/2025/11/11/basic-news-template/?edit (styles below are not needed for figures) */
-/* SEE: https://www.tacc.utexas.edu/education/k-12-students/high-school-camps/gencyber-level-up/ (styles below are needed for images) */
-/* SEE: https://matcssi.tacc.utexas.edu/ (v3.11.1) (styles below not needed for image) */
-img.align-center {
-    display: block;
-}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-cms.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-cms.css
@@ -17,7 +17,6 @@
 @import url("./for-core-cms/components/c-footer.css") layer(project);
 @import url("./for-core-cms/components/django.cms.blog.app.item.css") layer(project);
 @import url("./for-core-cms/components/django.cms.blog.app.page.css") layer(project);
-@import url("./for-core-cms/components/django.cms.picture.css") layer(project);
 @import url("./for-core-cms/components/lightgallery.css") layer(project);
 
 /* TRUMPS */


### PR DESCRIPTION
## Overview

Migrated django.cms.picture.css to core-cms

## Related

- [TUP-632](https://jira.tacc.utexas.edu/browse/TUP-632)

## Changes

- Removed css from tup-ui and migrated to core-cms
- https://github.com/TACC/Core-CMS/pull/736


## Testing

- https://www.tacc.utexas.edu/education/k-12-students/high-school-camps/gencyber-level-up/
- https://matcssi.tacc.utexas.edu/

## UI
<img width="2557" alt="Screenshot 2023-10-23 at 1 51 33 PM" src="https://github.com/TACC/tup-ui/assets/63771558/2dde8ac0-885e-4e9a-a65d-3c51a8c7e3a5">