### PR TITLE
fix: tup-675 submit form without email gives 500

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -70,7 +70,7 @@ def callback(form, cleaned_data, **kwargs):
     logger.debug(f"received submission from {form.name}")
     if form.name == 'rt-ticket-form':
         submit_ticket(cleaned_data)
-    elif cleaned_data["email"]:
+    elif hasattr(cleaned_data, "email"):
         send_confirmation_email(form.name, cleaned_data)
 
 

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -70,7 +70,7 @@ def callback(form, cleaned_data, **kwargs):
     logger.debug(f"received submission from {form.name}")
     if form.name == 'rt-ticket-form':
         submit_ticket(cleaned_data)
-    else:
+    elif cleaned_data["email"]:
         send_confirmation_email(form.name, cleaned_data)
 
 


### PR DESCRIPTION
## Overview

Avoid 500 error on a form that does not have `email` field, by only trying to send confirmation email if there is an `email` field.

## Related

- [TUP-675](https://tacc-main.atlassian.net/browse/TUP-675)
- fixes #392

## Changes

- **added** condition for sending confirmation e-mail

## Testing

### Fix
1. Open old [/about/tours/request/](https://dev.tup.tacc.utexas.edu/about/tours/request/) or create a simple form.
2. Verify form does **not** have a `name="email"` field.
3. Submit form.
4. Verify form submits without 500 error.

### Regression
1. Open old [/about/help-not-via-rt/](https://dev.tup.tacc.utexas.edu/about/help-not-via-rt/) or create a simple form.
2. Verify form **does** have a `name="email-address"` field.
3. Submit form.
4. Verify form submits without 500 error.

## UI

| field (`email-address`) | submit (success) |
| - | - |
| <img width="894" alt="tup-675 pr 399 - field" src="https://github.com/TACC/tup-ui/assets/62723358/cdaa8634-ad16-4699-8a32-008504ce1630"> | <img width="894" alt="tup-675 pr 399 - success" src="https://github.com/TACC/tup-ui/assets/62723358/5e65de31-113c-4bea-851c-e2d2c4c8e42f"> |
