### PR TITLE
docs(README): remove duplicate code from a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Local dev setup:
 8.  (if CMS assets change) Collect updated CMS assets:
 
 - a) `docker exec -it tup_cms /bin/bash`
-- b) `python manage.py python manage.py collectstatic --ignore assets/*/font*.css`
+- b) `python manage.py collectstatic --ignore assets/*/font*.css`
 
 The TUP dashboard is accessed at http://localhost:8000/portal.
 To bring containers down after development, run `npx nx down tup-cms`.


### PR DESCRIPTION
## Overview

Removed copy-pasta from README's `collectstatic` command.