### PR TITLE
feat: tup-677 css/django/vite interoperability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Local dev setup:
 
 - a) `docker exec -it tup_cms /bin/bash`
 - b) `python manage.py migrate`
+
 8.  (if CMS assets change) Collect updated CMS assets:
 
 - a) `docker exec -it tup_cms /bin/bash`

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Local dev setup:
 
 - a) `docker exec -it tup_cms /bin/bash`
 - b) `python manage.py migrate`
+8.  (if CMS assets change) Collect updated CMS assets:
+
+- a) `docker exec -it tup_cms /bin/bash`
+- b) `python manage.py python manage.py collectstatic --ignore assets/*/font*.css`
 
 The TUP dashboard is accessed at http://localhost:8000/portal.
 To bring containers down after development, run `npx nx down tup-cms`.

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,4 +1,4 @@
-# TACC/Core-CMS#4.4.2
+# TACC/Core-CMS#v4.4.2
 FROM taccwma/core-cms:01206e1
 
 WORKDIR /code

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v4.3.0
-FROM taccwma/core-cms:7dabc2e
+# TACC/Core-CMS#778 (likely to be in v4.3.1)
+FROM taccwma/core-cms:1478229
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#778 (likely to be in v4.3.1)
-FROM taccwma/core-cms:80020d3
+# TACC/Core-CMS#780 (likely to be in v4.3.1)
+FROM taccwma/core-cms:ab5fec8
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
 # TACC/Core-CMS#778 (likely to be in v4.3.1)
-FROM taccwma/core-cms:1478229
+FROM taccwma/core-cms:80020d3
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#780 (likely to be in v4.3.1)
-FROM taccwma/core-cms:ab5fec8
+# TACC/Core-CMS#4.4.2
+FROM taccwma/core-cms:01206e1
 
 WORKDIR /code
 

