### PR TITLE
fix: tup-712 "Username" not "User Name"

### DIFF
--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
@@ -27,7 +27,7 @@ describe('LoginComponent', () => {
       value: { replace: mockNavigate },
     });
     const { getByLabelText, getByRole } = testRender(<LoginComponent />);
-    const username = getByLabelText(/User Name/);
+    const username = getByLabelText(/Username/);
     const password = getByLabelText(/Password/);
     const submit = getByRole('button');
     await act(async () => {
@@ -50,7 +50,7 @@ describe('LoginComponent', () => {
     const { getByLabelText, getByRole, getAllByText } = testRender(
       <LoginComponent />
     );
-    const username = getByLabelText(/User Name/);
+    const username = getByLabelText(/Username/);
     const password = getByLabelText(/Password/);
     const submit = getByRole('button');
     await act(async () => {
@@ -79,7 +79,7 @@ describe('LoginComponent', () => {
     const { getByLabelText, getByRole, getAllByText } = testRender(
       <LoginComponent />
     );
-    const username = getByLabelText(/User Name/);
+    const username = getByLabelText(/Username/);
     const password = getByLabelText(/Password/);
     const submit = getByRole('button');
     await act(async () => {

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -118,7 +118,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
           <LoginError status={status} isError={isError} />
           <FormikInput
             name="username"
-            label="User Name"
+            label="Username"
             type="text"
             autoComplete="username"
             required


### PR DESCRIPTION
## Overview / Changes

Update TACC login form to display "Username" not "User Name".

## Related

- noticed during [TUP-712](https://tacc-main.atlassian.net/browse/TUP-712)

## Testing / UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/tup-ui/assets/62723358/01b08eb6-af15-4fba-a51c-834523d6981b) | ![after](https://github.com/TACC/tup-ui/assets/62723358/a87afa82-b69b-41f3-aec6-6726f9cc9dc9) |