### PR TITLE
hotfix: revert c-footer layout change

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/components/c-footer.css
@@ -159,7 +159,7 @@ svg {
         background-color: var(--global-color-primary--x-dark);
     }
     html:not(#page-portal) .c-footer {
-        padding-left: revert; /* undo core-styles.cms.css */
+        padding-right: revert; /* undo core-styles.cms.css */
     }
     #cms-footer .c-pane--common {
         padding-inline: var(--pad-horz);


### PR DESCRIPTION
## Overview

Revert the CSS change that supported a footer layout change on production that I was just told to undo.

> [!IMPORTANT]
> This change is coupled to a bunch of bootstrap class changes I made to footer columns via the CMS admin. I did not track those changes. I am sorry.

## Related

- [CMD-82](https://tacc-main.atlassian.net/browse/CMD-82)
- revert CSS change from #425

## Changes

- **changed** `padding-left` back to `padding-right`

## Testing

**Fast Way**: Verify that prod looks as it was before #425 now… (I removed the snippet that replicated the #425 change on prod.)

## UI

https://tacc.utexas.edu/