### PR TITLE
task/TUP-528: send an email when users submit a form

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/secrets.sample.py
+++ b/apps/tup-cms/src/taccsite_cms/secrets.sample.py
@@ -1,1 +1,4 @@
 TUP_SERVICES_ADMIN_JWT = "CHANGEME"
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = ""

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -32,9 +32,6 @@ DATABASES = {
     }
 }
 
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = "relay.tacc.utexas.edu"
-
 SESSION_COOKIE_AGE = 14400
 
 CMS_TEMPLATES = (

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -32,6 +32,9 @@ DATABASES = {
     }
 }
 
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = "relay.tacc.utexas.edu"
+
 SESSION_COOKIE_AGE = 14400
 
 CMS_TEMPLATES = (


### PR DESCRIPTION
## Overview
Catch form submission events and send users an email to confirm the submission.

## Related

- [TUP-528](https://tacc-main.atlassian.net/browse/TUP-528)


## Testing

1. Submit a form from the TACC website (excluding the ticket form-- tickets already notify users through RT)
2. Check that you receive an email confirmation at the address you entered.

