### PR TITLE
TASK/TUP-495 Adding search styles

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/generics/search-elements.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/generics/search-elements.css
@@ -31,11 +31,17 @@
         border: unset;
         padding-inline: unset;
         background: unset;
+        vertical-align: middle;
     }
 
     & .gsc-selected-option-container {
         background: #fff;
         border: var(--global-border--normal);
+    }
+
+    & .gsc-result-info {
+        padding: unset;
+        font-size: var(--global-font-size--medium);
     }
 
 
@@ -122,5 +128,10 @@
     & .gcsc-find-more-on-google:hover {
         text-decoration-line: underline;
         text-decoration-style: solid;
+    }
+
+    & .gcsc-branding-img-noclear {
+        vertical-align: unset;
+        top: 1px;
     }
 }

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/generics/search-elements.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/generics/search-elements.css
@@ -1,10 +1,61 @@
 #cms-content {
+    /* Whole Search Container */
+    /* removes padding from search container */
+    & .gsc-control-cse {
+        padding: unset;
+    }
 
-    /* Effects suggestion phrase after "Did you mean:" */
+    /* make header same as news */
+    & h1 {
+        color: var(--global-color-primary--x-dark);
+    }
+
+
+
+
+
+    /* Table containing search stats and sorting selection options */
+    /* remove border from search analytics, add gray background */
+    & .gsc-above-wrapper-area {
+        border-bottom: unset;
+        margin-inline: -100vw;
+        padding-inline: 100vw;
+        background: var(--global-color-primary--x-light);
+    }
+
+    & .gsc-above-wrapper-area-container {
+        border-bottom: unset;
+    }
+
+    & tbody>tr:first-child>:is(td, th) {
+        border: unset;
+        padding-inline: unset;
+        background: unset;
+    }
+
+    & .gsc-selected-option-container {
+        background: #fff;
+        border: var(--global-border--normal);
+    }
+
+
+
+
+
+    /* Suggestion phrase after "Did you mean:" */
     & .gs-spelling a {
         color: var(--global-color-accent--normal);
     }
 
+    & .gs-spelling {
+        padding: unset;
+    }
+
+
+
+
+
+    /* Search Results */
     /* search result body text */
     & .gs-snippet {
         color: var(--global-color-primary--dark);
@@ -28,6 +79,22 @@
         text-decoration-style: solid;
     }
 
+    /* push search-result description to right */
+    & .gs-image-box {
+        margin-right: 10px;
+    }
+
+
+
+
+
+    /* Bottom Google Page Navigation */
+    & .gsc-cursor-box {
+        display: flex;
+        justify-content: center;
+        margin-block: var(--global-space--large);
+    }
+
     & .gsc-cursor-current-page {
         color: var(--global-color-accent--normal);
         text-decoration: none;
@@ -40,6 +107,11 @@
         text-decoration-style: solid;
     }
 
+
+
+
+
+    /* adjusts google branding */
     & .gcsc-find-more-on-google {
         color: var(--global-color-accent--normal);
         text-decoration: none;
@@ -50,11 +122,5 @@
     & .gcsc-find-more-on-google:hover {
         text-decoration-line: underline;
         text-decoration-style: solid;
-    }
-
-
-
-    h1 {
-        color: var(--global-color-primary--x-dark);
     }
 }

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/generics/search-elements.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/generics/search-elements.css
@@ -1,0 +1,60 @@
+#cms-content {
+
+    /* Effects suggestion phrase after "Did you mean:" */
+    & .gs-spelling a {
+        color: var(--global-color-accent--normal);
+    }
+
+    /* search result body text */
+    & .gs-snippet {
+        color: var(--global-color-primary--dark);
+    }
+
+    /* url under search result title */
+    & .gs-webResult div.gs-visibleUrl {
+        color: var(--global-color-accent--secondary);
+    }
+
+    /* search result titles */
+    & a.gs-title:link {
+        color: var(--global-color-accent--normal);
+        text-decoration: none;
+        text-decoration-thickness: var(--global-border-width--normal);
+        text-underline-offset: 0.2em;
+    }
+
+    & a.gs-title:link:hover {
+        text-decoration-line: underline;
+        text-decoration-style: solid;
+    }
+
+    & .gsc-cursor-current-page {
+        color: var(--global-color-accent--normal);
+        text-decoration: none;
+        text-decoration-thickness: var(--global-border-width--normal);
+        text-underline-offset: 0.2em;
+    }
+
+    & .gsc-cursor-current-page:hover {
+        text-decoration-line: underline;
+        text-decoration-style: solid;
+    }
+
+    & .gcsc-find-more-on-google {
+        color: var(--global-color-accent--normal);
+        text-decoration: none;
+        text-decoration-thickness: var(--global-border-width--normal);
+        text-underline-offset: 0.2em;
+    }
+
+    & .gcsc-find-more-on-google:hover {
+        text-decoration-line: underline;
+        text-decoration-style: solid;
+    }
+
+
+
+    h1 {
+        color: var(--global-color-primary--x-dark);
+    }
+}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-cms.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-core-cms.css
@@ -6,6 +6,7 @@
 
 /* GENERICS */
 @import url("./for-core-cms/generics/pseudo-elements.css") layer(project);
+@import url("./for-core-cms/generics/search-elements.css");
 
 /* ELEMENTS */
 /* … */


### PR DESCRIPTION
## Overview
Adding styles to google search


## Related

- [TUP-495](https://jira.tacc.utexas.edu/browse/TUP-495)

## Changes

- instead of Google colors, use TACC colors (see "Reference")
- remove/prevent the bleed of TACC's Core table styles onto Google search results e.g.
       -- the borders above and below the "About 355 results (0.19 seconds)"
- at least center the pagination


## Testing

http://localhost:8000/search/?q=lonestar&page=1#gsc.tab=0&gsc.q=lonestar&gsc.sort=

## UI

| before | after |
| - | - |
| ![screencapture-tacc-utexas-edu-search-2023-11-22-14_09_37](https://github.com/TACC/tup-ui/assets/63771558/73d784b8-1c22-4361-affc-4b48b5465d5e) | ![screencapture-localhost-8000-search-2023-11-22-14_10_43](https://github.com/TACC/tup-ui/assets/63771558/729d11ac-a71b-4093-b58b-7137f876a95f) |
| ![screencapture-tacc-utexas-edu-search-2023-11-22-14_13_04](https://github.com/TACC/tup-ui/assets/63771558/a89efe5b-0ac1-47b6-9ef2-5edcbaec4c69) | ![screencapture-localhost-8000-search-2023-11-22-14_12_05](https://github.com/TACC/tup-ui/assets/63771558/5fbf6c87-ed4a-4f0d-9344-f4521458df9c) | 

## Notes
