### PR TITLE
feat: cmd-147 bluesky social media share icon

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.10.2
+FROM taccwma/core-cms:v4.11.0
 
 WORKDIR /code
 

--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -148,7 +148,7 @@ INCLUDES_SEARCH_BAR = True
 # TACC: SOCIAL MEDIA
 ########################
 
-TACC_SOCIAL_SHARE_PLATFORMS = ['linkedin', 'facebook', 'email']
+TACC_SOCIAL_SHARE_PLATFORMS = ['linkedin', 'facebook', 'bluesky', 'email']
 
 ########################
 # DJANGOCMS_BLOG


### PR DESCRIPTION
## Overview

Add BlueSky social media service to share icons.

> [!WARNING]
> - [x] [pending CMD review](https://tacc-team.slack.com/archives/C16DACT26/p1713202913382919)
> - [x] [close until BlueSky link sharing is more common and reads from page](https://tacc-team.slack.com/archives/C16DACT26/p1713207509583919?thread_ts=1713202913.382919&cid=C16DACT26)

## Related

- [CMD-147](https://tacc-main.atlassian.net/browse/CMD-147)

## Changes

- **changed** CMS image
- **added** `bluesky` to `TACC_SOCIAL_SHARE_PLATFORMS`

## Testing

1. Build/Start CMS.
2. Create/Open news article.
4. Verify BlueSky icon is present in share options.
5. Click BlueSky icon.
6. Verify URL is `https://bsky.app/intent/compose?text={{ url }}` where `{{ url }}` is the URL of the page.

## UI

https://github.com/TACC/tup-ui/assets/62723358/77f1c38a-3c94-477d-9f3f-54a2aae1838e

## Notes

> [!WARNING]
> This is not [yet](https://github.com/bluesky-social/social-app/issues/1301) as fully featured as other platforms's share-via-URL services.