--- a/apps/tup-cms/README.md
+++ b/apps/tup-cms/README.md
@@ -16,6 +16,9 @@ A `Makefile` has been included for convenience. You may use
 make start
 ```
 
+> **Important**
+> If you must run `python manage.py collectstatic` locally, do so via `python manage.py collectstatic --ignore assets/*/font*.css` to avoid error.
+
 ## Based on Core CMS Custom
 
 This is a downstream CMS project, like those in [Core CMS Custom](https://github.com/tacc/core-cms-custom), but has been placed in [tup-ui](https://github.com/tacc/tup-ui) for convenient access to all public TUP code.

--- a/apps/tup-cms/README.md
+++ b/apps/tup-cms/README.md
@@ -17,7 +17,7 @@ make start
 ```
 
 > **Important**
-> If you must run `python manage.py collectstatic` locally, do so via `python manage.py collectstatic --ignore assets/*/font*.css` to avoid error.
+> If you must run `python manage.py collectstatic`, do so via `python manage.py collectstatic --ignore assets/*/font*.css` to avoid error.
 
 ## Based on Core CMS Custom
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -32,6 +32,15 @@ DATABASES = {
     }
 }
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}
+
 SESSION_COOKIE_AGE = 14400
 
 CMS_TEMPLATES = (

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--list.css
@@ -1,9 +1,7 @@
-/* TODO: When integrated into Core-Styles, uncomment this *//*
-@import url("@tacc/core-styles/src/lib/_imports/tools/x-article-link.css");
-@import url("@tacc/core-styles/src/lib/_imports/tools/x-truncate.css");
-
-@import url("_imports/tools/media-queries.css");
-*/
+/* TODO: When integrated into Core-Styles, import these */
+/* @tacc/core-styles/src/lib/_imports/tools/x-article-link.css */
+/* @tacc/core-styles/src/lib/_imports/tools/x-truncate.css */
+/* _imports/tools/media-queries.css */
 
 
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--read.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news--read.css
@@ -1,11 +1,7 @@
-/* TODO: When integrated into Core-Styles, uncomment this *//*
-@import url("@tacc/core-styles/src/lib/_imports/objects/o-offset-content.css");
-*/
-/*
-@import url("@tacc/core-styles/src/lib/_imports/objects/o-offset-content.css");
-@import url("@tacc/core-styles/src/lib/_imports/tools/x-figure.css");
-@import url("@tacc/core-styles/src/lib/_imports/tools/x-blockquote.css");
-*/
+/* TODO: When integrated into Core-Styles, import these */
+/* @tacc/core-styles/src/lib/_imports/objects/o-offset-content.css */
+/* @tacc/core-styles/src/lib/_imports/tools/x-figure.css */
+/* @tacc/core-styles/src/lib/_imports/tools/x-blockquote.css */
 
 
 

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-news.css
@@ -1,6 +1,5 @@
-/* TODO: When integrated into Core-Styles, uncomment this *//*
-@import url("@tacc/core-styles/src/lib/_imports/components/c-tag.css");
-*/
+/* TODO: When integrated into Core-Styles, import these */
+/* @tacc/core-styles/src/lib/_imports/components/c-tag.css */
 
 @import url("./c-news--read.css");
 @import url("./c-news--list.css");

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/elements/mailto-link.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/elements/mailto-link.css
@@ -1,9 +1,0 @@
-@import url("../../../../site_cms/css/build/mailto-link.css");
-
-/* TODO: Consider a new, different inheritence trick */
-/* TODO: Consider for Core-CMS, not Core-Styles */
-/* WARNING: Do not move to Core-Styles, because client font size is uncertain */
-a[data-user][data-domain]::before {
-    /* To hard-code font-size, because inheritance trick failed */
-    font-size: var(--global-font-size--medium);
-}

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/elements/mailto-link.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/elements/mailto-link.css
@@ -1,4 +1,14 @@
-@import url("../../../../../../../taccsite_cms/static/site_cms/css/build/mailto-link.css");
+a[data-user][data-domain] {
+    font-size: 0;
+    visibility: hidden;
+}
+
+a[data-user][data-domain]:before {
+content: attr(data-user) "@" attr(data-domain);
+display: inline;
+font-size: medium;
+visibility: visible;
+}
 
 /* TODO: Consider a new, different inheritence trick */
 /* TODO: Consider for Core-CMS, not Core-Styles */

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/elements/mailto-link.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/elements/mailto-link.css
@@ -1,14 +1,4 @@
-a[data-user][data-domain] {
-    font-size: 0;
-    visibility: hidden;
-}
-
-a[data-user][data-domain]:before {
-content: attr(data-user) "@" attr(data-domain);
-display: inline;
-font-size: medium;
-visibility: visible;
-}
+@import url("../../../../site_cms/css/build/mailto-link.css");
 
 /* TODO: Consider a new, different inheritence trick */
 /* TODO: Consider for Core-CMS, not Core-Styles */

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/elements/mailto-link.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/elements/mailto-link.css
@@ -1,4 +1,4 @@
-@import url("/static/site_cms/css/build/mailto-link.css");
+@import url("../../../../../../../taccsite_cms/static/site_cms/css/build/mailto-link.css");
 
 /* TODO: Consider a new, different inheritence trick */
 /* TODO: Consider for Core-CMS, not Core-Styles */

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-tup-cms.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/tup-cms.for-tup-cms.css
@@ -9,7 +9,6 @@
 
 /* ELEMENTS */
 @import url("./for-tup-cms/elements/headings--cms.css") layer(project);
-@import url("./for-tup-cms/elements/mailto-link.css") layer(project);
 
 /* OBJECTS */
 @import url("./for-tup-cms/objects/o-section.css") layer(project);

--- a/libs/core-components/src/lib/TextCopyField/TextCopyField.module.css
+++ b/libs/core-components/src/lib/TextCopyField/TextCopyField.module.css
@@ -7,7 +7,7 @@
   transition: color var(--transition-duration),
     background-color var(--transition-duration);
 
-  composes: c-button--secondary from '@tacc/core-styles/src/lib/_imports/components/c-button.css';
+  composes: c-button--secondary from '@tacc/core-styles/dist/components/c-button.css';
 }
 
 .copy-button.is-copied,

--- a/libs/core-components/src/lib/TextCopyField/TextCopyField.module.css
+++ b/libs/core-components/src/lib/TextCopyField/TextCopyField.module.css
@@ -6,8 +6,6 @@
 
   transition: color var(--transition-duration),
     background-color var(--transition-duration);
-
-  composes: c-button--secondary from '@tacc/core-styles/dist/components/c-button.css';
 }
 
 .copy-button.is-copied,

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nx/vite": "16.5.3",
         "@nx/web": "16.5.3",
         "@nx/workspace": "16.5.3",
