### PR TITLE
sub-task/tup-575 Adds in new aria-describedby link attributes

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/js-new-tab-new-window-accessibility.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/js-new-tab-new-window-accessibility.html
@@ -1,0 +1,23 @@
+
+<script id="new-tab-new-window-accessibility" type="text/javascript">
+
+    // // NOTE: Some links have `target="_blank"` even though they should not
+    const pathsOfManualNewTabLinks = document.querySelectorAll(
+        '[target="_blank"]:not([aria-describedby])'
+    );
+
+    // /** Adds accessibility attribute to links that open in new tab */
+    function supportA11y( link ) {
+        const hasA11yNote = link.querySelector('span.sr-only');
+        const hasA11yDesc = link.hasAttribute('aria-describedby');
+        if ( ! hasA11yNote && ! hasA11yDesc ) {
+            link.setAttribute('aria-describedby', 'msg-open-new-window');
+            if (window.DEBUG) {
+                console.debug(`Link ${link} now has "aria-describedby"`);
+            }
+        }
+    }
+
+    // /* To apply a11y attribute to manual new tab links */
+    [ ...pathsOfManualNewTabLinks ].forEach( supportA11y );
+</script>


### PR DESCRIPTION
## Overview
Let's target all of the `a` tags that have `target="_blank"` and make them accessible.

## Related

- [TUP-575](https://tacc-main.atlassian.net/browse/TUP-575)

## Changes

- Simple snippet change.
- Snippet must be added to the footer in order to be utilized on full document.
- Changes add aria-describedby="msg-open-ext-site-new-window" throughout homepage.

## Testing

1. Make sure to run `npx nx build tup-cms` and `npx nx build tup-ui`
2. Serve both of them
3. Add Snippet JS: New Tab | New Window to Footer-Content - Accessibility
4. Find each `target` in the inspector. Make sure any target with `"_blank" has the `aria-describedby="msg-open-ext-site-new-window"` attribute

## UI
| Add snippet to Footer-Content |
| - |
| <img width="406" alt="Screenshot 2023-12-07 at 3 10 48 PM" src="https://github.com/TACC/tup-ui/assets/63771558/a661a324-4d37-47ab-8662-bbd57a58acaa"> |

| Check for aria-describedby attribute |
| - |
| <img width="1687" alt="Screenshot 2023-12-06 at 11 49 48 AM" src="https://github.com/TACC/tup-ui/assets/63771558/dc9f01f4-a4f2-49ad-be6b-56d846afff46"> | 



## Notes
