### PR TITLE
CMD-80 Adds post-nomial exclusions

### DIFF
--- a/apps/tup-cms/src/apps/staff_profile/forms.py
+++ b/apps/tup-cms/src/apps/staff_profile/forms.py
@@ -5,6 +5,12 @@ from django.utils.translation import gettext_lazy as _
 from djangocms_text_ckeditor.widgets import TextEditorWidget
 
 from .models import StaffProfilePlugin
+from django.core.exceptions import ValidationError
+
+def validate_jr_and_sr(value):
+    if value.lower().endswith('jr') or value.lower().endswith('sr'):
+        if not value.endswith('.'):
+            raise ValidationError('Please use a period after Jr. or Sr.')
 
 class StaffProfilePluginForm(ModelForm):
     first_name = forms.CharField(
@@ -17,7 +23,8 @@ class StaffProfilePluginForm(ModelForm):
     post_nomials = forms.CharField(
         required=False,
         label=_('Post-nomials'),
-        help_text=_('E.g. Ph.D., B.S., M.B.A.')
+        help_text=_('E.g. Ph.D., B.S., M.B.A.'),
+        validators=[validate_jr_and_sr]
     )
     title = forms.CharField(
         required=True,

--- a/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
+++ b/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
@@ -1,8 +1,8 @@
 {% load post_nomials %}
 
-{% post_nomial_exclusions as post_nomial_exclusion_list %}
+{% post_nomials as post_nomials %}
 
-{% if instance.post_nomials and instance.post_nomials not in post_nomial_exclusion_list %}
+{% if instance.post_nomials and instance.post_nomials not in post_nomials %}
     {{ instance.first_name }} {{ instance.last_name }}, {{ instance.post_nomials }}
 {% else %}
   {{ instance.first_name }} {{ instance.last_name }} {{ instance.post_nomials }}

--- a/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
+++ b/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
@@ -1,7 +1,5 @@
 {% load post_nomials %}
 
-{% post_nomials_exclusion_list as post_nomials_exclusion_list %}
-
 {% if instance.post_nomials and instance.post_nomials not in post_nomials_exclusion_list %}
     {{ instance.first_name }} {{ instance.last_name }}, {{ instance.post_nomials }}
 {% else %}

--- a/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
+++ b/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
@@ -1,5 +1,9 @@
-{% if instance.post_nomials %}
-  {{instance.first_name}} {{instance.last_name}}, {{instance.post_nomials}}
+{% load post_nomials %}
+
+{% post_nomial_exclusions as post_nomial_exclusion_list %}
+
+{% if instance.post_nomials not in post_nomial_exclusion_list%}
+   {{ instance.first_name }} {{ instance.last_name }}, {{ instance.post_nomials }}
 {% else %}
-  {{instance.first_name}} {{instance.last_name}}
+   {{ instance.first_name }} {{ instance.last_name }}
 {% endif %}

--- a/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
+++ b/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
@@ -2,8 +2,8 @@
 
 {% post_nomial_exclusions as post_nomial_exclusion_list %}
 
-{% if instance.post_nomials not in post_nomial_exclusion_list%}
-   {{ instance.first_name }} {{ instance.last_name }}, {{ instance.post_nomials }}
+{% if instance.post_nomials and instance.post_nomials not in post_nomial_exclusion_list %}
+    {{ instance.first_name }} {{ instance.last_name }}, {{ instance.post_nomials }}
 {% else %}
-   {{ instance.first_name }} {{ instance.last_name }}
+  {{ instance.first_name }} {{ instance.last_name }} {{ instance.post_nomials }}
 {% endif %}

--- a/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
+++ b/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
@@ -1,5 +1,7 @@
 {% load post_nomials %}
 
+{% post_nomials_exclusion_list as post_nomials_exclusion_list %}
+
 {% if instance.post_nomials and instance.post_nomials not in post_nomials_exclusion_list %}
     {{ instance.first_name }} {{ instance.last_name }}, {{ instance.post_nomials }}
 {% else %}

--- a/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
+++ b/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
@@ -1,8 +1,8 @@
 {% load post_nomials %}
 
-{% post_nomials as post_nomials %}
+{% post_nomial_exclusions as post_nomial_exclusion_list %}
 
-{% if instance.post_nomials and instance.post_nomials not in post_nomials %}
+{% if instance.post_nomials and instance.post_nomials not in post_nomial_exclusion_list %}
     {{ instance.first_name }} {{ instance.last_name }}, {{ instance.post_nomials }}
 {% else %}
   {{ instance.first_name }} {{ instance.last_name }} {{ instance.post_nomials }}

--- a/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
+++ b/apps/tup-cms/src/apps/staff_profile/templates/staff_profile/includes/display_name.html
@@ -1,8 +1,8 @@
 {% load post_nomials %}
 
-{% post_nomial_exclusions as post_nomial_exclusion_list %}
+{% post_nomials_exclusion_list as post_nomials_exclusion_list %}
 
-{% if instance.post_nomials and instance.post_nomials not in post_nomial_exclusion_list %}
+{% if instance.post_nomials and instance.post_nomials not in post_nomials_exclusion_list %}
     {{ instance.first_name }} {{ instance.last_name }}, {{ instance.post_nomials }}
 {% else %}
   {{ instance.first_name }} {{ instance.last_name }} {{ instance.post_nomials }}

--- a/apps/tup-cms/src/apps/staff_profile/templatetags/post_nomials.py
+++ b/apps/tup-cms/src/apps/staff_profile/templatetags/post_nomials.py
@@ -1,12 +1,12 @@
 from django import template
 from django.conf import settings
 
-POST_NOMIAL_EXCLUSIONS = settings.TACC_STAFF_PROFILE_EXCLUDED_POST_NOMIAL_LIST
+POST_NOMIAL_EXCLUSIONS = settings.TACC_EXCLUDED_POST_NOMIAL_LIST
 
 register = template.Library()
 
 @register.simple_tag
-def post_nomials():
+def post_nomial_exclusions():
 
     return POST_NOMIAL_EXCLUSIONS
 

--- a/apps/tup-cms/src/apps/staff_profile/templatetags/post_nomials.py
+++ b/apps/tup-cms/src/apps/staff_profile/templatetags/post_nomials.py
@@ -1,12 +1,12 @@
 from django import template
 from django.conf import settings
 
-POST_NOMIAL_EXCLUSIONS = settings.TACC_EXCLUDED_POST_NOMIAL_LIST
+POST_NOMIAL_EXCLUSIONS = settings.TACC_STAFF_PROFILE_EXCLUDED_POST_NOMIAL_LIST
 
 register = template.Library()
 
 @register.simple_tag
-def post_nomial_exclusions():
+def post_nomials():
 
     return POST_NOMIAL_EXCLUSIONS
 

--- a/apps/tup-cms/src/apps/staff_profile/templatetags/post_nomials.py
+++ b/apps/tup-cms/src/apps/staff_profile/templatetags/post_nomials.py
@@ -1,0 +1,13 @@
+from django import template
+from django.conf import settings
+
+POST_NOMIAL_EXCLUSIONS = settings.TACC_EXCLUDED_POST_NOMIAL_LIST
+
+register = template.Library()
+
+@register.simple_tag
+def post_nomial_exclusions():
+
+    return POST_NOMIAL_EXCLUSIONS
+
+

--- a/apps/tup-cms/src/apps/staff_profile/templatetags/post_nomials.py
+++ b/apps/tup-cms/src/apps/staff_profile/templatetags/post_nomials.py
@@ -1,13 +1,13 @@
 from django import template
 from django.conf import settings
 
-POST_NOMIAL_EXCLUSIONS = settings.TACC_EXCLUDED_POST_NOMIAL_LIST
+POST_NOMIALS_EXCLUSION_LIST = settings.TACC_STAFF_PROFILE_POST_NOMIALS_EXCLUSION_LIST
 
 register = template.Library()
 
 @register.simple_tag
-def post_nomial_exclusions():
+def post_nomials_exclusion_list():
 
-    return POST_NOMIAL_EXCLUSIONS
+    return POST_NOMIALS_EXCLUSION_LIST
 
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -202,7 +202,7 @@ TACC_CORE_STYLES_VERSION = 2
 ########################
 # TACC: STAFF PROFILE
 ########################
-TACC_STAFF_PROFILE_POST_NOMIALS_EXCLUSION_LIST = ["Jr", "Sr", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+TACC_STAFF_PROFILE_POST_NOMIALS_EXCLUSION_LIST = ["Jr.", "Sr.", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
 
 
 ########################

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -205,6 +205,12 @@ TACC_CORE_STYLES_VERSION = 2
 # https://github.com/django-cms/django-filer/blob/2.0.2/docs/permissions.rst
 FILER_ENABLE_PERMISSIONS = True
 
+# https://github.com/django-cms/djangocms-text-ckeditor
+CKEDITOR_SETTINGS = {
+    'autoParagraph': True, # Core-CMS had set this to False
+    'stylesSet': 'default:/static/js/addons/ckeditor.wysiwyg.js',
+    'contentsCss': ['/static/djangocms_text_ckeditor/ckeditor/contents.css'],
+}
 
 # DJANGOCMS_ICON SETTINGS
 # https://github.com/django-cms/djangocms-icon

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -192,13 +192,18 @@ TACC_BLOG_SHOW_TAGS = False
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'external'
 
-TACC_EXCLUDED_POST_NOMIAL_LIST = ["Jr", "Sr", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
 
 ########################
 # TACC: CORE STYLES
 ########################
 
 TACC_CORE_STYLES_VERSION = 2
+
+########################
+# TACC: STAFF PROFILE
+########################
+TACC_STAFF_PROFILE_POST_NOMIALS_EXCLUSION_LIST = ["Jr", "Sr", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+
 
 ########################
 # PLUGIN SETTINGS

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -192,6 +192,8 @@ TACC_BLOG_SHOW_TAGS = False
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'external'
 
+TACC_EXCLUDED_POST_NOMIAL_LIST = ["Jr", "Sr", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+
 ########################
 # TACC: CORE STYLES
 ########################

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -192,13 +192,18 @@ TACC_BLOG_SHOW_TAGS = False
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'external'
 
-TACC_EXCLUDED_POST_NOMIAL_LIST = ["Jr", "Sr", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
 
 ########################
 # TACC: CORE STYLES
 ########################
 
 TACC_CORE_STYLES_VERSION = 2
+
+########################
+# TACC: STAFF PROFILE
+########################
+TACC_STAFF_PROFILE_EXCLUDED_POST_NOMIAL_LIST = ["Jr", "Sr", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+
 
 ########################
 # PLUGIN SETTINGS

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -192,18 +192,13 @@ TACC_BLOG_SHOW_TAGS = False
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'external'
 
+TACC_EXCLUDED_POST_NOMIAL_LIST = ["Jr", "Sr", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
 
 ########################
 # TACC: CORE STYLES
 ########################
 
 TACC_CORE_STYLES_VERSION = 2
-
-########################
-# TACC: STAFF PROFILE
-########################
-TACC_STAFF_PROFILE_EXCLUDED_POST_NOMIAL_LIST = ["Jr", "Sr", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
-
 
 ########################
 # PLUGIN SETTINGS


### PR DESCRIPTION
## Overview
This adds a post-nomial exclusion list so it does not appear on staff directories. 

## Related

- [CMD-80](https://tacc-main.atlassian.net/browse/CMD-80)

## Changes

1. Adds in logic to watch for post-nomials.
2. Constant might need to be moved around in the settings file

## Testing

1. I used Rad.Buk. as a reference for this. Go [here](http://localhost:8000/about/staff-directory/)
2. Choose Rad.Buk. 
3. Change his post-nomials to something in the list that I added to settings. 
4. Watch for the appearance and disappearance of the comma before the post-nomial

## UI

| In exclusion list |
| --- |
| <img width="81" alt="Screenshot 2024-02-06 at 4 27 15 PM" src="https://github.com/TACC/tup-ui/assets/63771558/815cf07a-1785-4acd-92a1-220c5d856369"> |
| <img width="66" alt="Screenshot 2024-02-06 at 4 28 50 PM" src="https://github.com/TACC/tup-ui/assets/63771558/75be155b-504a-405b-b3d8-8c9ed6dc1cc1"> |

| Not in exclusion list |
| --- |
| <img width="129" alt="Screenshot 2024-02-06 at 4 29 13 PM" src="https://github.com/TACC/tup-ui/assets/63771558/ab2b263f-eeff-4ef5-9467-e4334651e19d"> |
| <img width="109" alt="Screenshot 2024-02-06 at 4 29 40 PM" src="https://github.com/TACC/tup-ui/assets/63771558/19f5d24b-b27b-4996-b15f-6656305fa3f9"> |




## Notes
