### PR TITLE
test: CMD-112 overwrite confirmation e-mail

### DIFF
--- a/apps/tup-cms/src/apps/email_management/assets/confirmation_email.html
+++ b/apps/tup-cms/src/apps/email_management/assets/confirmation_email.html
@@ -1,0 +1,12 @@
+<p>Greetings,</p>
+<p>
+    You have successfully submitted a form on the TACC website. Thank you for your submission.
+</p>
+<p>
+    Business hours are Monday - Friday, 8AM to 5PM Central. We will respond to your submission
+    according to the information provided on the form webpage.
+</p>
+<p>
+Sincerely,<br>
+TACC Communications
+</p>

--- a/apps/tup-cms/src/apps/email_management/assets/confirmation_email.txt
+++ b/apps/tup-cms/src/apps/email_management/assets/confirmation_email.txt
@@ -1,0 +1,8 @@
+Greetings,
+
+You have successfully submitted a form on the {site_name} website. Thank you for your submission.
+
+Business hours are Monday - Friday, 8AM to 5PM Central. We will respond to your submission according to the information provided on the form webpage.
+
+Sincerely,
+{site_name} Communications

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -4,7 +4,6 @@ import requests
 from django.dispatch import receiver
 from djangocms_forms.signals import form_submission
 from django.conf import settings
-from django.core.mail import send_mail
 
 
 logger = logging.getLogger(f"portal.{__name__}")
@@ -43,35 +42,10 @@ def submit_ticket(form_data):
     requests.post(f"{service_url}/tickets/noauth", data=ticket_data, files=[])
 
 
-def send_confirmation_email(form_name, form_data):
-    email_body = """
-            <p>Greetings,</p>
-            <p>
-                You have successfully submitted a form on the TACC website. Thank you for your submission.
-            </p>
-            <p>
-                Business hours are Monday - Friday, 8AM to 5PM Central. We will respond to your submission
-                according to the information provided on the form webpage.
-            </p>
-            <p>
-            Sincerely,<br>
-            TACC Communications
-            </p>
-            """
-    send_mail(
-    f"TACC Form Submission Received: {form_name}",
-    email_body,
-    "no-reply@tacc.utexas.edu",
-    [form_data["email"]],
-    html_message=email_body)
-
-
 def callback(form, cleaned_data, **kwargs):
     logger.debug(f"received submission from {form.name}")
     if form.name == 'rt-ticket-form':
         submit_ticket(cleaned_data)
-    elif ('email' in cleaned_data):
-        send_confirmation_email(form.name, cleaned_data)
 
 
 class PortalConfig(AppConfig):


### PR DESCRIPTION
## Overview

- Use Core-CMS confirmation e-mail code.
- Overwrite Core-CMS confirmation e-mail content.

## Related

- [CMD-112](https://tacc-main.atlassian.net/browse/TUCMDP-112)

## Changes

- **added** confirmation email overwrite files
- **removed** TUP's confirmation e-mail code

## Testing

### Core-CMS

1. ```sh
    git checkout CMD-112
    make build
    make start
    ```
2. ```sh
    docker commit core_cms
    docker tag sha256:__THE_IDENTIFIER_FROM_PREV_CMD__ core-cms_cmd-112_UNIQUE-ID
    ```
3. Stop Core-CMS container.

### TUP-UI

1. Make edits only for testing (not to be commited):
    - In `/apps/tup-cms/Dockefile`, change `taccwma/core-cms:v4.9.0` to `core-cms_cmd-112_UNIQUE-ID`.
2. ```sh
    npx nx build tup-cms
    npx nx serve tup-cms
    ```
3. Browse files on `tup_cms` container.
4. Open `/code/apps/email_management/assets/confirmation_email.*` files.
5. Verify both files have "Business hours …" paragraph.
6. Open a CMS form (**not** `/about/help`) with an e-mail field (display name is "Email" or "email").
7. Make sure form would send e-mail e.g.
    - edit form and have e-mail address in "Send form data to e-mail address:",
    - in `/apps/tup-cms/src/taccsite_cms/settings_local.py`, set `DEFAULT_FROM_EMAIL` to an e-mail address.
8. Submit e-mail address via form.
8. Verify only one _confirmation_ e-mail would be received.
9. Verify that confirmation e-mail has "Business hours …" paragraph.

## UI

> [!IMPORTANT]
> Test failed. No screensots available.