### PR TITLE
fix: restore auto-paragraph

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -205,6 +205,12 @@ TACC_CORE_STYLES_VERSION = 2
 # https://github.com/django-cms/django-filer/blob/2.0.2/docs/permissions.rst
 FILER_ENABLE_PERMISSIONS = True
 
+# https://github.com/django-cms/djangocms-text-ckeditor
+CKEDITOR_SETTINGS = {
+    'autoParagraph': True, # Core-CMS had set this to False
+    'stylesSet': 'default:/static/js/addons/ckeditor.wysiwyg.js',
+    'contentsCss': ['/static/djangocms_text_ckeditor/ckeditor/contents.css'],
+}
 
 # DJANGOCMS_ICON SETTINGS
 # https://github.com/django-cms/djangocms-icon


### PR DESCRIPTION
## Overview

Allow WYSIWYG to force `<p>` tags.

## Related

- revert https://github.com/TACC/Core-CMS/pull/574
- <details><summary>depends on several Core-Styles PRs</summary>

    - https://github.com/TACC/Core-Styles/pull/293
    - https://github.com/TACC/Core-Styles/pull/290
    - https://github.com/TACC/Core-Styles/pull/289
    - https://github.com/TACC/Core-Styles/pull/260
    - https://github.com/TACC/Core-Styles/pull/251

    </details>

## Changes

- **added** CKEDITOR_SETTINGS from CMS
- **changed** one CKEDITOR_SETTINGS value from CMS

## Testing

0. Screenshot Text in a card pattern on homepage.
1. Edit that Text plugin isntance.
2. View WYSIWYG **source** editor.
3. Find inline elements that are not wrapped in a`<p>` tag.
4. View WYSIWYG **preview** editor.
5. Place cursor after the inline element.
6. Press enter (to wrap element with `<p>`).
7. Press backspace (to remove extra new empty `<p>` after element).
8. Save
9. Compare style of card to screenshot.
10. Verify content of the Text has not changed in style.
11. Repeat for other types of unwrapped inline elements.

## UI

…