### PR TITLE
fix: RT-99514 unique state for suspended user

### DIFF
--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -44,8 +44,7 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
   if (status === 451) {
     return (
       <div className="c-form__errors">
-        Your account is suspended.
-        <br />
+        Your account is suspended.{' '}
         <a
           rel="noopener noreferrer"
           target="_blank"

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -44,17 +44,14 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
   if (status === 451) {
     return (
       <div className="c-form__errors">
-        Sorry, your account is suspended.
-        <br />
-        Please{' '}
+        Your account is suspended.{' '}
         <a
           rel="noopener noreferrer"
           target="_blank"
           href="https://accounts.tacc.utexas.edu/login_support"
         >
-          request account support
+          Request account support.
         </a>
-        .
       </div>
     );
   }

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -44,14 +44,15 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
   if (status === 451) {
     return (
       <div className="c-form__errors">
-        Your account is suspended.{' '}
+        Your account has been suspended. Please{' '}
         <a
           rel="noopener noreferrer"
           target="_blank"
           href="https://accounts.tacc.utexas.edu/login_support"
         >
-          Request account support.
+          request account support
         </a>
+        .
       </div>
     );
   }

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -44,14 +44,17 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
   if (status === 451) {
     return (
       <div className="c-form__errors">
-        Your account is suspended.{' '}
+        Sorry, your account is suspended.
+        <br />
+        Please{' '}
         <a
           rel="noopener noreferrer"
           target="_blank"
           href="https://accounts.tacc.utexas.edu/login_support"
         >
-          Request account support.
+          request account support
         </a>
+        .
       </div>
     );
   }

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -44,17 +44,15 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
   if (status === 451) {
     return (
       <div className="c-form__errors">
-        Sorry, your account is suspended.
+        Your account is suspended.
         <br />
-        Please
         <a
           rel="noopener noreferrer"
           target="_blank"
           href="https://accounts.tacc.utexas.edu/login_support"
         >
-          request account support
+          Request account support.
         </a>
-        .
       </div>
     );
   }

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -44,15 +44,15 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
   if (status === 451) {
     return (
       <div className="c-form__errors">
-        Sorry, you're account is currently unavailable.
+        Sorry, your account is suspended.
         <br />
-        Please try again or{' '}
+        Please
         <a
           rel="noopener noreferrer"
           target="_blank"
           href="https://accounts.tacc.utexas.edu/login_support"
         >
-          check your account status
+          request account support
         </a>
         .
       </div>

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -41,6 +41,23 @@ const LoginError: React.FC<{ status?: number; isError: boolean }> = ({
       </div>
     );
   }
+  if (status === 451) {
+    return (
+      <div className="c-form__errors">
+        Sorry, you're account is currently unavailable.
+        <br />
+        Please try again or{' '}
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+          href="https://accounts.tacc.utexas.edu/login_support"
+        >
+          check your account status
+        </a>
+        .
+      </div>
+    );
+  }
   return (
     <div className="c-form__errors">
       Sorry. Something went wrong while trying to log in. Please try again


### PR DESCRIPTION
## Overview

Tell user if there account is suspended. Direct them to TAM.

## Related

- [RT #99514](https://consult.tacc.utexas.edu/Ticket/Display.html?id=99514)
- [Slack discussion (short-lived link)](https://tacc-team.slack.com/archives/CKB616RB8/p1722017896778129)

## Changes

- **add** new error code to `<LoginError>`

## Testing

1. Render the error. Options:
    - Try to login with suspended account.
    - Fake a `451` response from server.
    - Enter bad credentials, then edit error markup.
2. Verify login form shows error about account suspension.
3. Verify error has working link to https://accounts.tacc.utexas.edu/login_support.

## UI

| balanced (a290672) |
| - |
| <img width="980" alt="RT 99514 Solution Proposal - Balanced" src="https://github.com/user-attachments/assets/0b8f93a7-d97d-4e61-bd45-be433f99ebea"> |

<details><summary>Archived</summary>

| terse (f037ced) | nice (07039b0) |
| - | - |
| <img width="980" alt="RT 99514" src="https://github.com/user-attachments/assets/51e26b5c-f4ad-4bd6-8eac-d061ae6c894f"> | <img width="980" alt="RT 99514 Solution Proposal - Nicer" src="https://github.com/user-attachments/assets/2c473830-7b83-4612-bbad-31dd3faed612"> |

</details>

## Notes

- @jarosenb can provide specific error code for this state.
- Designers have taught me not to use Please or Thank you in messages ([example article](https://www.nngroup.com/articles/error-message-guidelines/)).[^1]
- An existing message uses "Please" and "Sorry", so I mimic.

[^1]: Simply let user know what happened, and what to do, politely.