### PR TITLE
TUP-689  On Small Screen, Stack Manage Account Blocks into 1 Column

### DIFF
--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -1,3 +1,5 @@
+@import url('@tacc/core-styles/src/lib/_imports/tools/media-queries.css');
+
 .account-layout{
     padding: var(--global-space--section);
     padding-right: 30px;
@@ -59,4 +61,16 @@
 
 .mfa-options {
     /* no styles needed yet */
+}
+
+@media (--narrow-and-below) {
+    .tap-separator {
+        display: none;
+    }
+
+    .account-body {
+        flex-direction: column;
+        gap: 20px;
+    }
+
 }

--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -69,6 +69,10 @@
 @media (--narrow-and-below) {
     .account-body {
         flex-direction: column-reverse;
-        gap: 10px;
+        gap: 20px;
+    }
+
+    .tap-separator {
+        display: none;
     }
 }

--- a/libs/tup-components/src/accounts/ManageAccount.module.css
+++ b/libs/tup-components/src/accounts/ManageAccount.module.css
@@ -54,23 +54,21 @@
     width: fit-content;
 }
 
-.tap-separator {
-    border-right: 1px solid #707070;
-    margin-top: 10px;
-}
-
 .mfa-options {
     /* no styles needed yet */
 }
 
-@media (--narrow-and-below) {
+@media (--narrow-and-above) {
     .tap-separator {
-        display: none;
+        border-right: 1px solid #707070;
+        margin-top: 10px;
     }
 
+}
+
+@media (--narrow-and-below) {
     .account-body {
-        flex-direction: column;
-        gap: 20px;
+        flex-direction: column-reverse;
+        gap: 10px;
     }
-
 }

--- a/libs/tup-components/src/accounts/ManageAccount.tsx
+++ b/libs/tup-components/src/accounts/ManageAccount.tsx
@@ -104,7 +104,6 @@ const ManageAccount: React.FC = () => {
           <section>
             <ManageUser />
             <ManagePassword />
-            <span />
             <ManageDNs />
             <ManageUpload />
           </section>


### PR DESCRIPTION
## Overview

Stacks content in the Account Management screen when the narrow breakpoint is reached.

## Related

- [TUP-537 (Parent Ticket)](https://tacc-main.atlassian.net/browse/TUP-537)
- [TUP-689](https://tacc-main.atlassian.net/browse/TUP-689)
- [TUP-688](https://tacc-main.atlassian.net/browse/TUP-688)
- [TUP-690](https://tacc-main.atlassian.net/browse/TUP-690)

## Changes

Stacks content in the Account Management screen when the narrow breakpoint is reached.

## Testing

1. http://localhost:8000/portal/account
2. Make screen smaller and wider to see the MFA be under the main content on left

## UI

| Before | After |
| - | - |
| <img width="587" alt="Screenshot 2024-02-19 at 1 06 07 PM" src="https://github.com/TACC/tup-ui/assets/63771558/bc2bd818-8000-4884-a54f-1882c39742d8"> | <img width="586" alt="Screenshot 2024-02-19 at 1 06 30 PM" src="https://github.com/TACC/tup-ui/assets/63771558/35972724-a71a-4d91-b892-4744fce59145"> |

## Notes
**FEB 19:** Waiting on DESIGN APPROVAL.
