### PR TITLE
fix: support local cms data and media clones

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,7 @@
 node_modules
 **/secrets.py
 **/settings_local.py
+
+# ignore local CMS data and media folders
+apps/tup-cms/src/data/
+apps/tup-cms/src/media/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .nx
 .cache
 node_modules
+dist
 **/secrets.py
 **/settings_local.py
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,5 @@ node_modules
 **/secrets.py
 **/settings_local.py
 
-# ignore local CMS data and media folders
-apps/tup-cms/src/data/
+# ignore local CMS media folder
 apps/tup-cms/src/media/

--- a/apps/tup-cms/.gitignore
+++ b/apps/tup-cms/.gitignore
@@ -11,15 +11,12 @@ nohup.out
 /portal/.docs/build/
 
 # ignore local static and media folders
+src/media/
 server/static
 server/portal/static/vendor/lib/node_modules
 server/media
 server/cms
 server/docs
-
-# ignore local CMS data and media folders
-src/data/
-src/media/
 
 # Ignore local Django settings
 *secrets.py

--- a/apps/tup-cms/.gitignore
+++ b/apps/tup-cms/.gitignore
@@ -18,8 +18,8 @@ server/cms
 server/docs
 
 # ignore local CMS data and media folders
-apps/tup-cms/src/data/
-apps/tup-cms/src/media/
+src/data/
+src/media/
 
 # Ignore local Django settings
 *secrets.py

--- a/apps/tup-cms/.gitignore
+++ b/apps/tup-cms/.gitignore
@@ -10,12 +10,16 @@ nohup.out
 
 /portal/.docs/build/
 
-#ignore local static and media folders
+# ignore local static and media folders
 server/static
 server/portal/static/vendor/lib/node_modules
 server/media
 server/cms
 server/docs
+
+# ignore local CMS data and media folders
+apps/tup-cms/src/data/
+apps/tup-cms/src/media/
 
 # Ignore local Django settings
 *secrets.py

--- a/apps/tup-cms/docker-compose.dev.yml
+++ b/apps/tup-cms/docker-compose.dev.yml
@@ -11,6 +11,8 @@ services:
     hostname: tup_cms
     volumes:
       - ./src/apps:/code/apps
+      - ./src/media:/code/media
+      - ./src/data:/var/tmp/data
       - ./src/taccsite_custom:/code/taccsite_custom
       - ./src/taccsite_cms/custom_app_settings.py:/code/taccsite_cms/custom_app_settings.py
       - ./src/taccsite_cms/urls_custom.py:/code/taccsite_cms/urls_custom.py


### PR DESCRIPTION
## Overview

Support syncing host's CMS `…/data/` and `…/media/` directories into container.

## Related

- fixes local CMS build failure (@R-Tomas-Gonzalez, @wesleyboar)
- needed since merge to `main` of https://github.com/TACC/tup-ui/pulls/409

## Changes

- **added** sync of CMS `media/` and `data/` folders
- **added** ignore of CMS `media/` and `data/` folders

## Testing

<details open><summary>Via Existing Repo Clone</summary>

1. stop running containers
1. remove global `.gitignore` entries for CMS `data/` and `media/`
1. checkout this branch
1. verify `apps/tup-cms/src/data` is present but ignored
1. verify `apps/tup-cms/src/media` is present but ignored
1. `npm ci`
1. `npx nx build tup-cms`
1. `npx nx serve tup-cms`

</details>
<details><summary>Via New Repo Clone</summary>

1. stop running containers
1. remove global `.gitignore` entries for CMS `data/` and `media/`
1. reclone tup-ui into new directory
1. cd into that new directory
1. checkout this branch
1. `cp -r ../tup-ui/apps/tup-cms/src/data ./apps/tup-cms/src/data`
1. `cp -r ../tup-ui/apps/tup-cms/src/media ./apps/tup-cms/src/media`
1. `docker system prune`
1. `npm ci`
1. `npx nx build tup-cms`
1. `npx nx serve tup-cms`

</details>

## UI

<img width="960" alt="PR 413" src="https://github.com/TACC/tup-ui/assets/62723358/6fb457e1-9316-4910-b407-c2fb5365da99">