-        "@tacc/core-styles": "^2.22.3",
+        "@tacc/core-styles": "github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5502,10 +5502,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.3.tgz",
-      "integrity": "sha512-niE9F32p/eoywM+cdeHAaN+kIp0GbatBH+4KyRvBFxifKFxfAhnZljFZtGo6NxGHI6PRICjMoNZn+kMBWmDr/g==",
+      "version": "2.22.4",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#4e85f6cf8f605d691634a9f1be90fc2ba5a469ac",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -25541,10 +25541,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.3.tgz",
-      "integrity": "sha512-niE9F32p/eoywM+cdeHAaN+kIp0GbatBH+4KyRvBFxifKFxfAhnZljFZtGo6NxGHI6PRICjMoNZn+kMBWmDr/g==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#4e85f6cf8f605d691634a9f1be90fc2ba5a469ac",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
       "requires": {}
     },
     "@tanstack/query-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nx/vite": "16.5.3",
         "@nx/web": "16.5.3",
         "@nx/workspace": "16.5.3",
-        "@tacc/core-styles": "github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
+        "@tacc/core-styles": "^2.23.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -5502,10 +5502,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.22.4",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#4e85f6cf8f605d691634a9f1be90fc2ba5a469ac",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.23.1.tgz",
+      "integrity": "sha512-Hu3T1/wfdbuQBZ//DBz2FwxAg+3/x9P1skS6sVldnq7yy3EZZpuOO7Tgu4OZbMlWHJG6IebWQnfniyRTOl9mVA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -25541,9 +25541,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#4e85f6cf8f605d691634a9f1be90fc2ba5a469ac",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.23.1.tgz",
+      "integrity": "sha512-Hu3T1/wfdbuQBZ//DBz2FwxAg+3/x9P1skS6sVldnq7yy3EZZpuOO7Tgu4OZbMlWHJG6IebWQnfniyRTOl9mVA==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
       "requires": {}
     },
     "@tanstack/query-core": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nx/vite": "16.5.3",
     "@nx/web": "16.5.3",
     "@nx/workspace": "16.5.3",
-    "@tacc/core-styles": "github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
+    "@tacc/core-styles": "^2.23.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nx/vite": "16.5.3",
     "@nx/web": "16.5.3",
     "@nx/workspace": "16.5.3",
-    "@tacc/core-styles": "^2.22.3",
+    "@tacc/core-styles": "github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## Overview

Edit CSS so that Django and Vite do not use it unexpectedly.

## Related

- [TUP-677](https://tacc-main.atlassian.net/browse/TUP-677)

<details><summary>Pull Requests</summary>

- https://github.com/TACC/tup-ui/pull/400 requires:
    - https://github.com/TACC/Core-Styles/pull/285
    - https://github.com/TACC/Core-CMS/pull/780 requires:
        - https://github.com/TACC/Core-Styles/pull/285
        - https://github.com/TACC/Core-CMS-Resources/pull/197

</details>

## Changes

- **refactored** comments that suggest to `@import` code
- **removed** unnecessary CSS `composes`
- **refactored** absolute `/static` paths to be relative
- **changed** core-cms & core-styles version
- **added** `STORAGES` setting to "fix a cache problem"

## Testing

0. **Uncertain.** See https://github.com/TACC/tup-ui/pull/398.
1. Verify `TextCopyField` button UI and UX is unchanged.
    1. Open [/portal/mfa/totp](https://dev.tup.tacc.utexas.edu/portal/mfa/totp).
    2. Press the [ Click to Generate QR Code ] button.
    3. View & Use the button under "Can't scan QR code?".
2. Verify `/static/tup_cms/css/for-tup-cms/elements/mailto-link.css` successfully imports its `site_cms` counterpart.
3. Verify `/static/site_cms/css/build/mailto-link.css` has `font-size: inherit` (not `font-size: medium`).

## UI

1. https://github.com/TACC/tup-ui/assets/62723358/01d839e6-a799-4d03-aef1-aebb6b9937cb

    https://github.com/TACC/tup-ui/assets/62723358/b23a61cb-4422-4ee7-94d4-ecd2becec66f

2. <img width="960" alt="mailto-link css loads" src="https://github.com/TACC/tup-ui/assets/62723358/5f78d2f0-564d-4645-90b1-9230d54f481d">

3. <img width="960" alt="mailto-link css has font-size initial" src="https://github.com/TACC/tup-ui/assets/62723358/6ab30eba-4730-4fb6-a18c-6663cadb3825">
