### PR TITLE
feat: tup 584 redesign news metadata

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,8 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-# TACC/Core-CMS#773 (v4.9 candidate)
-FROM taccwma/core-cms:80860e7c
+FROM taccwma/core-cms:v4.9.0
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,8 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.8.3
+# TACC/Core-CMS#813 merged (v4.9 candidate)
+FROM taccwma/core-cms:8fed0812
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,8 +7,8 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-# TACC/Core-CMS#813 merged (v4.9 candidate)
-FROM taccwma/core-cms:8fed0812
+# TACC/Core-CMS#773 (v4.9 candidate)
+FROM taccwma/core-cms:80860e7c
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -145,6 +145,12 @@ INCLUDES_PORTAL_NAV = True
 INCLUDES_SEARCH_BAR = True
 
 ########################
+# TACC: SOCIAL MEDIA
+########################
+
+TACC_SOCIAL_SHARE_PLATFORMS = ['linkedin', 'facebook', 'email']
+
+########################
 # DJANGOCMS_BLOG
 ########################
 


### PR DESCRIPTION
## Overview

Redesign news metadata.

## Related

- [TUP-584](https://tacc-main.atlassian.net/browse/TUP-584)
- requires https://github.com/TACC/Core-CMS/pull/773
- includes #442

## Changes

- re-ordered share links
- changed position of news article metadata

## Testing

Deployed to [dev server](https://dev.tup.tacc.utexas.edu/news/latest-news/).
<sup>If testing locally, run `npx nx build tup-cms && npx nx serve tup-cms`.</sup>

1. Open news list.
2. Compare to production.
3. Open any news article that has an author.
4. Compare that article to production.
5. Review design UI and responsiveness and usability.
6. Verify [I got designer approval](https://tacc-team.slack.com/archives/C060NU133D5/p1710520467347929).

## UI

### Article Page

| Before | After |
| - | - |
| <img width="1194" alt="page before" src="https://github.com/TACC/tup-ui/assets/62723358/aa5716d9-a536-461f-880a-fa006f2176a2"> | <img width="1194" alt="page after" src="https://github.com/TACC/tup-ui/assets/62723358/9cdcd547-6296-4517-aa82-37bed7923056"> |

| Mouse<br /><sup>e.g. typical Desktop</sup> | Touch<br /><sup>e.g. typical Mobile</sup> |
| - | - |
| <img width="1155" alt="page after - mouse" src="https://github.com/TACC/tup-ui/assets/62723358/b05b23a4-9256-4ba5-ab6e-6d06b4fb86f2"> | <img width="1155" alt="page after - touch" src="https://github.com/TACC/tup-ui/assets/62723358/c48f91ff-51e3-4866-9c69-110b0c9db27b"> |

https://github.com/TACC/tup-ui/assets/62723358/2197fab9-845a-413d-9f6d-719353ec3ae3

### Article List Item

| Before | After |
| - | - |
| <img width="1194" alt="list before" src="https://github.com/TACC/tup-ui/assets/62723358/c0ea636b-03ff-410c-bfdc-1ebb7ed07f55"> | <img width="1194" alt="list after" src="https://github.com/TACC/tup-ui/assets/62723358/19e40a24-d219-49b8-bf72-ece47abd51d3"> |

## Notes

### Known Issues

#### 1. Extra Space Between Short Category tag and Publish Date

| to fix, refactor grid into flex; might require changing markup |
| - |
| <img width="1194" alt="excess space" src="https://github.com/TACC/tup-ui/assets/62723358/71ee6ac3-d197-4af2-b6df-79605cbde781"> |
| <img width="1194" alt="grid" src="https://github.com/TACC/tup-ui/assets/62723358/0bee4aea-e7e2-443b-bcc0-1479e9f62fc8"> |

The mini-refactor may not be worth the effort, especially give a News markup and CSS refactor already scheduled this year.