### PR TITLE
enhance: WI-154 do not show recaptcha data

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -49,7 +49,8 @@ def send_confirmation_email(form_name, form_data):
     if form_name == "Tour Request Form":
         tour_receipt = "<p>A copy of your tour request is provided below for your records:</p>\n"
         for key in form_data:
-            tour_receipt += f"<p>{key}: {form_data[key]}</p>\n"
+            if not key.startswith('recaptcha_'):
+                tour_receipt += f"<p>{key}: {form_data[key]}</p>\n"
 
     email_body = f"""
             <p>Greetings,</p>


### PR DESCRIPTION
## Overview

Do **not** show `recaptcha_…` field and value in Tour Request response

## Related

- [WI-154](https://tacc-main.atlassian.net/browse/WI-154)
- enhances #480
- included in #483

## Changes

- **added** conditional to field output

## Testing

0. Have a form called "Tour Request Form".
1. Ensure form has functional ReCaptcha field.
2. Submit form.
3. Verify auto-reply does **not** show `recaptcha_…` field **nor** value.

## UI

See https://github.com/TACC/tup-ui/pull/483.