### PR TITLE
feat: tup-463 migrate css to core - misc bugs

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#678 (core-styles v2.11 to v2.22; migrate css to core-cms|styles)
-FROM taccwma/core-cms:d7b7407
+# TACC/Core-CMS#753 (core-styles v2.11 to v2.22; migrate css to core-cms|styles)
+FROM taccwma/core-cms:fcb82f2
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/trumps/search-elements.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/trumps/search-elements.css
@@ -22,7 +22,8 @@
         border-bottom: unset;
     }
 
-    & tbody>tr:first-child>:is(td, th) {
+    /* To override Core-Styles tables */
+    & tbody > tr:first-child > :is(td, th) {
         border: unset;
         padding-inline: unset;
         background: unset;

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/trumps/search-elements.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/trumps/search-elements.css
@@ -35,7 +35,7 @@
     }
 
     & .gsc-selected-option-container {
-        background: #fff;
+        background: var(--global-color-primary--xx-light);
         border: var(--global-border--normal);
     }
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/trumps/search-elements.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/trumps/search-elements.css
@@ -1,4 +1,4 @@
-#cms-content {
+#tacc-google-search {
     /* Whole Search Container */
     /* removes padding from search container */
     & .gsc-control-cse {

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/trumps/search-elements.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/trumps/search-elements.css
@@ -5,11 +5,6 @@
         padding: unset;
     }
 
-    /* make header same as news */
-    & h1 {
-        color: var(--global-color-primary--x-dark);
-    }
-
 
 
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -17,6 +17,12 @@ svg {
 .c-footer .c-button,
 .c-footer [class*="button--"] {
     --max-width: auto; /* override core-styles.base.css */
+    font-size: 80%; /* mimic Botstrap .small and <small> */
+
+    /* TODO: (1) Remove <small> from footer buttons (2) Remove this font-size */
+    & small {
+        font-size: inherit; /* gracefully deprecate use of <small> */
+    }
 }
 
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -11,6 +11,18 @@ svg {
 
 
 
+/* BUTTONS */
+
+/* To style buttons differently than in body */
+.c-footer .c-button,
+.c-footer [class*="button--"] {
+    --max-width: auto; /* override core-styles.base.css */
+}
+
+
+
+
+
 /* LOGOS */
 
 /* To set baseline styles for footer logos */

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nx/vite": "16.5.3",
         "@nx/web": "16.5.3",
         "@nx/workspace": "16.5.3",
-        "@tacc/core-styles": "github:TACC/Core-Styles#9ac94d3d",
+        "@tacc/core-styles": "^2.22.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5502,10 +5502,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.22.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9ac94d3d547e870b8a6eb675a3f73f787c5f19a4",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.2.tgz",
+      "integrity": "sha512-r2QTrZOcUZIjSIcOLktluGhPzGxvYNTEOKF7h6gYmQn8tgiFcesw4xzoIDCVynA5WpaPMZ2jkV3wM+M7SoBd9Q==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -25541,9 +25541,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9ac94d3d547e870b8a6eb675a3f73f787c5f19a4",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.2.tgz",
+      "integrity": "sha512-r2QTrZOcUZIjSIcOLktluGhPzGxvYNTEOKF7h6gYmQn8tgiFcesw4xzoIDCVynA5WpaPMZ2jkV3wM+M7SoBd9Q==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#9ac94d3d",
       "requires": {}
     },
     "@tanstack/query-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nx/vite": "16.5.3",
         "@nx/web": "16.5.3",
         "@nx/workspace": "16.5.3",
-        "@tacc/core-styles": "github:TACC/Core-Styles#a06f5af",
+        "@tacc/core-styles": "github:TACC/Core-Styles#9ac94d3d",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5502,8 +5502,8 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.22.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#a06f5afb12b027dd71470d5ab50c198c9b403697",
+      "version": "2.22.1",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9ac94d3d547e870b8a6eb675a3f73f787c5f19a4",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -25541,9 +25541,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#a06f5afb12b027dd71470d5ab50c198c9b403697",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9ac94d3d547e870b8a6eb675a3f73f787c5f19a4",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#a06f5af",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#9ac94d3d",
       "requires": {}
     },
     "@tanstack/query-core": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nx/vite": "16.5.3",
     "@nx/web": "16.5.3",
     "@nx/workspace": "16.5.3",
-    "@tacc/core-styles": "github:TACC/Core-Styles#9ac94d3d",
+    "@tacc/core-styles": "^2.22.2",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nx/vite": "16.5.3",
     "@nx/web": "16.5.3",
     "@nx/workspace": "16.5.3",
-    "@tacc/core-styles": "github:TACC/Core-Styles#a06f5af",
+    "@tacc/core-styles": "github:TACC/Core-Styles#9ac94d3d",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## Overview / Related

Fix miscellaneous bugs in #344.

## Related

- fixes #344
- coupled with https://github.com/TACC/Core-CMS/pull/753

## Changes / Testing

- Search results order dropdown is still white.
- Footer buttons match production (or look better).

## UI

| test | screenshot |
| - | - |
| search | ![search](https://github.com/TACC/tup-ui/assets/62723358/bafbad77-ed54-4e2e-8790-d74cfbf818cc) |
| footer buttons | ![before](https://github.com/TACC/tup-ui/assets/62723358/0f769433-7c71-4ff8-8b7c-82a3f93a9f22) / ![after](https://github.com/TACC/tup-ui/assets/62723358/4ee78494-3891-4127-8c4e-0df41a2cbd22)