### PR TITLE
enhance: tup-463 login component should use core-styles

### DIFF
--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -1,17 +1,3 @@
-/* To use new c-nav component not yet in TACC/Core-CMS core-styles.base.css */
-/* TODO: Remove when TACC/Core-CMS loads TACC/Core-Styles v2.13+ */
-/* CAVEAT: Duplicates older, unchanged, global c-nav styles */
-@import url("@tacc/core-styles/dist/components/c-nav.css");
-
-/* To use s-affixed-input-wrapper which had been unused outside TACC/Core-CMS */
-/* TODO: Remove when TACC/Core-CMS loads TACC/Core-Styles v2.14+ */
-@import url("@tacc/core-styles/dist/trumps/s-affixed-input-wrapper.css");
-
-/* To use new form styles in core-styles.base.css */
-/* TODO: Remove when TACC/Core-CMS loads TACC/Core-Styles v2.15+ */
-@import url("@tacc/core-styles/dist/elements/form.css");
-@import url("@tacc/core-styles/dist/trumps/s-form.css");
-
 /* To use login form styles */
 @import url('@tacc/core-styles/dist/components/c-form--login.css');
 

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
@@ -1,97 +1,11 @@
-/* CONTAINER */
-
-.root {
-  font-size: 1.6rem;
-  font-family: var(--global-font-family--sans--cms);
-}
-
-
-
-/* LINKS */
-
-.link {
-  font-weight: var(--medium);
-}
-
-
-
-/* TITLE */
-
-.title,
-.subtitle {
-  text-align: center;
-  color: var(--global-color-primary--xx-dark);
-}
-.title {
-  font-size: 2.4rem;
-  font-weight: var(--black);
-}
-.subtitle {
-  font-size: 1.6rem;
-}
-
-.logo {
-  display: block; /* to collapse margins with heading */
-  margin-inline: auto; /* to re-center image */
-  height: 75px;
-  margin-bottom: 45px;
-}
-
-.subtitle {
-  font-weight: var(--medium); /* mimics value (not appearance) from design */
-  margin-block: 25px; /* mimics django-cms-forms.css `.description` */
-}
-
-
-
-/* FORM */
-
 /* To hide "(required)" (which is an obvious attribute on a login form) */
