### PR TITLE
fix: CMD-172 user news 10px font not accessible

### DIFF
--- a/libs/tup-components/src/news/UserNews.module.css
+++ b/libs/tup-components/src/news/UserNews.module.css
@@ -1,5 +1,5 @@
 .news-list {
-  font-size: var(--global-font-size--x-small);
+  font-size: var(--global-font-size--small);
 }
 
 .news-list-item {


### PR DESCRIPTION
## Overview

User News uses too small a font size. It is:

- inconsistent with the rest of the portal
- below minimum _generally-accepted_ accessible font size

## Related

- [CMD-172](https://tacc-main.atlassian.net/browse/CMD-172)

## Changes

- **changed** a style

## Testing

Verify font-size of User News smallest text:
1. is bigger
2. matches table cell text font size

## UI

| before | after |
| - | - |
| <img width="1200" alt="user news - before" src="https://github.com/TACC/tup-ui/assets/62723358/233b2646-e96d-4198-a854-423516f33dd6"> | <img width="1200" alt="user news - after" src="https://github.com/TACC/tup-ui/assets/62723358/bf44ad17-ca08-426a-916f-30845d7eb1c4"> |