### PR TITLE
fix: TUP-730 news drop-cap from Core-CMS

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.10.3
+FROM taccwma/core-cms:v4.14.1
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.14.1
+FROM taccwma/core-cms:v4.10.3
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.10.2
+FROM taccwma/core-cms:fix-TUP-730-news-drop-cap-should-work-even-if-no-caption
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:ec7b758b
+FROM taccwma/core-cms:v4.14.1
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:fix-TUP-730-news-drop-cap-should-work-even-if-no-caption
+FROM taccwma/core-cms:ec7b758b
 
 WORKDIR /code
 


### PR DESCRIPTION
## Status

> [!IMPORTANT]
> Closed in favor of a PR that tests all Core-CMS releases since [v4.10.2](https://github.com/TACC/Core-CMS/releases/v4.10.2):
> - #476
>
> <sub>I don't release a v4.10.3 because that still has several Core-Styles updates I'd rather test first on TUP.</sub>

## Overview

Add `s-drop-cap` support via code to Core instead of snippet on TUP.

## Related

- [TUP-730](https://tacc-main.atlassian.net/browse/TUP-730)
- **requires** https://github.com/TACC/Core-CMS/pull/864

## Changes

- **updated** to [Core-CMS v4.14.1](https://github.com/TACC/Core-Styles/releases/v4.14.1)
- **updated** to [Core-Styles v2.31.0](https://github.com/TACC/Core-Styles/releases/v2.31.0)

## Testing & UI

| automatic | manual | html unsuitable |
| - | - | - |
| <img width="920" alt="auto application" src="https://github.com/user-attachments/assets/aa58cc08-3d80-4fdd-8683-2afe5a264008"> | <img width="920" alt="direct application" src="https://github.com/user-attachments/assets/ed6c3f56-d230-497f-b67b-05f060d041ff"> | <img width="920" alt="image no caption" src="https://github.com/user-attachments/assets/a87e89d1-788e-4bb7-9795-354d57693232"> |