### PR TITLE
fix: TUP-700 @tacc/core-components - a typescript bug

### DIFF
--- a/libs/tup-components/src/mfa/MfaQRPanel.tsx
+++ b/libs/tup-components/src/mfa/MfaQRPanel.tsx
@@ -59,7 +59,6 @@ const MfaQRPanel: React.FC = () => {
               id="text"
               value={data.otpkey.value_b32}
               buttonClassName="s-affixed-input-wrapper__prepend"
-              firstElement="input"
             />
           </div>
         </p>


### PR DESCRIPTION
## Overview

Remove unused property (not previously noticed, cuz core-components TypeScript was not checked).

## Related

- [TUP-700](https://tacc-main.atlassian.net/browse/TUP-700)
- fixes bugs in #463

## Changes

- **fixed** dependency organization
- **refactored** Formik field wrappers to work from external package

## Testing

1. `npx nx build tup-ui --skip-nx-cache`
2. Verify no **errors**.

## UI

<details><summary>Before</summary>

```log
npx nx build tup-ui --skip-nx-cache

   ✔    1/1 dependent project tasks succeeded [0 read from cache]

   Hint: you can run the command with --verbose to see the full dependent project outputs

 ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————


> nx run tup-ui:build:production

libs/tup-components/src/mfa/MfaQRPanel.tsx:62:15 - error TS2322: Type '{ id: string; value: string; buttonClassName: string; firstElement: string; }' is not assignable to type 'IntrinsicAttributes & TextCopyFieldProps'.
  Property 'firstElement' does not exist on type 'IntrinsicAttributes & TextCopyFieldProps'.

  60 |               value={data.otpkey.value_b32}
  61 |               buttonClassName="s-affixed-input-wrapper__prepend"
> 62 |               firstElement="input"
     |               ^
  63 |             />
  64 |           </div>
  65 |         </p>

Found 1 error.

 >  NX   Found type errors. See above.

   Pass --verbose to see the stacktrace.


 ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Ran target build for project tup-ui and 1 task(s) they depend on (18s)
 
    ✖    1/2 failed
    ✔    1/2 succeeded [0 read from cache]

```

</details> 
<details><summary>After</summary>

```log
npx nx build tup-ui --skip-nx-cache                

   ✔    1/1 dependent project tasks succeeded [0 read from cache]

   Hint: you can run the command with --verbose to see the full dependent project outputs

 ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————


> nx run tup-ui:build:production

vite v5.0.11 building for production...
transforming (134) ../../libs/tup-components/src/projects/details/ProjectDetails.module.css[vite:css] start value has mixed support, consider using flex-start instead
6  |  
7  |    display: flex;
8  |    align-items: start;
   |    ^^^^^^^^^^^^^^^^^^^
9  |  }
10 |  .form label {
transforming (301) ../../node_modules/reactstrap/esm/ListInlineItem.js[vite:css] end value has mixed support, consider using flex-end instead
36 |    flex-direction: column;
37 |    justify-content: right;
38 |    align-items: end;
   |    ^^^^^^^^^^^^^^^^^
39 |  }
40 |  
✓ 1037 modules transformed.

(!) outDir /Users/wbomar/Code/tup-ui/dist/apps/tup-ui is not inside project root and will not be emptied.
Use --emptyOutDir to override.

../../dist/apps/tup-ui/imports.html                                0.17 kB │ gzip:   0.13 kB
../../dist/apps/tup-ui/assets/TACC-formal-Black-1c-7JqO7Kf5.svg    4.90 kB │ gzip:   1.81 kB
../../dist/apps/tup-ui/assets/imports-qdriRysu.css                45.70 kB │ gzip:   8.68 kB
../../dist/apps/tup-ui/assets/imports-4ZEY-eNg.js                532.73 kB │ gzip: 164.44 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 5.34s

 ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target build for project tup-ui and 1 task it depends on (35s)

```

</details> 