+/* FAQ: Core-Styles does this for `c-form--star` but not Bootstrap's `badge` */
 .root label :global(.badge) {
   display: none;
-}
-.field {
-  /* To use larger field inputs, always (not just coarse pointer devices) */
-  padding: 12px 12px; /* mimic Core Styles forms.css @media (pointer: coarse) */
-}
-
-
-
-.submit {
-  padding-block: 10px; /* overrides core-styles.base.css button styles */
-}
-
-.submit-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-
-
-/* FOOTER */
-
-.footer {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 12px;
-
-  margin-top: 35px; /* mimics django-cms-forms.css `.button-wrapper` */
-}
-.footer > p {
-  margin-block: 0; /* overwrite browser */
-}
-
-
-/* ERRORS */
-
-.error {
-  margin-bottom: 2rem; /* TODO: move to @tacc/core-styles */
 }
 
 /* When (the only known) error would wrap, move all lines to one line */
 @media screen and (max-width: 435px) {
-  .error br { content: ""; } /* to remove new line */
-  .error br::after { content: " "; } /* to add space */
+  .root :global(.c-form-errors) br { content: ""; } /* to remove new line */
+  .root :global(.c-form-errors) br::after { content: " "; } /* to add space */
 }

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -26,7 +26,7 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
   }
   if (status === 403) {
     return (
-      <div className={`c-form__errors ${styles.error}`}>
+      <div className="c-form__errors">
         Sorry, we can't find an account matching those credentials.
         <br />
         Please try again or <a href="/account/create">create a new account</a>.
@@ -34,7 +34,7 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
     );
   }
   return (
-    <div className={`c-form__errors ${styles.error}`}>
+    <div className="c-form__errors">
       Sorry. Something went wrong while trying to log in. Please try again
       later.
     </div>
@@ -46,7 +46,6 @@ const CreateAccountLink = () => (
     href="https://accounts.tacc.utexas.edu/register"
     target="_blank"
     rel="noreferrer"
-    className={styles.link}
   >
     Create Account
   </a>
@@ -57,7 +56,6 @@ const AccountHelpLink = () => (
     href="/about/help/"
     target="_blank"
     rel="noreferrer"
-    className={styles.link}
   >
     Account Help
   </a>
@@ -68,7 +66,6 @@ const ResetPasswordLink = () => (
     href="https://accounts.tacc.utexas.edu/forgot_password"
     target="_blank"
     rel="noreferrer"
-    className={styles.link}
   >
     Reset Password
   </a>
@@ -115,11 +112,11 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
 
   return (
     <div className={`c-form c-form--login ${styles.root} ${className}`}>
-      <h3 className={`c-form__title ${styles.title}`}>
-        <img src={blackLogo} className={styles.logo} alt="TACC Logo" />
+      <h3 className="c-form__title">
+        <img src={blackLogo} alt="TACC Logo" />
         <span>Log In</span>
       </h3>
-      <p className={`c-form__desc ${styles.subtitle}`}>
+      <p className="c-form__desc">
         to continue to the TACC User Portal
       </p>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
@@ -129,7 +126,6 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
             name="username"
             label="User Name"
             type="text"
-            className={styles.field}
             autoComplete="username"
             required
           />
@@ -137,17 +133,15 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
             name="password"
             label="Password"
             type="password"
-            className={styles.field}
             autoComplete="current-password"
             required
           />
-          <div className={`c-form__buttons ${styles['submit-container']}`}>
+          <div className="c-form__buttons">
             <CreateAccountLink />
             <Button
               type="primary"
               attr="submit"
               size="long"
-              className={styles.submit}
               isLoading={isLoading || !!data}
             >
               Log In
@@ -155,7 +149,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
           </div>
         </Form>
       </Formik>
-      <div className={styles.footer}>
+      <div className="c-form__nav">
         <p>Having trouble logging in?</p>
         <ResetPasswordLink />
         <AccountHelpLink />

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -52,11 +52,7 @@ const CreateAccountLink = () => (
 );
 
 const AccountHelpLink = () => (
-  <a
-    href="/about/help/"
-    target="_blank"
-    rel="noreferrer"
-  >
+  <a href="/about/help/" target="_blank" rel="noreferrer">
     Account Help
   </a>
 );
@@ -116,9 +112,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
         <img src={blackLogo} alt="TACC Logo" />
         <span>Log In</span>
       </h3>
-      <p className="c-form__desc">
-        to continue to the TACC User Portal
-      </p>
+      <p className="c-form__desc">to continue to the TACC User Portal</p>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
           <LoginError status={status} isError={isError} />


### PR DESCRIPTION
## Overview

Delete CSS module styles that mimic Core-Styles.

<details>

- Some Core-Styles CSS was added after TUP login form was developed.
- Now that it is available, TUP login form can use it. Less module CSS!

</details>

## Related

- [TUP-463](https://jira.tacc.utexas.edu/browse/TUP-463)

## Changes

- **removes** `LoginComponent.module.css` styles that are redundant
- **changes** `<LoginComponent>` to rely mostly on Core-Styles

## Testing

1. Open login form.
2. Verify form styles match production.
3. Force error to appear.
4. Verify form styles match production.
5. Resize window.
6. Verify form styles match production.

## UI

| before | after | prod |
| - | - | - |
| ![login form BEFORE](https://github.com/TACC/tup-ui/assets/62723358/9c082dbf-950e-4005-a046-5f735e782976) | ![login form AFTER](https://github.com/TACC/tup-ui/assets/62723358/7d65e352-7a5e-4317-9d81-be9900af99b8) | ![login form PROD](https://github.com/TACC/tup-ui/assets/62723358/52b54a20-567d-466d-9afe-dd2c9e504323) |