### PR TITLE
feat: set share platforms in repo code & reorder them

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,8 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.8.3
+# TACC/Core-CMS#813 merged (v4.9 candidate)
+FROM taccwma/core-cms:8fed0812
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -145,6 +145,12 @@ INCLUDES_PORTAL_NAV = True
 INCLUDES_SEARCH_BAR = True
 
 ########################
+# TACC: SOCIAL MEDIA
+########################
+
+TACC_SOCIAL_SHARE_PLATFORMS = ['linkedin', 'facebook', 'email']
+
+########################
 # DJANGOCMS_BLOG
 ########################
 


### PR DESCRIPTION
## Overview

Set the public share platforms settings in the repo, not hidden on the server in secrets.

## Related

- requires https://github.com/TACC/Core-CMS/pull/813
- tangentially…
    - [TUP-584](https://tacc-main.atlassian.net/browse/TUP-584)
    - [TUP-667](https://tacc-main.atlassian.net/browse/TUP-667)

## Changes

- **added** settings that were on dev server
- **changed** order of the platforms

## Testing

1. Load https://dev.tacc.utexas.edu/news/.
2. Open a news article.
3. Verify share buttons are present and working in this order:
    1. linkedin
    2. facebook
    3. email

## UI

| Before | After |
| - | - |
| <img width="1194" alt="tup-ui 442 before" src="https://github.com/TACC/tup-ui/assets/62723358/55a1e8a7-caf0-4efd-8999-cca162c74f5b"> | <img width="1194" alt="Screenshot 2024-03-08 at 3 59 28 PM" src="https://github.com/TACC/tup-ui/assets/62723358/688716ee-af03-4e04-9619-8060f5795acd"> |