### PR TITLE
fix: tup-711 confirmation e-mail not sent

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -70,7 +70,7 @@ def callback(form, cleaned_data, **kwargs):
     logger.debug(f"received submission from {form.name}")
     if form.name == 'rt-ticket-form':
         submit_ticket(cleaned_data)
-    elif hasattr(cleaned_data, "email"):
+    elif ('email' in cleaned_data):
         send_confirmation_email(form.name, cleaned_data)
 
 


### PR DESCRIPTION
## Overview

Fix TUP-managed confirmation e-mails not being sent.

## Related

- [TUP-711](https://tacc-main.atlassian.net/browse/TUP-711) & [TUP-709](https://tacc-main.atlassian.net/browse/TUP-709)

## Changes

- **fixed** wrong syntax within `elif` conditional

## Testing

1. Test via a form that has an "Email" (`email`) field e.g.
    - `/about/tours/request/`
    - [`/about/help-not-via-rt/`](https://dev.tup.tacc.utexas.edu/about/help-not-via-rt/) (set recipient e-mail to your own)
2. Check whether e-mail is received.
3. Set mail program to render mail as text.
4. Check whether the received mail has excess indentation.

## UI

### Remote

| to User | to TACC |
| - | - |
| <img width="705" alt="to User" src="https://github.com/TACC/tup-ui/assets/62723358/c4b568db-7031-42cd-a9ee-7d41a8f00666"> | <img width="705" alt="to TACC" src="https://github.com/TACC/tup-ui/assets/62723358/c28209ec-d618-4b96-9fb3-7898a327f2c4"> |

### Local

| Form | Log |
| - | - |
| <img width="1024" alt="form" src="https://github.com/TACC/tup-ui/assets/62723358/8861cf27-f9d1-4f4e-8a63-080b07781574"> | <img width="1024" alt="log" src="https://github.com/TACC/tup-ui/assets/62723358/e68f9f81-5f08-4850-ad8a-c4f18ad799a3"> |