### PR TITLE
fix: tup-657 icons too small / redundant cortal.icon.css import

### DIFF
--- a/libs/core-components/src/lib/Icon/Icon.css
+++ b/libs/core-components/src/lib/Icon/Icon.css
@@ -1,1 +1,0 @@
-@import url('@tacc/core-styles/dist/components/cortal.icon.css');

--- a/libs/core-components/src/lib/Icon/Icon.tsx
+++ b/libs/core-components/src/lib/Icon/Icon.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import './Icon.css';
 
 type sizes = 'xs' | 'sm' | 'md' | 'lg';
 


### PR DESCRIPTION
## Overview

<details><summary>Remove redundant import of <code>cortal.icon.css</code>.</summary>

Redundant because:
1. [Portal app imports `core-styles.portal.css`.](https://github.com/TACC/tup-ui/blob/v1.1.2/apps/tup-cms/src/apps/portal/templates/portal/assets.html#L6)
2. [`core-styles.portal.css` already imports `cortal.icon.css`.](https://github.com/TACC/Core-Styles/blob/v2.21.1/src/lib/_imports/core-styles.portal.css#L27)
3. [`Icon.tsx` uses global `icon` classes.](https://github.com/TACC/tup-ui/blob/chore/remove-unnecessary-import/libs/core-components/src/lib/Icon/Icon.tsx#L20)

</details>

It caused duplicate CSS which had greater precedence than the original.

## Related

- [TUP-657](https://jira.tacc.utexas.edu/browse/TUP-657)

## Changes

- **removed** import of `cortal.icon.css`

## Testing

1. Open portal.
2. Verify icons still load (e.g. in sidebar).
3. Verify icon size is larger than production.

## UI

| before | after |
| - | - |
| ![before (prod)](https://github.com/TACC/tup-ui/assets/62723358/0ee7a593-decd-40fc-9e0b-6a524090a6c1) | ![after (local)](https://github.com/TACC/tup-ui/assets/62723358/fb58de94-c1b7-4677-be13-a147404b7a2c) |