### PR TITLE
hotfix: c-feed-list must support `<p><time/></p>`

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -67,7 +67,6 @@
 .c-feed-list > :is(div, article) > p:has(time) { grid-area: time; }
 .c-feed-list > :is(div, article) > :is(h1, h2, h3, h4, h5, h6) { grid-area: name; }
 .c-feed-list > :is(div, article) > p:not(:has(time, a:only-child)) { grid-area: desc; }
-.c-feed-list > :is(div, article) > a:last-child,
 .c-feed-list > :is(div, article) > p:has(a:only-child) { grid-area: link; }
 
 .c-feed-list > :is(div, article) > :is(h1, h2, h3, h4, h5, h6) {
@@ -96,7 +95,6 @@
   overflow: hidden;
   -webkit-line-clamp: var(--lines, 2);
 }
-.c-feed-list > :is(div, article) > a:last-child,
 .c-feed-list > :is(div, article) > p:has(a:only-child) {
   padding-inline: var(--global-space--unnamed);
   margin-bottom: unset;

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -82,7 +82,7 @@
   text-transform: uppercase;
 }
 .c-feed-list > :is(div, article) > p:has(time):not(:is(h1, h2, h3, h4, h5, h6) *) {
-  margin-bottom: 0;
+  margin-bottom: unset;
 }
 
 .c-feed-list > :is(div, article) > p:not(:has(time, a:only-child)) {
@@ -111,6 +111,7 @@
 
 .c-feed-list > a:last-child,
 .c-feed-list > p:has(a:only-child) {
+  margin-bottom: unset;
   padding-top: 15px;
 
   /* TODO: When migrated to core-styles, use @extend instead */

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -64,10 +64,10 @@
 .c-feed-list > :is(div, article):last-of-type {
   border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--xx-dark);
 }
-.c-feed-list > :is(div, article) > time,
 .c-feed-list > :is(div, article) > p:has(time) { grid-area: time; }
 .c-feed-list > :is(div, article) > :is(h1, h2, h3, h4, h5, h6) { grid-area: name; }
 .c-feed-list > :is(div, article) > p:not(:has(time, a:only-child)) { grid-area: desc; }
+.c-feed-list > :is(div, article) > a:last-child,
 .c-feed-list > :is(div, article) > p:has(a:only-child) { grid-area: link; }
 
 .c-feed-list > :is(div, article) > :is(h1, h2, h3, h4, h5, h6) {
@@ -76,7 +76,6 @@
 }
 
 /* TODO: Share styles between c-news and c-feed-list (`time:not(…)`) */
-.c-feed-list > :is(div, article) > time:not(:is(h1, h2, h3, h4, h5, h6) *),
 .c-feed-list > :is(div, article) > p:has(time):not(:is(h1, h2, h3, h4, h5, h6) *) {
   color: var(--global-color-accent--secondary);
   font-weight: var(--medium);
@@ -86,7 +85,7 @@
   margin-bottom: 0;
 }
 
-.c-feed-list > :is(div, article) > p:not(:has(time)) {
+.c-feed-list > :is(div, article) > p:not(:has(time, a:only-child)) {
   /* WARNING: Value is guess-n-check; prevents unexplained visibile 3rd line */
   margin-bottom: 1.15rem;
 
@@ -97,6 +96,7 @@
   overflow: hidden;
   -webkit-line-clamp: var(--lines, 2);
 }
+.c-feed-list > :is(div, article) > a:last-child,
 .c-feed-list > :is(div, article) > p:has(a:only-child) {
   padding-inline: var(--global-space--unnamed);
 
@@ -106,6 +106,8 @@
 }
 
 /* Elements: Link */
+
+/* NOTE: `p:has(a:only-child)` is used, but `a:last-child` is desired, but not used until "Link" plugin instance supports an icon before the text. */
 
 .c-feed-list > a:last-child,
 .c-feed-list > p:has(a:only-child) {

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -99,6 +99,7 @@
 .c-feed-list > :is(div, article) > a:last-child,
 .c-feed-list > :is(div, article) > p:has(a:only-child) {
   padding-inline: var(--global-space--unnamed);
+  margin-bottom: unset;
 
   /* To vertically center content */
   display: flex;
@@ -111,7 +112,6 @@
 
 .c-feed-list > a:last-child,
 .c-feed-list > p:has(a:only-child) {
-  margin-bottom: unset;
   padding-top: 15px;
 
   /* TODO: When migrated to core-styles, use @extend instead */

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -64,10 +64,11 @@
 .c-feed-list > :is(div, article):last-of-type {
   border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--xx-dark);
 }
-.c-feed-list > :is(div, article) > time { grid-area: time; }
+.c-feed-list > :is(div, article) > time,
+.c-feed-list > :is(div, article) > p:has(time) { grid-area: time; }
 .c-feed-list > :is(div, article) > :is(h1, h2, h3, h4, h5, h6) { grid-area: name; }
-.c-feed-list > :is(div, article) > p:first-of-type { grid-area: desc; }
-.c-feed-list > :is(div, article) > p:not(:first-of-type) { grid-area: link; }
+.c-feed-list > :is(div, article) > p:not(:has(time, a:only-child)) { grid-area: desc; }
+.c-feed-list > :is(div, article) > p:has(a:only-child) { grid-area: link; }
 
 .c-feed-list > :is(div, article) > :is(h1, h2, h3, h4, h5, h6) {
   margin-top: 10px;
@@ -75,13 +76,17 @@
 }
 
 /* TODO: Share styles between c-news and c-feed-list (`time:not(…)`) */
-.c-feed-list > :is(div, article) > time:not(:is(h1, h2, h3, h4, h5, h6) *) {
+.c-feed-list > :is(div, article) > time:not(:is(h1, h2, h3, h4, h5, h6) *),
+.c-feed-list > :is(div, article) > p:has(time):not(:is(h1, h2, h3, h4, h5, h6) *) {
   color: var(--global-color-accent--secondary);
   font-weight: var(--medium);
   text-transform: uppercase;
 }
+.c-feed-list > :is(div, article) > p:has(time):not(:is(h1, h2, h3, h4, h5, h6) *) {
+  margin-bottom: 0;
+}
 
-.c-feed-list > :is(div, article) > p {
+.c-feed-list > :is(div, article) > p:not(:has(time)) {
   /* WARNING: Value is guess-n-check; prevents unexplained visibile 3rd line */
   margin-bottom: 1.15rem;
 
@@ -92,7 +97,7 @@
   overflow: hidden;
   -webkit-line-clamp: var(--lines, 2);
 }
-.c-feed-list > :is(div, article) > p:not(:first-of-type) {
+.c-feed-list > :is(div, article) > p:has(a:only-child) {
   padding-inline: var(--global-space--unnamed);
 
   /* To vertically center content */
@@ -102,7 +107,8 @@
 
 /* Elements: Link */
 
-.c-feed-list > a:last-child {
+.c-feed-list > a:last-child,
+.c-feed-list > p:has(a:only-child) {
   padding-top: 15px;
 
   /* TODO: When migrated to core-styles, use @extend instead */
@@ -115,9 +121,11 @@
   font-weight: var(--bold);
   font-size: var(--global-font-size--medium)
 }
-.o-section--style-dark .c-feed-list > a:last-child {
+.o-section--style-dark .c-feed-list > a:last-child,
+.o-section--style-light .c-feed-list > p:has(a:only-child) {
   color: var(--global-color-primary--xx-light);
 }
-.o-section--style-light .c-feed-list > a:last-child {
+.o-section--style-light .c-feed-list > a:last-child,
+.o-section--style-light .c-feed-list > p:has(a:only-child) {
   color: var(--global-color-primary--xx-dark);
 }


### PR DESCRIPTION
## Overview

In `c-feed-list`:
- Add support for `<time>` wrapped in `<p>`.
- Retain support for `<time>` **not** wrapped in `<p>`.

### Problem

| Before Editing Text Plugin Instances | After Editing Text Plugin Instances |
| - | - |
| The `<time>` is **not** wrapped in a `<p>` tag. Nor is "See all …" link. | The `<time>` **is** wrapped in a `<p>` tag. So is "See all …" link. |
| <img width="531" alt="after edit" src="https://github.com/TACC/tup-ui/assets/62723358/f00eb900-f2f1-482e-80ef-13ad18d05b29"> | <img width="531" alt="beofre edit" src="https://github.com/TACC/tup-ui/assets/62723358/7a6a4dd1-eb13-48fa-9d16-6a467b0def06"> |

<details><summary>Video</summary>

https://github.com/TACC/tup-ui/assets/62723358/9fe25b2d-4f3b-4503-ab6d-dc8e50b4d695

</details> 

## Related

- fix side effect of TACC/tup-ui#412
    <sup> A `<p>` is added around any Text within a `c-feed-list`.</sup>

## Changes

- **edited** a stylesheet

## Testing

> [!IMPORTANT]
> Fixed on prod via a [snippet](https://tacc.utexas.edu/admin/djangocms_snippet/snippet/145/change/), so test on dev site.

0. See [home page](https://tacc.utexas.edu/) "User Updates" section UI before this hotfix.
1. Edit all **Text** blocks in:
    - [/training/](https://dev.tup.tacc.utexas.edu/use-tacc/training/)
        - under "Upcoming Training"
           <sup>don't forget the empty one that is where a "See all …" link would be</sup>
        - under "TACC Training Highlights"
    - [home page](https://dev.tup.tacc.utexas.edu/)
        - under "Training & Events"
2. Make no actual change.
3. Save each **Text** block.
    <sup>This **will** change the markup produced.</sup>
    - Automatically, a `<p>` **will** wrap the `<time>` in an event.
    - Automatically, a `<p>` **will** wrap the `<a>` in the "See all …" link.</sup>
4. Verify UI of those sections has **only** accepted changes.*
5. Verify UI of home page "User Updates" section does **not** change.*

> [!IMPORTANT]
> <details><summary>* Accepted Changes</summary>
> 
> - More space between icon and "See all …" on "Training & Events" and "TACC Training Highlights".
>    | Before | After |
>    | - | - |
>    | <img width="175" alt="before" src="https://github.com/TACC/tup-ui/assets/62723358/e5fe4e04-4444-4e0e-9e8e-1da03e783004"> | <img width="175" alt="after" src="https://github.com/TACC/tup-ui/assets/62723358/4e89e865-7b4d-4d4f-bd73-a4425c1c9dd8"> |
> - Vertical alignment of event buttons is more center/accurate.
>    | Before | After |
>    | - | - |
>    | ![old button alignment](https://github.com/TACC/tup-ui/assets/62723358/9310d750-8805-4d4c-a3b0-32b38fab6fc6) | ![new button alignment](https://github.com/TACC/tup-ui/assets/62723358/7b054c0e-21d4-431f-80e6-8c9eaaae1f48) |
>
> </details>

## UI

| | Before | After |
| - | - | - |
| Home "Train… & Events" | <img width="500" alt="home train before" src="https://github.com/TACC/tup-ui/assets/62723358/c59c1bee-2a25-439e-b0bd-857cabfbc6c2"> | <img width="500" alt="home train after snippet" src="https://github.com/TACC/tup-ui/assets/62723358/668bcedb-b530-409c-ab4e-8776decf0a64"> |
| Home "… Updates" | <img width="430" alt="home user before" src="https://github.com/TACC/tup-ui/assets/62723358/5ce00409-d159-4709-974b-f709e667904a"> | <img width="430" alt="home user after snippet" src="https://github.com/TACC/tup-ui/assets/62723358/4eca597b-5be9-4c40-ae2c-fcc07c07fe44"> |
| Training Page | <img width="1175" alt="all training before" src="https://github.com/TACC/tup-ui/assets/62723358/de166d6b-2566-4110-890d-c532cd241c30"> | <img width="1175" alt="all training after snippet" src="https://github.com/TACC/tup-ui/assets/62723358/d3e9f6b0-2cbf-4b4b-ba30-2eb686faa742"> |

### Notes

The "UI" screenshots were taken on Prod after adding a [snippet](https://tacc.utexas.edu/admin/djangocms_snippet/snippet/145/change/), but they match exactly my testing on dev with the updated stylesheet. I reverted my markup changes to dev, so a reviewer can test.