### PR TITLE
chore: save logos snippet, it has new unique code

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/logos-social-media.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/logos-social-media.html
@@ -1,0 +1,29 @@
+<!-- Manual version of TACC/Core-CMS template + BlueSky -->
+<!-- SEE: https://github.com/TACC/Core-CMS/blob/v4.8.0/taccsite_cms/templates/share_on_social.html -->
+<p class="logos--social">
+  <a href="https://www.facebook.com/tacc.utexas" target="_blank" class="logos__facebook">
+    <svg viewbox="0 0 25 25">
+      <use href="/static/site_cms/img/org_logos/facebook.svg#facebook-icon"></use>
+    </svg>
+  </a>
+  <a href="https://www.youtube.com/user/TACCutexas" target="_blank" class="logos__youtube">
+    <svg viewbox="0 0 25 25">
+      <use href="/static/site_cms/img/org_logos/youtube.svg#youtube-icon"></use>
+    </svg>
+  </a>
+  <a href="https://www.linkedin.com/company/texas-advanced-computing-center-tacc" target="_blank" class="logos__linkedin">
+    <svg viewbox="0 0 25 25">
+      <use href="/static/site_cms/img/org_logos/linkedin.svg#linkedin-icon"></use>
+    </svg>
+  </a>
+  <a href="https://www.instagram.com/taccutexas/" target="_blank" class="logos__instagram">
+    <svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+        <path d="M160,128a32,32,0,1,1-32-32A32.03667,32.03667,0,0,1,160,128Zm68-44v88a56.06353,56.06353,0,0,1-56,56H84a56.06353,56.06353,0,0,1-56-56V84A56.06353,56.06353,0,0,1,84,28h88A56.06353,56.06353,0,0,1,228,84Zm-52,44a48,48,0,1,0-48,48A48.05436,48.05436,0,0,0,176,128Zm16-52a12,12,0,1,0-12,12A12,12,0,0,0,192,76Z" />
+    </svg>
+  </a>
+  <a href="https://staging.bsky.app/profile/taccutexas.bsky.social" target="_blank" class="logos__bluesky">
+    <svg viewBox="0 0 64 57" xmlns="http://www.w3.org/2000/svg">
+      <path d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805ZM50.127 3.805C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745Z"></path>
+    </svg>
+  </a>
+<p>


### PR DESCRIPTION
## Overview

Saving a snippet, because it has unique code.

## Related

- manual version of https://github.com/TACC/Core-CMS/blob/v4.8.0/taccsite_cms/templates/share_on_social.html output + new BlueSky item (not in Core-CMS)

## Changes

- **added** CMS template

## Testing

1. Verify code is saved in snippet.
2. Verify social media icons include BlueSky.
3. Verify social media icons are responsive.

> [!IMPORTANT]
> Log in to Portal before clicking link.

| Site | Log In | Snippet |
| - | - | - |
| Prod | [`/login`](https://tacc.utexas.edu/login) | [snippet #100](https://tacc.utexas.edu/admin/djangocms_snippet/snippet/100/change/) |
| Dev | [`/login`](https://dev.tup.tacc.utexas.edu/login) | [snippet #100](https://dev.tup.tacc.utexas.edu/admin/djangocms_snippet/snippet/100/change/) |

## UI

| 1. & 2. |
| - |
| <img width="299" alt="footer screenshot annotated" src="https://github.com/TACC/tup-ui/assets/62723358/8efa4bdc-b864-426c-9255-78d1fd587e40"> |

https://github.com/TACC/tup-ui/assets/62723358/443ff97d-176f-454e-a04a-ebb1361cc61b