### PR TITLE
bug/tup-655 Fix footer social icon overlap

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -27,11 +27,12 @@ svg {
 .c-footer .logos--branding {
     --gap: 2rem;
 
-    min-height: 60px;
-    max-height: 120px;
-
     /* NOTE: Test any changes on all browsers and screen sizes */
     grid-template-columns: repeat( 3, minmax(0, 1fr) );
+}
+.c-footer .logos--branding a {
+    min-height: 60px;
+    max-height: 120px;
 }
 
 .c-footer [class*="logos--"] a {


### PR DESCRIPTION
## Overview

Quick Fix: On production site, social media icons overlap the branding icons on footer.

## Related

- [TUP-655](https://jira.tacc.utexas.edu/browse/TUP-655)

## Changes

- Added style to the `a` tag of logo branding instead of to the `p` tag


## Testing

1. https://www.tacc.utexas.edu/
Scroll down to footer, expand window (if not on wide screen) and make sure icons don't overlap.

## UI

| before | after |
| - | - |
| <img width="2560" alt="Screenshot 2023-11-17 at 5 56 49 PM" src="https://github.com/TACC/tup-ui/assets/63771558/c395b0ae-5785-43c8-ba5d-2c0956bbee35"> | <img width="2560" alt="Screenshot 2023-11-17 at 5 59 52 PM" src="https://github.com/TACC/tup-ui/assets/63771558/1324da96-5ab3-415b-9aba-772fbf989324"> Not sure the max-height is necessary. @wesleyboar please advise. |



## Notes
