### PR TITLE
fix: misspelling in confirmation e-mail

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -47,7 +47,7 @@ def send_confirmation_email(form_name, form_data):
     email_body = """
             <p>Greetings,</p>
             <p>
-                Your have successfully submitted a form on the TACC website. Thank you for your submission.
+                You have successfully submitted a form on the TACC website. Thank you for your submission.
             </p>
             <p>
                 Business hours are Monday - Friday, 8AM to 5PM Central. We will respond to your submission


### PR DESCRIPTION
## Overview / Changes

Fix a misspelling in the confirmation e-mail.

## Notes

This e-mail is not even being sent. The fix for that is https://github.com/TACC/tup-ui/pull/446.