### PR TITLE
hotfix: tup-658 login form title too small

### DIFF
--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -44,6 +44,7 @@ body > main {
 }
 
 /* Headings */
+/* TODO: Consider creating Core-Styles `…/elements/headings--portal.css` */
 /* FAQ: Put in base layer (like Core-Styles),
         so Core-Styles classes take precedence */
 @layer base {

--- a/apps/tup-ui/src/main.global.css
+++ b/apps/tup-ui/src/main.global.css
@@ -44,20 +44,24 @@ body > main {
 }
 
 /* Headings */
-h1, h2, h3, h4, h5, h6 {
-  margin-block: 0; /* overwrite Bootstrap <h1> through <h6> */
-}
-h1 {
-  font-size: var(--global-font-size--x-large);
-  font-weight: var(--regular);
-}
-h2 {
-  font-size: var(--global-font-size--large);
-  font-weight: var(--bold);
-}
-h3 {
-  font-size: var(--global-font-size--medium);
-  font-weight: var(--bold);
+/* FAQ: Put in base layer (like Core-Styles),
+        so Core-Styles classes take precedence */
+@layer base {
+  h1, h2, h3, h4, h5, h6 {
+    margin-block: 0; /* overwrite Bootstrap <h1> through <h6> */
+  }
+  h1 {
+    font-size: var(--global-font-size--x-large);
+    font-weight: var(--regular);
+  }
+  h2 {
+    font-size: var(--global-font-size--large);
+    font-weight: var(--bold);
+  }
+  h3 {
+    font-size: var(--global-font-size--medium);
+    font-weight: var(--bold);
+  }
 }
 
 /* Tables */


### PR DESCRIPTION
## Overview

Fix size of login form title "Log in" (was too small).

## Related

- [TUP-658](https://jira.tacc.utexas.edu/browse/TUP-658)
- caused by #379

## Changes

- **moved** heading element styles into `base` layer

## Testing

1. Open login form.
2. Verify "Log in" text is large, not small.

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/4f5cc471-0fae-4fbf-96bd-1b54fcd83fc1) | ![after](https://github.com/TACC/tup-ui/assets/62723358/d9f35251-f5c8-49c7-b82f-aa8f2ebba5b4) |

## Notes

These heading styles might belong in Core-Styles anyway... so I added a comment suggesting that.
