### PR TITLE
fix: tup-654 use c-form--login from core-styles

### DIFF
--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -12,6 +12,9 @@
 @import url("@tacc/core-styles/dist/elements/form.css");
 @import url("@tacc/core-styles/dist/trumps/s-form.css");
 
+/* To use login form styles */
+@import url('@tacc/core-styles/dist/components/c-form--login.css');
+
 /* To overwrite @tacc/core-styles CEPv2 spacing */
 #page-portal main /* i.e. global-safe :root */ {
   /* TACC/Core-Styles/blob/823b7b9/src/lib/_imports/settings/space.css */

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -114,7 +114,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
   const status = (error as AxiosError)?.response?.status;
 
   return (
-    <div className={`${styles.root} ${className}`}>
+    <div className={`c-form c-form--login ${styles.root} ${className}`}>
       <h3 className={`c-form__title ${styles.title}`}>
         <img src={blackLogo} className={styles.logo} alt="TACC Logo" />
         <span>Log In</span>

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -123,7 +123,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
         to continue to the TACC User Portal
       </p>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form className="c-form">
+        <Form>
           <LoginError status={status} isError={isError} />
           <FormikInput
             name="username"


### PR DESCRIPTION
## Overview

Load `c-form--login` from Core-Styles.

## Related

- [TUP-654](https://jira.tacc.utexas.edu/browse/TUP-654)

## Changes

- **added** `c-form` and `c-form--login` classes
- **loaded** `c-form--login.css`

## Testing

1. Login login form.
2. Verify form fields stretch to fill content area.

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/0a92abbd-cf7c-44ed-9631-89dd6fe56581) | ![after](https://github.com/TACC/tup-ui/assets/62723358/d572049b-0baa-44aa-b216-030bd17e54df) |

## Notes

There are many stylesheets and styles that can be removed since Core-Styles v2.21. Some of those removals will remove redundant styles in the login form. I will do this clean up separately, so that this PR remains solely a bug fix.