### PR TITLE
feat: example of custom formik error message comp

### DIFF
--- a/libs/core-wrappers/src/lib/FieldWrapperFormik/FieldWrapperFormik.tsx
+++ b/libs/core-wrappers/src/lib/FieldWrapperFormik/FieldWrapperFormik.tsx
@@ -10,6 +10,7 @@ export type FieldWrapperProps = {
   required?: boolean;
   className?: string;
   description?: React.ReactNode;
+  errorComponent?: React.FC;
 };
 const FieldWrapper: React.FC<React.PropsWithChildren<FieldWrapperProps>> = ({
   name,
@@ -17,6 +18,7 @@ const FieldWrapper: React.FC<React.PropsWithChildren<FieldWrapperProps>> = ({
   required,
   description,
   className,
+  errorComponent: ErrorComponent,
   children,
 }) => {
   return (
@@ -28,7 +30,10 @@ const FieldWrapper: React.FC<React.PropsWithChildren<FieldWrapperProps>> = ({
         {required && <Badge color="danger">Required</Badge>}
       </label>
       {children}
-      <ErrorMessage name={name}>
+      <ErrorMessage
+        name={name}
+        {...(ErrorComponent ? { component: <ErrorComponent /> } : {})}
+      >
         {(msg) => {
           return (
             <ul className="c-form__errors">

--- a/libs/core-wrappers/src/lib/FieldWrapperFormik/fields/FormikTextarea.tsx
+++ b/libs/core-wrappers/src/lib/FieldWrapperFormik/fields/FormikTextarea.tsx
@@ -3,13 +3,14 @@ import FieldWrapper from '../FieldWrapperFormik';
 import { useField } from 'formik';
 import { FormikTextareaProps } from '.';
 
-const FormikTextarea: React.FC<FormikTextareaProps> = ({
+const FormikTextarea: React.FC<FormikTextareaProps & { errorComponent?: React.FC<any> }> = ({
   name,
   label,
   required,
   description,
+  errorComponent: ErrorComponent,
   ...props
-}: FormikTextareaProps) => {
+}) => {
   const [field] = useField(name);
   return (
     <FieldWrapper
@@ -17,6 +18,7 @@ const FormikTextarea: React.FC<FormikTextareaProps> = ({
       label={label}
       required={required}
       description={description}
+      errorComponent={ErrorComponent}
     >
       <textarea {...field} {...props} id={name} />
     </FieldWrapper>

--- a/libs/tup-components/src/tickets/TicketDetailModal/TicketReplyForm.tsx
+++ b/libs/tup-components/src/tickets/TicketDetailModal/TicketReplyForm.tsx
@@ -22,6 +22,8 @@ const formSchema = Yup.object().shape({
   text: Yup.string().required('Required'),
 });
 
+const shouldShowError = false;
+
 export const TicketReplyForm: React.FC<{ ticketId: string }> = ({
   ticketId,
 }) => {
@@ -68,6 +70,9 @@ export const TicketReplyForm: React.FC<{ ticketId: string }> = ({
               label="Reply"
               description=""
               style={{ maxWidth: '100%' }}
+              errorComponent={({ msg }) => (
+                shouldShowError && msg
+              )}
               required
             />
             <FormikSelect name="status" label="Status">


### PR DESCRIPTION
## Overview

How to allow and use a custom error message component for our Formik field wrappers.

> ![IMPORTANT]
> This solution failed.

## Related

- tickets @R-Tomas-Gonzalez is working

## Changes

- **added** `errorComponent` prop to `…Formik/FieldWrapper` and `…/FormikTextarea`
- **added** sample use of `errorComponent` in `TicketReplyForm`

## Testing

0. Run tup-cms and tup-ui with this branch.
1. Open a ticket reply form modal.
2. Notice the "Required" text is **not** underneath the Reply text area field.
3. Change `const shouldShowError` to equal `true`;
4. Notice the "Required" text **is** underneath the Reply text area field.

## UI

Fail.