### PR TITLE
chore: run `npx update-browserslist-db@latest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8669,9 +8669,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
+      "version": "1.0.30001655",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
+      "integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
### Overview

Update outdated database that checks for CSS support.

### Testing & UI

1. Checkout `main`.
2. Run `npm ci`.
3. <details><summary>Run <a href="https://jenkins01.tacc.utexas.edu/job/tup-cms-deploy/231/console" target="_blank">a Jenkins build off `main`<a/>.</summary>

    ```
      > nx run tup-ui:build:production

      vite v5.0.11 building for production...
      [91mBrowserslist: caniuse-lite is outdated. Please run:
      npx update-browserslist-db@latest
      Why you should do it regularly: https://github.com/browserslist/update-db#readme
      [0mtransforming...
      [91m[vite:css] start value has mixed support, consider using flex-start instead
      6  |  
      7  |    display: flex;
      8  |    align-items: start;
         |    ^^^^^^^^^^^^^^^^^^^
      9  |  }
      10 |  .form label {
      [0m[91m[vite:css] end value has mixed support, consider using flex-end instead
      36 |    flex-direction: column;
      37 |    justify-content: right;
      38 |    align-items: end;
         |    ^^^^^^^^^^^^^^^^^
      39 |  }
      40 |  
    ```

    </details>

4. See warning.
5. <details><summary>Run <a href="chore/npx-update-browserslist-db-latest" target="_blank">a Jenkins build off `main`<a/>.</summary>

    ```      > nx run tup-ui:build:production

      vite v5.0.11 building for production...
      transforming...
      [91m[vite:css] start value has mixed support, consider using flex-start instead
      6  |  
      7  |    display: flex;
      8  |    align-items: start;
         |    ^^^^^^^^^^^^^^^^^^^
      9  |  }
      10 |  .form label {
      [0m[91m[vite:css] end value has mixed support, consider using flex-end instead
      36 |    flex-direction: column;
      37 |    justify-content: right;
      38 |    align-items: end;
         |    ^^^^^^^^^^^^^^^^^
      39 |  }
      40 |  
    ```

    </details>
6. ❌ See **no** warning.
