### PR TITLE
task/tup-670 Footer branding visible on mobile and safari

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -57,7 +57,6 @@ svg {
     display: inline-flex;
     align-items: center;
     justify-content: center; /* horz align when image narrower than grid cell */
-    min-height: 0;
 }
 
 /* For independent logo sizes */


### PR DESCRIPTION
## Overview
The logos--branding wasn't showing on the footer in mobile view or on Safari.

## Related

- [TUP-670](https://tacc-main.atlassian.net/browse/TUP-670)

## Changes

Removed a conflicting min-height style that for some reason wasn't an issue in Chrome

## Testing

1. Check the branding on Safari and Safari mobile(?)
2. Check other browsers

## UI

| before | after |
| - | - |
| <img width="1680" alt="Screenshot 2023-12-21 at 8 10 02 PM" src="https://github.com/TACC/tup-ui/assets/63771558/99ee17b5-6da8-489f-9905-710fc849f12c"> | <img width="1530" alt="Screenshot 2023-12-21 at 8 51 40 PM" src="https://github.com/TACC/tup-ui/assets/63771558/9b90f2b0-afc5-40ea-8e58-58a363e27e21"> |