### PR TITLE
hotfix: tup-654 mfa c nav pipe not showing

### DIFF
--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -1,5 +1,5 @@
 /* To use login form styles */
-@import url('@tacc/core-styles/dist/components/c-form--login.css');
+@import url('@tacc/core-styles/dist/components/c-form--login.css') layer(base);
 
 /* To overwrite @tacc/core-styles CEPv2 spacing */
 #page-portal main /* i.e. global-safe :root */ {

--- a/libs/core-components/src/lib/TextCopyField/TextCopyField.module.css
+++ b/libs/core-components/src/lib/TextCopyField/TextCopyField.module.css
@@ -7,7 +7,7 @@
   transition: color var(--transition-duration),
     background-color var(--transition-duration);
 
-  composes: c-button--secondary from '@tacc/core-styles/dist/components/c-button.css';
+  composes: c-button--secondary from '@tacc/core-styles/src/lib/_imports/components/c-button.css';
 }
 
 .copy-button.is-copied,


### PR DESCRIPTION
## Overview

Show the invisible pipe between header links in MFA section.

<details><summary><strong>Details</strong></summary>

### Problems

On the first link (the `<button>`), multiple `overflow: hidden`'s were overriding the `overflow: visible` from `c-nav`.

<details>

1. From `TextCopyField.module.css` via `c-button.css`:
    1. The `x-truncate`'s `overflow: hidden` overwrote `overflow: visible`.
    2. It should be the other way around.
    3. Composing from `c-button.css` from `dist/` includes entire file into global scope.
2. From `main.global.css` via `c-form--login.css`:
    1. The `x-truncate`'s `overflow: hidden` overwrote `overflow: visible`.
    2. It should be the other way around.
    3. Importing `c-form--login.css` without layer gave it precedence.

</details>

### Solutions

1. Compose from `/src`, to allow CSS pre-processing to get only what is necessary.
2. Import into `base` layer, so all (relevant) Core-Styles are in base.

### Lessons

1. Always `composes` from `/src` (not `/dist`).
2. Always `@import` Core-Styles into `base` layer (not "anonymous").

</details>

## Related

- [TUP-654](https://jira.tacc.utexas.edu/browse/TUP-654)

## Changes

- **changed** composes path to be from `src/` instead of `dist/`
- **changed** import to be in `base` layer instead of "anonymous"

## Testing

1. Open https://dev.tup.tacc.utexas.edu/portal/mfa.
2. Verify there is a pipe between "Get Help" and "MFA Documentation".

## UI

| Before | After |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/3eb2ac11-4f07-4def-98d8-e49e671a384a) | ![after](https://github.com/TACC/tup-ui/assets/62723358/5ecb5fc9-9947-4496-a44d-a7ca0518e83f) |