### PR TITLE
feat(tup-cms)!: filter latest news by category

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#735 (cms-forms export hotfix)
-FROM taccwma/core-cms:5ceecdd
+# TACC/Core-CMS#752 (custom news feed)
+FROM taccwma/core-cms:7d3934c
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -1,0 +1,18 @@
+{# https://github.com/TACC/Core-CMS/blob/feat/cmd-57-allow-custom-news-feed/taccsite_cms/templates/djangocms_blog/post_list.html #}
+{% extends "djangocms_blog/tacc/post_list.html" %}
+{% load i18n blog_post_is_in_category %}
+
+{% block post_loop %}
+{% spaceless %}
+    {% for post in post_list %}
+        {# TACC (when listing, exclude posts that are not of certain categories): #}
+        {% blog_post_is_in_category post category 'feature-story' as should_exclude_post %}
+        {% if not should_exclude_post %}
+            {% include "djangocms_blog/includes/blog_item.html" with post=post image="true" TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
+        {% endif %}
+        {# /TACC #}
+    {% empty %}
+        <p class="blog-empty">{% trans "No article found." %}</p>
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}

--- a/apps/tup-cms/src/taccsite_cms/templatetags/blog_post_is_in_category.py
+++ b/apps/tup-cms/src/taccsite_cms/templatetags/blog_post_is_in_category.py
@@ -1,0 +1,35 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag
+def blog_post_is_in_category(post=None, curr_category=None, category_slug=''):
+    """
+    Custom Template Tag `blog_post_is_in_category`
+
+    Use: Return (boolean) whether given blog post is in a given category.
+
+    Load custom tag into template:
+        {% load blog_post_is_in_category %}
+
+    Template inline usage:
+        {# (renders `True` or `False`) #}
+        {% blog_post_is_in_category post 'include-me' %}
+
+        {# (renders "A" or "B") #}
+        {% blog_post_is_in_category post 'include-me' as should_include_post %}
+        {% if should_include_post %} A {% else %} B {% endif %}
+
+    Example:
+        ../templates/djangocms_blog/post_list.html
+    """
+    is_in_category = False
+    is_category_list = bool(curr_category)
+
+    if not is_category_list:
+        if post.categories.exists:
+            for category in post.categories.all():
+                if category.slug == category_slug:
+                    is_in_category = True
+
+    return is_in_category


### PR DESCRIPTION
## Overview

When rendering news, filter out articles that are not in a certain category.

> [!WARNING] 
> This breaks pagination.

## Related

- [CMD-57](https://jira.tacc.utexas.edu/browse/CMD-57)
- requires https://github.com/TACC/Core-CMS/pull/752

## Changes

- **added** templatetag `blog_post_is_in_category`
- **changed** template `post_list.html` to use templatetag `blog_post_is_in_category`

## Testing

1. Have Blog/News installed.
2. Create two new articles.
3. Make one article be in a category "Exclude" (with slug as `exclude`).
4. Make one article be in a category "Normal Category" (with slug as `normal-category`).
5. Open News page.
6. Verify the "Exclude" article is **not** present.
7. Verify the other article **is** present.
8. Verify "Normal Category" category news feed **still** shows all its articles.
9. Verify "Exclude" category news feed **still** shows all its articles.

## UI

Skipped. _But would be similar to https://github.com/TACC/Core-CMS/pull/751._

