### PR TITLE
feat: tup-712 login form new help links

### DIFF
--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
@@ -27,7 +27,7 @@ describe('LoginComponent', () => {
       value: { replace: mockNavigate },
     });
     const { getByLabelText, getByRole } = testRender(<LoginComponent />);
-    const username = getByLabelText(/User Name/);
+    const username = getByLabelText(/Username/);
     const password = getByLabelText(/Password/);
     const submit = getByRole('button');
     await act(async () => {
@@ -50,7 +50,7 @@ describe('LoginComponent', () => {
     const { getByLabelText, getByRole, getAllByText } = testRender(
       <LoginComponent />
     );
-    const username = getByLabelText(/User Name/);
+    const username = getByLabelText(/Username/);
     const password = getByLabelText(/Password/);
     const submit = getByRole('button');
     await act(async () => {
@@ -79,7 +79,7 @@ describe('LoginComponent', () => {
     const { getByLabelText, getByRole, getAllByText } = testRender(
       <LoginComponent />
     );
-    const username = getByLabelText(/User Name/);
+    const username = getByLabelText(/Username/);
     const password = getByLabelText(/Password/);
     const submit = getByRole('button');
     await act(async () => {

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
@@ -105,11 +105,11 @@ describe('LoginComponent', () => {
     expect(links[1].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/login_support'
     );
-    expect(getByText('Reset Password')).toBeDefined();
+    expect(getByText('Forgot Password')).toBeDefined();
     expect(links[2].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/forgot_password'
     );
-    expect(getByText('Request Username')).toBeDefined();
+    expect(getByText('Recover Username')).toBeDefined();
     expect(links[3].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/forgot_username'
     );

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
@@ -93,20 +93,24 @@ describe('LoginComponent', () => {
       ).toEqual(1)
     );
   });
-  it('should link to TAS Create Account if Create Account clicked', async () => {
+  it('should link to TAM', async () => {
     const { getByText, getAllByRole } = testRender(<LoginComponent />);
     await waitFor(() => getAllByRole('link'));
     const links: HTMLElement[] = getAllByRole('link');
-    expect(getByText('Account Help')).toBeDefined();
+    expect(getByText('Create Account')).toBeDefined();
     expect(links[0].getAttribute('href')).toEqual(
+      'https://accounts.tacc.utexas.edu/register'
+    );
+    expect(getByText('Account Help')).toBeDefined();
+    expect(links[1].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/login_support'
     );
     expect(getByText('Reset Password')).toBeDefined();
-    expect(links[1].getAttribute('href')).toEqual(
+    expect(links[2].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/forgot_password'
     );
     expect(getByText('Request Username')).toBeDefined();
-    expect(links[1].getAttribute('href')).toEqual(
+    expect(links[3].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/forgot_username'
     );
   });

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
@@ -97,15 +97,17 @@ describe('LoginComponent', () => {
     const { getByText, getAllByRole } = testRender(<LoginComponent />);
     await waitFor(() => getAllByRole('link'));
     const links: HTMLElement[] = getAllByRole('link');
-    expect(getByText('Create Account')).toBeDefined();
+    expect(getByText('Account Help')).toBeDefined();
     expect(links[0].getAttribute('href')).toEqual(
-      'https://accounts.tacc.utexas.edu/register'
+      'https://accounts.tacc.utexas.edu/login_support'
     );
     expect(getByText('Reset Password')).toBeDefined();
     expect(links[1].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/forgot_password'
     );
-    expect(getByText('Account Help')).toBeDefined();
-    expect(links[2].getAttribute('href')).toEqual('/about/help/');
+    expect(getByText('Request Username')).toBeDefined();
+    expect(links[1].getAttribute('href')).toEqual(
+      'https://accounts.tacc.utexas.edu/forgot_username'
+    );
   });
 });

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -159,6 +159,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
       </Formik>
       <div className="c-form__nav">
         <p>Having trouble logging in?</p>
+        {/* CAUTION: Do not exceed three links. If more needed, ask design. */}
         <AccountHelpLink />
         <ForgotPasswordLink />
         <ForgotUsernameLink />

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -73,7 +73,7 @@ const ForgotPasswordLink = () => (
 
 const ForgotUsernameLink = () => (
   <a
-    href="https://accounts.tacc.utexas.edu/forgot_password"
+    href="https://accounts.tacc.utexas.edu/forgot_username"
     target="_blank"
     rel="noreferrer"
   >

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -73,7 +73,7 @@ const ForgotUsernameLink = () => (
     target="_blank"
     rel="noreferrer"
   >
-    Reset Password
+    Request Username
   </a>
 );
 

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -67,7 +67,7 @@ const ForgotPasswordLink = () => (
     target="_blank"
     rel="noreferrer"
   >
-    Reset Password
+    Forgot Password
   </a>
 );
 
@@ -77,7 +77,7 @@ const ForgotUsernameLink = () => (
     target="_blank"
     rel="noreferrer"
   >
-    Request Username
+    Recover Username
   </a>
 );
 

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -52,12 +52,22 @@ const CreateAccountLink = () => (
 );
 
 const AccountHelpLink = () => (
-  <a href="/about/help/" target="_blank" rel="noreferrer">
+  <a href="https://accounts.tacc.utexas.edu/login_support" target="_blank" rel="noreferrer">
     Account Help
   </a>
 );
 
-const ResetPasswordLink = () => (
+const ForgotPasswordLink = () => (
+  <a
+    href="https://accounts.tacc.utexas.edu/forgot_password"
+    target="_blank"
+    rel="noreferrer"
+  >
+    Reset Password
+  </a>
+);
+
+const ForgotUsernameLink = () => (
   <a
     href="https://accounts.tacc.utexas.edu/forgot_password"
     target="_blank"
@@ -145,8 +155,9 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
       </Formik>
       <div className="c-form__nav">
         <p>Having trouble logging in?</p>
-        <ResetPasswordLink />
         <AccountHelpLink />
+        <ForgotPasswordLink />
+        <ForgotUsernameLink />
       </div>
     </div>
   );

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -132,7 +132,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
           <LoginError status={status} isError={isError} />
           <FormikInput
             name="username"
-            label="User Name"
+            label="Username"
             type="text"
             autoComplete="username"
             required

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -52,7 +52,11 @@ const CreateAccountLink = () => (
 );
 
 const AccountHelpLink = () => (
-  <a href="https://accounts.tacc.utexas.edu/login_support" target="_blank" rel="noreferrer">
+  <a
+    href="https://accounts.tacc.utexas.edu/login_support"
+    target="_blank"
+    rel="noreferrer"
+  >
     Account Help
   </a>
 );


### PR DESCRIPTION
## Overview

Update TACC login form to _synergize_ with TAM login form.

## Related

- [TUP-712](https://tacc-main.atlassian.net/browse/TUP-712)
- https://github.com/DesignSafe-CI/portal/pull/1324

## Changes

- **changed** Account Help link to new login support form
- **changed** internal name of Reset Password link

## Testing

1. Load login page.
2. Verify it has this text and link combo:

    > Having trouble logging in?
    > - [Account Help](https://accounts.tacc.utexas.edu/login_support)
    > - [Forgot Password](https://accounts.tacc.utexas.edu/forgot_password)
    > - [Recover Username](https://accounts.tacc.utexas.edu/forgot_username)

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/66b643db-0925-447a-b21b-888972a59043) | ![after](https://github.com/TACC/tup-ui/assets/62723358/1f91839f-bb9b-4cee-9540-ed6b9d6416e8) |

<details><summary>Ideas</summary>

| Quick Fix | New Link Texts | Call & Response | Misc. |
| - | - | - | - |
| <img width="665" alt="A" src="https://github.com/TACC/tup-ui/assets/62723358/e473c158-c1b8-448f-8434-0b7ebd1dd23d"> | <img width="665" alt="B" src="https://github.com/TACC/tup-ui/assets/62723358/a2ed2530-bb30-4b16-8b7e-5095a863d744"> | <img width="665" alt="C" src="https://github.com/TACC/tup-ui/assets/62723358/f0171340-fef3-4fd4-b3f6-81f6c84e9509"> | <img width="665" alt="D" src="https://github.com/TACC/tup-ui/assets/62723358/274b2a90-617e-4b66-b6f9-1394d7d91789"> |

</details>

## Notes

> [!IMPORTANT]
> No more such links. CMD agrees three such links is the max. Anymore, and design must re-think this.

> [!NOTE]
> This **was** pending reciprocal TAM updates based on https://github.com/TACC/tup-ui/issues/452, but design is not forthcoming, so I request this change as is.