### PR TITLE
feat: tup 648 do not use plain highlight class

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
@@ -23,7 +23,7 @@
     left: 0; top: 0; bottom: 0; right: 0;
     background-color: var(--global-color-primary--x-light);
 }
-.banner-cell--major a:hover .highlight {
+.banner-cell--major a:hover .u-highlight {
     background-color: var(--global-color-accent--normal);
 }
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/banner.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/banner.css
@@ -73,7 +73,7 @@
   margin-bottom: 2.0rem;
 }
 
-[class*="banner-cell--"] .highlight {
+[class*="banner-cell--"] .u-highlight {
 	padding-inline: var(--tag-padding);
 
 	color: var(--global-color-primary--xx-light);


### PR DESCRIPTION
## Overview

Use `.u-highlight` not `.highlight`.

> **Warning**
> Merge delayed; pending https://github.com/TACC/Core-Styles/pull/261.

> **Important**
> After deploy:
> 1. Replace use of `highlight` class with `u-highlight` in snippet.
> 2. Replace use of `highlight` class with `u-highlight` in markup.
> 3. Test again.
> 4. Publish
>
> <details><summary>screenshot guides</summary>
>
> | | Before | After |
> | - | - | - |
> | markup | ![markup BEFORE](https://github.com/TACC/tup-ui/assets/62723358/f2ad24e6-21f0-4ceb-8425-98688a11bb3b) | ![markup AFTER](https://github.com/TACC/tup-ui/assets/62723358/b7f11284-25b7-4db8-8f6b-cd7880f37a48) |
> | snippet | ![snippet BEFORE](https://github.com/TACC/tup-ui/assets/62723358/731af865-4b79-416f-bbc4-e142703ed381) | ![snippet AFTER](https://github.com/TACC/tup-ui/assets/62723358/cab924d7-bff4-450b-bbd6-80552a5d3de4) |
>
> </details>

## Related

- [TUP-648](https://jira.tacc.utexas.edu/browse/TUP-648)
- expects https://github.com/TACC/Core-Styles/pull/261

## Changes

- **changed** CSS in a CMS snippet
- **changed** CSS in a CMS stylesheet

## Testing

1. Mimic changes from https://github.com/TACC/Core-Styles/pull/261.
2. Load styles from this #370 PR.
3. Edit markup of banner text to use `u-highlight`, not `highlight`.
4. Verify header text is highlighted the same as before.
5. Verify header text — on hover — is highlighted the same as before.

## UI

| changed markup and css, annotated screenshot |
| - |
| ![annotated screenshot](https://github.com/TACC/tup-ui/assets/62723358/20eeb825-5dbb-4942-b7c2-d87aa797c949) |

| changed markup and css, mouse hover screenshot |
| - |
| ![screenshot on hover](https://github.com/TACC/tup-ui/assets/62723358/609cec23-92f3-4f40-b70e-6fbc119ee9ac) |
