### PR TITLE
feat/tup-640 Delete c-card and c-content-block imports

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-styles.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-styles.css
@@ -14,8 +14,6 @@
 /* … */
 
 /* COMPONENTS */
-@import url("./for-core-styles/components/c-card.css") layer(base);
-@import url("./for-core-styles/components/c-content-block.css") layer(base);
 @import url("./for-core-styles/components/c-feed-list.css") layer(base);
 @import url("./for-core-styles/components/c-news.css") layer(base);
 


### PR DESCRIPTION
## Overview

Deleting c-card and c-content-block imports

## Related

- [TUP-640](https://jira.tacc.utexas.edu/browse/TUP-640)

## Changes

- Deleting imports from for-core-styles

## Testing

- Make sure items deleted are imported from core-styles