### PR TITLE
fix: sample secrets should not suggest user use smpt locally

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/secrets.sample.py
+++ b/apps/tup-cms/src/taccsite_cms/secrets.sample.py
@@ -1,4 +1,1 @@
 TUP_SERVICES_ADMIN_JWT = "CHANGEME"
-
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = ""

--- a/apps/tup-cms/src/taccsite_cms/settings_local.sample.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_local.sample.py
@@ -1,0 +1,1 @@
+TUP_SERVICES_URL = "https://dev.tup-services.tacc.utexas.edu"


### PR DESCRIPTION
## Overview

1. Do not suggest enabling SMTP in local settings/secrets. Why not?
    - [We should not send e-mail from localhost.](https://tacc-main.atlassian.net/wiki/x/ZhVv)
    - [Mail can be previewed in console via default Core-CMS settings.](https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/_settings/email.py#L22)
3. Do offer dev URL for TUP services.

## Related

- fix recipe for trouble in #392

## Changes

- **removed** secrets
- **added** settings

## Testing & UI

N/A