### PR TITLE
sub-task/tup-696 Adds in manage button to dashboard

### DIFF
--- a/libs/core-components/src/lib/SectionHeader/SectionHeader.jsx
+++ b/libs/core-components/src/lib/SectionHeader/SectionHeader.jsx
@@ -57,7 +57,7 @@ function SectionHeader({
   styleName = styleNameList.join(' ');
 
   return (
-    <HeaderTagName className={`${className} ${styleName}`}>
+    <HeaderTagName className={`${className} ${styleName} ${styleNameList}`}>
       {children && (
         <HeadingTagName className={styles['heading']}>
           {children}

--- a/libs/core-components/src/lib/SectionHeader/SectionHeader.jsx
+++ b/libs/core-components/src/lib/SectionHeader/SectionHeader.jsx
@@ -57,7 +57,7 @@ function SectionHeader({
   styleName = styleNameList.join(' ');
 
   return (
-    <HeaderTagName className={`${className} ${styleName} ${styleNameList}`}>
+    <HeaderTagName className={`${className} ${styleName}`}>
       {children && (
         <HeadingTagName className={styles['heading']}>
           {children}

--- a/libs/core-components/src/lib/SectionHeader/SectionHeader.module.css
+++ b/libs/core-components/src/lib/SectionHeader/SectionHeader.module.css
@@ -22,10 +22,10 @@
 .heading ~ * {
   max-height: 100%; /* (gently) force oversized elements to fit */
 }
-.heading ~ a {
+
+.root a {
   font-weight: var(--bold);
 }
-
 
 
 /* Modifiers */

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -25,11 +25,21 @@ const formatDateTime = (datestring: string): string => {
 const ViewAllUpdates = () => (
   <a
     href={`/news/user-updates/`}
-    className="c-button c-button--as-link"
+    className={`c-button c-button--as-link`}
     target="_blank"
     rel="noopener noreferrer"
   >
     View all Updates
+  </a>
+);
+const Manage = () => (
+  <a
+    href={`https://accounts.tacc.utexas.edu/subscriptions`}
+    className="c-button c-button--as-link"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    Manage
   </a>
 );
 
@@ -41,7 +51,12 @@ const UserNews: React.FC = () => {
   return (
     <SectionTableWrapper
       header="User Updates"
-      headerActions={<ViewAllUpdates />}
+      headerActions={
+        <nav className='c-nav c-nav--no-list c-nav--piped'>
+          <ViewAllUpdates />
+          <Manage />
+        </ nav>
+      }
       contentShouldScroll
     >
       <div className={styles['news-list']}>

--- a/libs/tup-components/src/news/UserNews.tsx
+++ b/libs/tup-components/src/news/UserNews.tsx
@@ -32,6 +32,7 @@ const ViewAllUpdates = () => (
     View all Updates
   </a>
 );
+
 const Manage = () => (
   <a
     href={`https://accounts.tacc.utexas.edu/subscriptions`}
@@ -52,10 +53,10 @@ const UserNews: React.FC = () => {
     <SectionTableWrapper
       header="User Updates"
       headerActions={
-        <nav className='c-nav c-nav--no-list c-nav--piped'>
+        <nav className="c-nav c-nav--no-list c-nav--piped">
           <ViewAllUpdates />
           <Manage />
-        </ nav>
+        </nav>
       }
       contentShouldScroll
     >


### PR DESCRIPTION
## Overview
Adds in a manage button to the dashboard.

## Related

- [TUP-696](https://tacc-main.atlassian.net/browse/TUP-696)

## Changes
Adds in a manage button to the dashboard using the `nav` element. Adds in a manage component to the UserNews file.

## Testing

1. Check http://localhost:8000/portal/dashboard for the manage button and test it's navigation.

## UI

| Links that are piped |
| --- |
| <img width="597" alt="Screenshot 2024-02-06 at 9 40 48 PM" src="https://github.com/TACC/tup-ui/assets/63771558/6e33015f-7527-4543-98b8-f2df1f075497"> |

| UI with console |
| --- |
| <img width="1505" alt="Screenshot 2024-02-06 at 9 41 33 PM" src="https://github.com/TACC/tup-ui/assets/63771558/2ee7b440-542a-4308-b422-57a9f987c703"> |

## Notes
