### PR TITLE
fix: c-feed-list must still support `<time/>`

### DIFF
--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-styles/components/c-feed-list.css
@@ -48,6 +48,8 @@
 
 /* Elements: Items */
 
+/* NOTE: `p:has(time)` styles CMS markup, but templates use `time` sans `<p>` */
+
 .c-feed-list > :is(div, article) {
   flex-grow: 1; /* to shrink feed title */
 
@@ -64,6 +66,7 @@
 .c-feed-list > :is(div, article):last-of-type {
   border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--xx-dark);
 }
+.c-feed-list > :is(div, article) > time,
 .c-feed-list > :is(div, article) > p:has(time) { grid-area: time; }
 .c-feed-list > :is(div, article) > :is(h1, h2, h3, h4, h5, h6) { grid-area: name; }
 .c-feed-list > :is(div, article) > p:not(:has(time, a:only-child)) { grid-area: desc; }
@@ -75,6 +78,7 @@
 }
 
 /* TODO: Share styles between c-news and c-feed-list (`time:not(…)`) */
+.c-feed-list > :is(div, article) > time:not(:is(h1, h2, h3, h4, h5, h6) *),
 .c-feed-list > :is(div, article) > p:has(time):not(:is(h1, h2, h3, h4, h5, h6) *) {
   color: var(--global-color-accent--secondary);
   font-weight: var(--medium);


### PR DESCRIPTION
## Overview

Style `<time>` used (by "User Updates" via `c-feed-list`) without a `<p>`.

## Related

- fixes #427

## Changes

- **added** selectors to style `<time>` **not** wrapped in `<p>`

## Testing

1. Open https://dev.tup.tacc.utexas.edu/ or local clone.
2. Scroll to "User Updates".
3. Verify the `<time>` (e.g. "Published:" and "FEBRUARY 12, 2024") is orange-ish.
4. Verify the style rule that does this would also style the `<time>` were it in a `<p>` tag.

## UI

| Before | After |
| - | - |
| <img width="350" alt="before" src="https://github.com/TACC/tup-ui/assets/62723358/923f53ae-016b-421f-a2f8-5bbff04a56b8"> | <img width="350" alt="after" src="https://github.com/TACC/tup-ui/assets/62723358/51f3ab65-bf3e-4a97-bde9-d9678d6265f9"> |

| Both Ways Work |
| - |
| <img width="1194" alt="works both ways" src="https://github.com/TACC/tup-ui/assets/62723358/922e1da4-7104-44ee-92ff-62b7b87cbd7b"> |