### PR TITLE
feat/tup-618: c-card-frontera-page migration

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-card--frontera-about-page.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-card--frontera-about-page.css
@@ -1,4 +1,0 @@
-/* To add font-weight that (before Core-Styles v1) was assummed */
-.c-card--frontera-about-page img+h3 {
-    font-weight: var(--bold);
-}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-styles.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-styles.css
@@ -17,7 +17,6 @@
 /* COMPONENTS */
 @import url("./for-core-styles/components/c-button.css") layer(base);
 @import url("./for-core-styles/components/c-card.css") layer(base);
-@import url("./for-core-styles/components/c-card--frontera-about-page.css") layer(base);
 @import url("./for-core-styles/components/c-content-block.css") layer(base);
 @import url("./for-core-styles/components/c-feed-list.css") layer(base);
 @import url("./for-core-styles/components/c-news.css") layer(base);


### PR DESCRIPTION
## Overview
This attribute is already in core-styles. Deleting from tup-ui repo.

## Related

- [TUP-618](https://jira.tacc.utexas.edu/browse/TUP-618)
- [core-styles, font-weight](https://github.com/TACC/Core-Styles/blob/b20884a012e50bc33c79aa077a3824ca172ba1ab/src/lib/_imports/components/c-card--frontera-about-page.css#L29)

## Notes

This attribute is already in core-styles. Deleting from tup-ui repo.