### PR TITLE
fix: add .nx to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
+# NX
+.nx
+
 # compiled output
 /dist
 /tmp


### PR DESCRIPTION
## Overview

Do not let `.nx` files be comitted.

## Related

- superseded by #407
- `.nx` files added in https://github.com/TACC/tup-ui/pull/404/commits/042edde

## Changes

- **added** `.nx` to `.gitignore`

## Testing

1. Run `npx nx serve tup-cms`.
1. Run `npx nx serve tup-ui`.
1. Run `npx nx format:write`.
1. Verify Git diff does not show `.nx` files.

## UI

<details><summary>Before</summary>

<img width="960" alt="nx format write caused nx cache diff" src="https://github.com/TACC/tup-ui/assets/62723358/a9c6946c-6f9a-425c-ad9d-a831edf53cc7">

</details>