### PR TITLE
feat: cmd-82 update nsf branding

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -90,18 +90,7 @@ UTEXAS_BRANDING = [
     "True"
 ]
 
-NSF_BRANDING = [
-    "nsf",
-    "site_cms/img/org_logos/nsf-white.png",
-    "branding-nsf",
-    "https://www.nsf.gov/",
-    "_blank",
-    "NSF Logo",
-    "anonymous",
-    "True"
-]
-
-BRANDING = [ NSF_BRANDING, UTEXAS_BRANDING ]
+BRANDING = [ UTEXAS_BRANDING ]
 
 ########################
 # TACC: LOGOS

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -159,7 +159,7 @@ svg {
         background-color: var(--global-color-primary--x-dark);
     }
     html:not(#page-portal) .c-footer {
-        padding-right: revert; /* undo core-styles.cms.css */
+        padding-left: revert; /* undo core-styles.cms.css */
     }
     #cms-footer .c-pane--common {
         padding-inline: var(--pad-horz);


### PR DESCRIPTION
## Overview

Support changes to NSF branding (per new guidelines and CMD decisions).

## Related

- [CMD-82](https://tacc-main.atlassian.net/browse/CMD-82)

## Changes

- (in repo code) **removed** `NSF_BRANDING`
- (in repo code) **changed** CSS `padding-…` value
- _(in CMS structure) **changed** footer layout_

## Testing

| Local | Dev ([deployed](https://jenkins01.tacc.utexas.edu/job/tup-cms-deploy/180/)) | Prod |
| - | - | - |
| replace CMS Footer columns in homepage [import](https://github.com/django-cms/djangocms-transfer/blob/1.0.0/README.rst#django-cms-transfer)ing this [export](https://github.com/TACC/tup-ui/files/14273731/cmd-82.cms.footer.plugins.json) | https://dev.tup.tacc.utexas.edu/ (no snippet) | https://tacc.utexas.edu/homepage-banner-2024-02/ (uses [snippet #144](https://tacc.utexas.edu/admin/djangocms_snippet/snippet/144/change/)) |

1. Verify header branding bar does **not** have NSF logo.
2. Verify footer **has** NSF logo.
3. Verify the div of the footer with NSF logo* is always at left or top of footer.
4. Get design approval on footer responsiveness.

<sup>* (and description of TACC, and other logos, and social media icons, and copyright)</sup>

## UI

| location, screen size | |
| - | - |
| Header | <img width="960" alt="dev header branding no nsf" src="https://github.com/TACC/tup-ui/assets/62723358/3bd22724-a8c9-4a91-81d4-2dcc13b88768"> |
| Footer, Wide | <img width="960" alt="footer, wide" src="https://github.com/TACC/tup-ui/assets/62723358/4c1888b0-7ea9-4f28-8f3e-619cf007b739"> |
| Footer, Medium | <img width="960" alt="footer, medium" src="https://github.com/TACC/tup-ui/assets/62723358/27fc77d3-aa62-4257-b4a7-413a74f7e80b"> |
| Footer, Narrow | <img width="960" alt="footer, narrow" src="https://github.com/TACC/tup-ui/assets/62723358/12b33a4b-63c0-42f9-b169-7af7bc5d6181"> |

https://github.com/TACC/tup-ui/assets/62723358/4f00bb53-f0d4-4846-a738-0fb2588be32f