### PR TITLE
feat: @tacc/core-components ⚠️ WIP

### DIFF
--- a/libs/core-components/package.json
+++ b/libs/core-components/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@tacc/core-components",
+  "version": "0.0.1",
+  "license": "MIT",
+  "author": "TACC ACI WMA <wma-portals@gmail.com>",
+  "description": "React components for TACC portals.",
+  "files": [
+    "docs",
+    "src"
+  ],
+  "homepage": "https://github.com/TACC/tup-ui/tree/main/libs/tup-components",
+  "repository": {
+    "type": "git",
+    "URL": "git@github.com:TACC/tup-ui.git",
+    "directory": "libs/tup-components"
+  }
+}


### PR DESCRIPTION
## Overview

Support a `@tacc/core-components` Node package.

_This would be a sibling package to [@tacc/core-styles](https://www.npmjs.com/package/@tacc/core-styles)._

## Related

- [TUP-700](https://tacc-main.atlassian.net/browse/TUP-700)

## Changes

- **added** package.json
- …

## Testing

1. …

## UI

…

## Notes

This should allow other TACC projects to re-use React and Typescript components.

Superseded by https://github.com/TACC/tup-ui/pull/433.