### PR TITLE
bug/TUP-692  TUP Login Form Error Message Unstyled

### DIFF
--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -114,7 +114,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
       </h3>
       <p className="c-form__desc">to continue to the TACC User Portal</p>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form className='c-form'>
+        <Form className="c-form">
           <LoginError status={status} isError={isError} />
           <FormikInput
             name="username"

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -107,14 +107,14 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
   const status = (error as AxiosError)?.response?.status;
 
   return (
-    <div className={`c-form c-form--login ${styles.root} ${className}`}>
+    <div className={`c-form--login ${styles.root} ${className}`}>
       <h3 className="c-form__title">
         <img src={blackLogo} alt="TACC Logo" />
         <span>Log In</span>
       </h3>
       <p className="c-form__desc">to continue to the TACC User Portal</p>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form>
+        <Form className='c-form'>
           <LoginError status={status} isError={isError} />
           <FormikInput
             name="username"


### PR DESCRIPTION
## Overview
Add error styling to tup login


## Related

- [TUP-692](https://tacc-main.atlassian.net/browse/TUP-692)

## Changes

Adds `className='c-form'` to `form` element instead of `div` element to allow for styling to take effect.

## Testing

1. http://localhost:8000/portal/login?from=/portal/account
2. Hit the submit button without entering any of the fields.
3. Make sure it pops up red

## UI

| Before | After |
| - | - |
| <img width="650" alt="Screenshot 2024-02-21 at 5 51 49 PM" src="https://github.com/TACC/tup-ui/assets/63771558/ce30ca32-f438-4fe9-bb0c-e651d5755a45"> | <img width="639" alt="Screenshot 2024-02-21 at 5 52 36 PM" src="https://github.com/TACC/tup-ui/assets/63771558/25616adf-0950-4528-b56b-eb433e750a7a"> |