### PR TITLE
chore: do not inherit blog category order from Core-CMS

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -205,6 +205,7 @@ TACC_BLOG_SHOW_TAGS = False
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'external'
 
+TACC_BLOG_CATEGORY_ORDER = ['press-release', 'feature-story', 'multimedia', 'podcast']
 
 ########################
 # TACC: CORE STYLES


### PR DESCRIPTION
## Overview

The setting `TACC_BLOG_CATEGORY_ORDER` was inherited from Core-CMS, but Core-CMS will [stop setting it](https://github.com/TACC/Core-CMS/commit/a8316ca
) in its next release, so TUP must set it.

## Related

None

## Changes

- **added** a setting _that **has been being inherited** from Core-CMS_

## Testing / UI

Verify category order is the same.

**Skipped.**
