### PR TITLE
feat: save 2 css snippets

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
@@ -1,3 +1,6 @@
+<template id="css-banner-tacc--notes">
+<!-- TO DYNAMICALL REDUCE HEIGHT OF BANNER: Do NOT edit CSS. Just set `style="height: 60vh; max-height: 550px; min-height: 230px;"` on banner "Picture / Image". To use static height, set `style="height: 550px"` instead. -->
+</template>
 <style id="css-banner-tacc">
 /* To limit width of title on wide screens */
 @media (width >= 992px) {

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
@@ -23,7 +23,7 @@
     left: 0; top: 0; bottom: 0; right: 0;
     background-color: var(--global-color-primary--x-light);
 }
-.banner-cell--major a:hover .u-highlight {
+.banner-cell--major a:hover :is(.u-highlight, .highlight) {
     background-color: var(--global-color-accent--normal);
 }
 

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
@@ -1,5 +1,5 @@
 <template id="css-banner-tacc--notes">
-<!-- TO DYNAMICALL REDUCE HEIGHT OF BANNER: Do NOT edit this stylesheet. Edit banner "Picture / Image" on CMS. Set `style="height: 60vh; max-height: 550px; min-height: 230px;"`. To use static height, set `style="height: 550px"` instead. -->
+<!-- TO DYNAMICALL REDUCE HEIGHT OF BANNER: NO NEED to edit this stylesheet. Edit banner "Picture / Image" on CMS. Set `style="height: 60vh; max-height: 550px; min-height: 230px;"`. To use static height, set `style="height: 550px"` instead. -->
 </template>
 <style id="css-banner-tacc">
 /* To limit width of title on wide screens */

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-banner-tacc.html
@@ -1,5 +1,5 @@
 <template id="css-banner-tacc--notes">
-<!-- TO DYNAMICALL REDUCE HEIGHT OF BANNER: Do NOT edit CSS. Just set `style="height: 60vh; max-height: 550px; min-height: 230px;"` on banner "Picture / Image". To use static height, set `style="height: 550px"` instead. -->
+<!-- TO DYNAMICALL REDUCE HEIGHT OF BANNER: Do NOT edit this stylesheet. Edit banner "Picture / Image" on CMS. Set `style="height: 60vh; max-height: 550px; min-height: 230px;"`. To use static height, set `style="height: 550px"` instead. -->
 </template>
 <style id="css-banner-tacc">
 /* To limit width of title on wide screens */

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-global-a11y.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-global-a11y.html
@@ -1,12 +1,5 @@
-<style id="css-homepage-2024-02">
-/* 1. To dynamically reduce height of banner */
-/* Change —
-    style="height: 550px"
-    — on banner image to —
-    style="height: 60vh; max-height: 550px; min-height: 230px;"
-*/
-
-/* 2. To make mobile menu button stand out */
+<style id="css-global-a11y">
+/* 1. To make mobile menu button stand out */
 .navbar-dark .navbar-toggler {
     border-color: var(--global-color-primary--normal);
 }

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-homepage-2024-02.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-homepage-2024-02.html
@@ -1,0 +1,26 @@
+<style id="css-homepage-2024-02">
+/* 1. To dynamically reduce height of banner */
+/* Change —
+    style="height: 550px"
+    — on banner image to —
+    style="height: 60vh; max-height: 550px; min-height: 230px;"
+*/
+
+/* 2. To make mobile menu button stand out */
+.navbar-dark .navbar-toggler {
+    border-color: var(--global-color-primary--normal);
+}
+
+/* 2. To make keyboard focus stand out on header */
+/*
+.nav-link:focus-visible,
+#header-logo:focus-visible,
+.navbar-dark .navbar-toggler:focus-visible {
+*/
+#s-header :focus,
+#header-branding a:focus,
+.s-search-bar::part(input):focus,
+.s-search-bar::part(button):focus {
+    outline-color: var(--global-color-primary--xx-light);
+}
+</style>


### PR DESCRIPTION
## Overview

Save snippet that only existed in CMS content. Migrate a note to an existing snippet.

## Related

None.

## Changes

- **added** `templates/css-global-a11y.html`
- **added** note to `templates/css-banner-tacc.html`

## Testing

> [!NOTE]
> Not required. This change merely saves code that has been working live.

1. Open two different pages on https://tacc.utexas.edu website.
2. Make window narrow enough that mobile nav appears.
3. **Verify mobile nav button has white-gray border.**
4. Open mobile nav.
5. Focus on search field.
6. **Verify search field button has thick white border.**

## UI

| sans new snippet | with new snippet |
| - | - |
| <img width="520" alt="before snippet" src="https://github.com/TACC/tup-ui/assets/62723358/ec71ef37-92a6-45b5-82d3-db1968c6c78e"> | <img width="520" alt="after snippet" src="https://github.com/TACC/tup-ui/assets/62723358/0c39e159-8a1c-4d2e-ae90-7f6d690a5407"> |