### PR TITLE
chore: cms v4.5.0

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,8 +7,8 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-# TACC/Core-CMS#v4.4.2 with Python 3.11
-FROM taccwma/core-cms:9d388ff
+# TACC/Core-CMS#v4.5.0 (Python 3.11)
+FROM taccwma/core-cms:5473db7
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Update CMS image to numbered release just after https://github.com/TACC/Core-CMS/pull/787 and https://github.com/TACC/tup-ui/pull/409 which just updated the CMS image.

## Related

- formalizes https://github.com/TACC/Core-CMS/pull/787
- formalizes https://github.com/TACC/tup-ui/pull/409

## Changes

- **changed** image of Core-CMS that tup-cms uses

## Testing & UI

N/A