### PR TITLE
Chore: update Manage Team link to fix deprecated ACCESS url

### DIFF
--- a/libs/tup-components/src/projects/users/UserList/ManageTeam.tsx
+++ b/libs/tup-components/src/projects/users/UserList/ManageTeam.tsx
@@ -14,7 +14,7 @@ const ManageTeam: React.FC<{ projectId: number }> = ({ projectId }) => {
     return (
       <div className={styles['user-navactions']}>
         <a
-          href="https://allocations.access-ci.org/user_management"
+          href="https://allocations.access-ci.org"
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
## Overview
Update Manage Team link to fix deprecated ACCESS url