### PR TITLE
fix: tup-715 save patch fix of subdomain link ugly URLs

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
@@ -4,7 +4,7 @@
     /* HACK: To revert URL of links that Google changes on hover */
     /* FAQ: Google Analytics settings interpret subdomain links as URLs to adjust so it can track navigation */
     [ ...links ].forEach( function restoreLinkHrefChangedOnHover(link) {
-        const isTACC = document.location.host.includes('tacc.utexas.edu');
+        const isTACC = link.host.includes('tacc.utexas.edu');
 
         if ( isTACC ) {
             let currentHrefVal = link.getAttribute('href');

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
@@ -1,7 +1,8 @@
 <script type="module" id="js-prevent-ugly-urls-tup-715">
     const links = document.querySelectorAll('body > :is(header, main, footer) a[target="_blank"]');
 
-    /* To revert URL of links that Google changes on hover */
+    /* HACK: To revert URL of links that Google changes on hover */
+    /* FAQ: Google Analytics settings interpret subdomain links as URLs to adjust so it can track navigation */
     [ ...links ].forEach( function restorLinkHrefIfChangedOnHover(link) {
         const isTACC = document.location.host.includes('tacc.utexas.edu');
 

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
@@ -1,7 +1,8 @@
 <script type="module" id="js-prevent-ugly-urls-tup-715">
     const links = document.querySelectorAll('body > :is(header, main, footer) a[target="_blank"]');
 
-    [ ...links ].forEach( function tup715(link) {
+    /* To revert URL of links that Google changes on hover */
+    [ ...links ].forEach( function restorLinkHrefIfChangedOnHover(link) {
         const isTACC = document.location.host.includes('tacc.utexas.edu');
 
         if ( isTACC ) {
@@ -12,7 +13,6 @@
                 const originalHrefVal = link.getAttribute('data-original-href');
 
                 currentHrefVal = link.getAttribute('href');
-
                 if ( currentHrefVal !== originalHrefVal ) {
                     link.setAttribute('href', originalHrefVal );
                 }

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
@@ -1,0 +1,22 @@
+<script type="module" id="js-prevent-ugly-urls-tup-715">
+    const links = document.querySelectorAll('body > :is(header, main, footer) a[target="_blank"]');
+
+    [ ...links ].forEach( function tup715(link) {
+        const isTACC = document.location.host.includes('tacc.utexas.edu');
+
+        if ( isTACC ) {
+            let currentHrefVal = link.getAttribute('href');
+
+            link.setAttribute('data-original-href', currentHrefVal );
+            link.addEventListener('click', () => {
+                const originalHrefVal = link.getAttribute('data-original-href');
+
+                currentHrefVal = link.getAttribute('href');
+
+                if ( currentHrefVal !== originalHrefVal ) {
+                    link.setAttribute('href', originalHrefVal );
+                }
+            });
+        }
+    });
+</script>

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/js-prevent-ugly-urls.html
@@ -3,7 +3,7 @@
 
     /* HACK: To revert URL of links that Google changes on hover */
     /* FAQ: Google Analytics settings interpret subdomain links as URLs to adjust so it can track navigation */
-    [ ...links ].forEach( function restorLinkHrefIfChangedOnHover(link) {
+    [ ...links ].forEach( function restoreLinkHrefChangedOnHover(link) {
         const isTACC = document.location.host.includes('tacc.utexas.edu');
 
         if ( isTACC ) {


### PR DESCRIPTION
## Overview

Save a working snippet that reverts some Google Analytics JavaScript.

<details>Links on CMS page to subdomain are changed by Google to be functional but full of unsightly query parameters.</details>

## Related

- [TUP-715](https://tacc-main.atlassian.net/browse/TUP-715)

## Changes

- **saved** snippet that I have long been using to patch the bug

## Testing

1. Open [tacc.utexas.edu](http://tacc.utexas.edu/).
2. In menu, click "Use TACC" > "Documentation".

Verify URL does **not** have a string of query parameters.

3. Open https://tacc.utexas.edu/use-tacc/getting-started/.
4. On page, click "1. Create an Account" > [Create Account].

Verify URL does **not** have a string of query parameters.

<sup>To test previous behavior, comment out `<script>` in [snippet #150](https://tacc.utexas.edu/admin/djangocms_snippet/snippet/150/change/), then follow steps 1 through 4.</sup>

## UI

<details open><summary><strong>With</strong> Snippet</summary>

https://github.com/user-attachments/assets/164f0630-87ec-4405-8846-2b162e969d8c

https://github.com/user-attachments/assets/a78074a1-1153-451a-b4a6-51dd3d464b80

</details>
<details><summary><strong>Sans</strong> Snippet</summary>

https://github.com/user-attachments/assets/01bc6ef4-5a41-4aea-b8c5-5e852ed4ebdc


https://github.com/user-attachments/assets/a62f5673-5a43-4a7a-b02e-99d348b30302

</details>

## Notes

Not directly used. Just saving from:

- https://tacc.utexas.edu/admin/djangocms_snippet/snippet/150/
- https://dev.tup.tacc.utexas.edu/admin/djangocms_snippet/snippet/144/