### PR TITLE
feat: RT 30345 new epic tableau dashboard snippet

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/js-epic-data-dashboard.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/js-epic-data-dashboard.html
@@ -1,22 +1,31 @@
 <!-- Tableau Snippet: Start -->
 <!-- TACC: For responsiveness, added class `embed-responsive` -->
-<div class="tableauPlaceholder embed-responsive" id="viz1669848991031" style="position: relative">
-	<noscript><a href="#"><img alt="LandingPage " src="https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;EP&#47;EPICDashboard&#47;LandingPage&#47;1_rss.png" style="border: none" /></a></noscript><object class="tableauViz" style="display: none"><param name="host_url" value="https%3A%2F%2Fpublic.tableau.com%2F" /><param name="embed_code_version" value="3" /><param name="site_root" value="" /><param name="name" value="EPICDashboard/LandingPage" /><param name="tabs" value="no" /><param name="toolbar" value="yes" /><param name="static_image" value="https://public.tableau.com/static/images/EP/EPICDashboard/LandingPage/1.png" /><param name="animate_transition" value="yes" /><param name="display_static_image" value="yes" /><param name="display_spinner" value="yes" /><param name="display_overlay" value="yes" /><param name="display_count" value="yes" /><param name="language" value="en-US" /></object></div>
-<script type="text/javascript">
-    var divElement = document.getElementById("viz1669848991031");
-    var vizElement = divElement.getElementsByTagName("object")[0];
-    if (divElement.offsetWidth > 800) {
-      vizElement.style.width = "1140px";
-      vizElement.style.height = "795px";
-    } else if (divElement.offsetWidth > 500) {
-      vizElement.style.width = "1140px";
-      vizElement.style.height = "795px";
-    } else {
-      vizElement.style.width = "100%";
-      vizElement.style.height = "1227px";
-    }
-    /* TACC: 100% width prevents overflow */ vizElement.style.width = "100%";
-    var scriptElement = document.createElement("script");
-    scriptElement.src = "https://public.tableau.com/javascripts/api/viz_v1.js";
-    vizElement.parentNode.insertBefore(scriptElement, vizElement);
-</script><!-- Tableau Snippet: End -->
+<div class='tableauPlaceholder embed-responsive' id='viz1723091620076' style='position:
+relative'><noscript><a href='#'><img alt='LandingPage '
+src='https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;EP&#47;EPICDas
+hboard3_0&#47;LandingPage&#47;1_rss.png' style='border: none'
+/></a></noscript><object class='tableauViz' style='display:none;'><param
+name='host_url' value='https%3A%2F%2Fpublic.tableau.com%2F' /> <param
+name='embed_code_version' value='3' /> <param name='site_root' value='' /><param
+name='name' value='EPICDashboard3_0&#47;LandingPage' /><param name='tabs'
+value='no' /><param name='toolbar' value='yes' /><param name='static_image'
+value='https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;EP&#47;EPIC
+Dashboard3_0&#47;LandingPage&#47;1.png' /> <param name='animate_transition'
+value='yes' /><param name='display_static_image' value='yes' /><param
+name='display_spinner' value='yes' /><param name='display_overlay' value='yes'
+/><param name='display_count' value='yes' /><param name='language' value='en-US'
+/><param name='filter' value='publish=yes' /></object></div>
+<script type='text/javascript'>
+var divElement = document.getElementById('viz1723091620076');
+var vizElement = divElement.getElementsByTagName('object')[0];
+if ( divElement.offsetWidth > 800 ) {
+vizElement.style.width='1140px';vizElement.style.height='795px';} else if (
+divElement.offsetWidth > 500 ) {
+vizElement.style.width='1140px';vizElement.style.height='795px';} else {
+vizElement.style.width='100%';vizElement.style.height='2427px';}
+/* TACC: 100% width prevents overflow */ vizElement.style.width = "100%";
+var scriptElement = document.createElement('script');
+scriptElement.src = 'https://public.tableau.com/javascripts/api/viz_v1.js';
+vizElement.parentNode.insertBefore(scriptElement, vizElement);
+</script>
+<!-- Tableau Snippet: End -->


### PR DESCRIPTION
## Overview

Update the EPIC tableau dashboard snippet with latest code from stakeholder.

> [!IMPORTANT]
> After deploy, consider emptying the HTML of [snippet #55](https://tacc.utexas.edu/admin/djangocms_snippet/snippet/55/change/).

## Related

- [RT #30345](https://tickets.tacc.utexas.edu/Ticket/Display.html?id=30345)

## Changes

- **added** a snippet

## Testing

1. Open https://dev.tup.tacc.utexas.edu/education/educators/data-dashboard/?edit
2. Test dashboard at different screen widths: <500, 500–800, 800+.

## UI

> [!CAUTION]
> Not responsive. H.P. assumed the task from me. On production. I trust her decision.

| in isolation | within tacc |
| - | - |
| <img width="1280" alt="unresponsive tableau isolated" src="https://github.com/user-attachments/assets/93c04854-43b1-40c5-afeb-2a485bf7b45e"> | <img width="1280" alt="unresponsive tableau in tacc" src="https://github.com/user-attachments/assets/0f638dc6-1c5f-4890-9a27-0225397a06e2">
