### PR TITLE
feat: TUP-705 remove decomissioned systems

### DIFF
--- a/libs/tup-components/src/software/SoftwareTable.tsx
+++ b/libs/tup-components/src/software/SoftwareTable.tsx
@@ -190,7 +190,6 @@ const SoftwareTable: React.FC = () => {
             <option value="">any</option>
             <option>Frontera</option>
             <option>Lonestar6</option>
-            <option>Longhorn</option>
             <option>Stampede2</option>
           </select>
         </label>

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -102,12 +102,10 @@ export const TicketCreateForm: React.FC = () => {
           <FormikSelect name="resource" label="System/Resource" required>
             <option value="">Please Choose One</option>
             <option>Corral (corral-login.tacc.utexas.edu)</option>
-            <option>Corral iRODS(icat.corral.tacc.utexas.edu)</option>
             <option>Corral-Protected(corral-protected.tacc.utexas.edu)</option>
             <option>Frontera(frontera.tacc.utexas.edu)</option>
             <option>Jetstream(jetstream.tacc.utexas.edu)</option>
             <option>Lonestar6(lonestar6.tacc.utexas.edu)</option>
-            <option>Longhorn(longhorn.tacc.utexas.edu)</option>
             <option>Ranch(ranch.tacc.utexas.edu)</option>
             <option>Stampede2(stampede2.tacc.utexas.edu)</option>
             <option>Stampede3(stampede3.tacc.utexas.edu)</option>


### PR DESCRIPTION
## Overview

Remove decommissioned systems from Help Ticket dropdown.

### Questions

1. Should I remove Longhorn from [/use-tacc/software-list/](https://tacc.utexas.edu/use-tacc/software-list/) i.e. [`SoftwareTable.tsx`](https://github.com/TACC/tup-ui/blob/v1.1.6/libs/tup-components/src/software/SoftwareTable.tsx#L193) also?
    - H.P. says "Yes" to removing from [Software Table](https://tacc.utexas.edu/use-tacc/software-list/) because V.T. said, "Yes" to removing it from Help Ticket. It's just an option. The data is from an API.
3. Should I remove [Longhorn and Maverick from test fixtures](https://github.com/TACC/tup-ui/blob/v1.1.6/libs/tup-testing/src/mocks/fixtures/system-status.ts#L25-L61)?

## Related

- [TUP-705](https://tacc-main.atlassian.net/browse/TUP-705)

## Changes

- **removed** some `<option>`s

## Testing

Skipped.

## UI

| | Before | After |
| - | - | - |
| Help Ticket | <img width="1440" alt="Portal" src="https://github.com/TACC/tup-ui/assets/62723358/9de14390-0230-4423-964c-e13e36588139"> | Skipped. |
| [Software List](https://tacc.utexas.edu/use-tacc/software-list/) | <img width="705" alt="TUP-705 Question About Longhorn in Software Table" src="https://github.com/TACC/tup-ui/assets/62723358/591e822c-799b-4169-a7a3-b1a31e2686b1"> | Skipped. |