### PR TITLE
style: WI-110 CMS settings naming and order

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -9,16 +9,14 @@ from django.utils.translation import gettext_lazy as _
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 ########################
-# CORE CMS SETTINGS
-# FAQ: These are in future versions of Core-CMS
+# DJANGO
 ########################
 
-# NOTE: Already in Core-CMS v3.12.0-beta.2
-# whether the session cookie should be secure (https:// only)
 SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_AGE = 14400
 
 ########################
-# DJANGO CMS SETTINGS
+# STORAGE
 ########################
 
 DATABASES = {
@@ -41,7 +39,9 @@ STORAGES = {
     },
 }
 
-SESSION_COOKIE_AGE = 14400
+########################
+# DJANGO_CMS
+########################
 
 CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
@@ -62,8 +62,16 @@ CMS_CACHE_DURATIONS = {
     'permissions': 0,
 }
 
+########################
+# DJANGO_RECAPTCHA
+########################
+
 RECAPTCHA_PRIVATE_KEY = ''
 RECAPTCHA_PUBLIC_KEY = ''
+
+########################
+# ELASTICSEARCH
+########################
 
 HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.BaseSignalProcessor'
 
@@ -78,6 +86,8 @@ GOOGLE_ANALYTICS_PRELOAD = True
 ########################
 # TACC: BRANDING
 ########################
+
+# NOTE: Variables NSF_BRANDING, TACC_BRANDING, and UTEXAS_BRANDING are duplicated from Core-CMS cuz current infrastructure lacks ability to reference default values.
 
 UTEXAS_BRANDING = [
     "utexas",
@@ -125,10 +135,15 @@ LOGO = [
 SEARCH_QUERY_PARAM_NAME = 'q'
 
 ########################
-# DJANGO
+# DJANGO: AUTH
 ########################
 
 AUTHENTICATION_BACKENDS = ['django.contrib.auth.backends.ModelBackend', 'apps.portal.backend.TupServicesBackend']
+
+########################
+# TACC: AUTH
+########################
+
 TUP_SERVICES_URL = "https://tup-services.tacc.utexas.edu"
 LOGIN_URL = "/portal/login"
 
@@ -141,7 +156,7 @@ INCLUDES_PORTAL_NAV = True
 INCLUDES_SEARCH_BAR = True
 
 ########################
-# TACC: NEWS/BLOG
+# DJANGOCMS_BLOG
 ########################
 
 from taccsite_cms.settings import INSTALLED_APPS
@@ -186,7 +201,10 @@ BLOG_AUTO_NAMESPACE = 'News'
 # Miscellaneous settings
 BLOG_ENABLE_COMMENTS = False
 
-# TACC settings
+########################
+# DJANGOCMS_BLOG: TACC
+########################
+
 TACC_BLOG_SHOW_CATEGORIES = True
 TACC_BLOG_SHOW_TAGS = False
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'
@@ -202,6 +220,7 @@ TACC_CORE_STYLES_VERSION = 2
 ########################
 # TACC: STAFF PROFILE
 ########################
+
 TACC_STAFF_PROFILE_POST_NOMIALS_EXCLUSION_LIST = ["Jr.", "Sr.", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
 
 


### PR DESCRIPTION
## Overview

In CMS settings, use comments/organization like Core-CMS.

_This is an innocuous piece of settings clean up across repos._

## Related

- [WI-110](https://tacc-main.atlassian.net/browse/WI-110)

## Changes

- **renamed** some CMS setting sections (comments)
- **moved** some CMS settings (no change)

## Testing & UI

N/A