### PR TITLE
sub-task/tup-580 Make footer button small 10px

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -17,11 +17,11 @@ svg {
 .c-footer .c-button,
 .c-footer [class*="button--"] {
     --max-width: auto; /* override core-styles.base.css */
-    font-size: 80%; /* mimic Botstrap .small and <small> */
+    font-size: 10px; /* mimic Botstrap .small and <small> */
 
     /* TODO: (1) Remove <small> from footer buttons (2) Remove this font-size */
     & small {
-        font-size: 10px; /* gracefully deprecate use of <small> */
+        font-size: inherit; /* gracefully deprecate use of <small> */
     }
 }
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -21,7 +21,7 @@ svg {
 
     /* TODO: (1) Remove <small> from footer buttons (2) Remove this font-size */
     & small {
-        font-size: inherit; /* gracefully deprecate use of <small> */
+        font-size: 10px; /* gracefully deprecate use of <small> */
     }
 }
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -17,7 +17,7 @@ svg {
 .c-footer .c-button,
 .c-footer [class*="button--"] {
     --max-width: auto; /* override core-styles.base.css */
-    font-size: 10px; /* mimic Botstrap .small and <small> */
+    font-size: var(--global-font-size--x-small); /* mimic Botstrap .small and <small> */
 
     /* TODO: (1) Remove <small> from footer buttons (2) Remove this font-size */
     & small {


### PR DESCRIPTION
## Overview

Make footer button small 10px. 
_Note:_ There is a comment in the code to remove small altogether. Didn't want to do this (know how to do this) until talking to @wesleyboar. 

## Related

- [TUP-580](https://jira.tacc.utexas.edu/browse/TUP-580)

## Changes

- Adds 10px to the small button in the footer

## Testing

1. Run tup-ui and check button size

## UI

<details>
<summary>Previous Solution</summary>

| ~~10px small button footer~~ Previous solution |
| - |
| <img width="1680" alt="Screenshot 2023-12-04 at 5 06 58 PM" src="https://github.com/TACC/tup-ui/assets/63771558/2d72158d-e6d2-4867-8d46-68af7c776376"> | 

</details>

<details>
<summary>New Solution</summary>

| 10px small button footer ( `a` tag parent) |
| - |
| <img width="1680" alt="Screenshot 2023-12-04 at 5 06 58 PM" src="https://github.com/TACC/tup-ui/assets/63771558/2d72158d-e6d2-4867-8d46-68af7c776376"> | 

</details>


## Notes
