### PR TITLE
Add cache busting for staticfiles

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -32,6 +32,15 @@ DATABASES = {
     }
 }
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}
+
 SESSION_COOKIE_AGE = 14400
 
 CMS_TEMPLATES = (


### PR DESCRIPTION
## Overview
Update settings to cache-bust staticfiles. Requires server restart after `collectstatic` runs (via post-deploy hook run by Watchtower).
