### PR TITLE
Fix/tup 598 running jobs cut off

### DIFF
--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
@@ -3,6 +3,15 @@
 .panels {
   display: grid;
 
+  /* To reproduce simple layout of narrow screens like CEPv2 */
+  @media (--wide-and-below) {
+    row-gap: 25px;
+    grid-template-rows: auto auto auto;
+    grid-template-areas:
+      "systems"
+      "projects_tickets"
+      "updates";
+  }
   /* To reproduce complex layout of design doc */
   @media (--wide-and-above) {
     gap: 25px;
@@ -21,15 +30,6 @@
   }
   @media (--x-wide-and-above) {
     grid-template-columns: 0.65fr 0.35fr;
-  }
-  /* To reproduce simple layout of narrow screens like CEPv2 */
-  @media (--wide-and-below) {
-    row-gap: 25px;
-    grid-template-rows: auto auto auto;
-    grid-template-areas:
-      "systems"
-      "projects_tickets"
-      "updates";
   }
 }
 .panels > * {

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
@@ -6,7 +6,6 @@
   /* To reproduce complex layout of design doc */
   @media (--wide-and-above) {
     gap: 25px;
-    grid-template-columns: 0.65fr 0.35fr;
     /*set first row as auto to prevent cutting off the sysmon*/
     grid-template-rows: auto 1fr 1fr 1fr;
     overflow:auto;
@@ -15,6 +14,13 @@
       "projects_tickets updates"
       "projects_tickets updates"
       "projects_tickets updates";
+  }
+  /* To avoid System Status columns being cut off if at 0.65fr 0.35fr */
+  @media (--wide-to-x-wide) {
+    grid-template-columns: 0.5fr 0.5fr;
+  }
+  @media (--x-wide-and-above) {
+    grid-template-columns: 0.65fr 0.35fr;
   }
   /* To reproduce simple layout of narrow screens like CEPv2 */
   @media (--wide-and-below) {
@@ -45,7 +51,7 @@
   gap: 25px;
   grid-template-columns: 1fr;
   grid-template-rows: 1fr 1fr;
-  grid-template-areas: 
+  grid-template-areas:
     "projects"
     "tickets";
 


### PR DESCRIPTION
## Overview

Prevent "Running Jobs" and "Waiting Jobs" from being cut off.

How? Change ratio of columns at specific screen width range.

## Related

- [TUP-598](https://jira.tacc.utexas.edu/browse/TUP-598)

## Changes

- **reduce ratio for a screen range**
- move narrowest screen to top

## Testing

1.

## UI

| Before | After |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/abce23e1-2eed-4a2a-8f07-8899ab23f3fc) | ![after](https://github.com/TACC/tup-ui/assets/62723358/f16b1834-f989-4cd7-b572-46a3905e066c) |

| Narrow | Medium (Fixed) | Wide |
| - | - | - |
| ![narrow](https://github.com/TACC/tup-ui/assets/62723358/69405fbc-862f-43e1-9371-7b5b7fe2fe0d) | ![medium](https://github.com/TACC/tup-ui/assets/62723358/234afd06-76c1-4173-b5a9-42531c47692c) | ![wide](https://github.com/TACC/tup-ui/assets/62723358/874587b1-6ec4-40cd-a6f0-320e9bd06531) |