### PR TITLE
feat/tup-637 Migrate c-card list support to core-styles

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-card.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-card.css
@@ -22,30 +22,6 @@
 
 
 
-
-
-/* SUPPORT LIST IN CARD */
-
-/* FAQ: The Portal uses Bootstrap ".card" for ticket modal */
-:is(.card, .c-card, [class*="card--"]) ul {
-    /* list-style: none; *//* H.P. restored bullets, M.S. does not know */
-    padding-left: 1em; /* overwrite core-styles.cms */
-}
-/* To add space between line items */
-/* FAQ: Using margin and li:not(:first-of-type) because of multi-line items */
-:is(.card, .c-card, [class*="card--"]) li:not(:first-of-type) {
-    margin-top: 0.5em;
-}
-/* TODO: Consider changing this site wide; SEE:
-:where([role=main],main) li:not(td li) { line-height: 1.6; } */
-:is(.card, .c-card, [class*="card--"]) ul:last-child:where(:not(#page-portal *)) {
-    margin-bottom: 2rem;
-}
-
-
-
-
-
 /* ADD CARD--IMAGE */
 
 /* Image */


### PR DESCRIPTION
## Overview

 Migrate c-card list support to core-styles

## Related

- [TUP-637](https://jira.tacc.utexas.edu/browse/TUP-637)

## Changes

- Removed c-card list support from tup-ui
- https://github.com/TACC/Core-Styles/pull/250

## Testing

Use Core-Styles to test list styles:
https://www.tacc.utexas.edu/education/k-12-students/high-school-camps/gencyber/
https://www.tacc.utexas.edu/education/k-12-students/high-school-camps/gencyber-level-up/
https://www.tacc.utexas.edu/education/k-12-students/high-school-camps/connected/

## UI

| Before | After |
| --- | --- |
| <img width="2560" alt="Screenshot 2023-10-26 at 10 38 08 AM" src="https://github.com/TACC/Core-Styles/assets/63771558/f90d4643-41c7-48eb-9ef4-774030cf2014"> | <img width="2527" alt="Screenshot 2023-10-26 at 11 24 38 AM" src="https://github.com/TACC/Core-Styles/assets/63771558/f957acb8-84fe-4f8b-aff8-81ae10d42d3e"> |
| <img width="2560" alt="Screenshot 2023-10-26 at 10 38 18 AM" src="https://github.com/TACC/Core-Styles/assets/63771558/0e7ae440-8795-4ec1-a206-b99476bdfb5b"> | <img width="2530" alt="Screenshot 2023-10-26 at 11 24 47 AM" src="https://github.com/TACC/Core-Styles/assets/63771558/f66f5008-6a47-4e36-8eba-6b25b48475b2"> |

## Notes
