### PR TITLE
task/tup-672 adjusts last c-feed-list font-size

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -103,9 +103,6 @@
 /* Elements: Link */
 
 .c-feed-list > a:last-child {
-  font-weight: var(--bold);
-}
-.c-feed-list > a:last-child {
   padding-top: 15px;
 
   /* TODO: When migrated to core-styles, use @extend instead */
@@ -114,6 +111,9 @@
   overflow: hidden;
   white-space: nowrap;
   /* max-width: 100%; /* SEE: https://stackoverflow.com/a/44521595 */
+
+  font-weight: var(--bold);
+  font-size: var(--global-font-size--medium)
 }
 .o-section--style-dark .c-feed-list > a:last-child {
   color: var(--global-color-primary--xx-light);


### PR DESCRIPTION
## Overview

Makes a slight adjustment for the last-child `a` tag to be 14px same as above links

## Related

- [TUP-672](https://tacc-main.atlassian.net/browse/TUP-672)

## Changes

1. Gets rid of duplicate `.c-feed-list > a:last-child` selector
2. Adjusts the size of the `.c-feed-list > a:last-child` element

## Testing

1. View the last `a` tag of the `.c-feed-list` element. Make sure the buttons are not 14px, but the last `a` tag is.

## UI

| Before |
| --- |
| <img width="1603" alt="Screenshot 2024-01-02 at 5 28 28 PM" src="https://github.com/TACC/tup-ui/assets/63771558/a24693a5-f084-4bbc-9127-d246c071d5c2"> | 
| <img width="1521" alt="Screenshot 2024-01-02 at 5 28 36 PM" src="https://github.com/TACC/tup-ui/assets/63771558/15b7ddfd-d9ea-4250-892f-75e3a7ffaa29"> | 
| <img width="1459" alt="Screenshot 2024-01-02 at 5 28 44 PM" src="https://github.com/TACC/tup-ui/assets/63771558/099517dd-0c99-40bb-bc56-3c1f195a16f3"> | 

| After |
| --- |
| <img width="1427" alt="Screenshot 2024-01-02 at 5 29 37 PM" src="https://github.com/TACC/tup-ui/assets/63771558/eb5dea87-14f9-4823-9d1c-e2dfbe880a49"> | 
| <img width="1402" alt="Screenshot 2024-01-02 at 5 29 46 PM" src="https://github.com/TACC/tup-ui/assets/63771558/52e8f5c3-5d94-47d5-b092-cf10d0091146"> | 
| <img width="1353" alt="Screenshot 2024-01-02 at 5 29 56 PM" src="https://github.com/TACC/tup-ui/assets/63771558/c1b38563-f609-4e92-afe0-e70ff7162626"> | 


## Notes
