### PR TITLE
fix: deprecated docker-compose command

### DIFF
--- a/apps/tup-cms/project.json
+++ b/apps/tup-cms/project.json
@@ -14,7 +14,7 @@
         }
       ],
       "options": {
-        "commands": ["docker-compose -f docker-compose.dev.yml build"],
+        "commands": ["docker compose -f docker-compose.dev.yml build"],
         "cwd": "apps/tup-cms",
         "parallel": false
       }
@@ -23,8 +23,8 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "docker-compose -f docker-compose.dev.yml stop",
-          "docker-compose -f docker-compose.dev.yml up"
+          "docker compose -f docker-compose.dev.yml stop",
+          "docker compose -f docker-compose.dev.yml up"
         ],
         "cwd": "apps/tup-cms",
         "parallel": false
@@ -33,7 +33,7 @@
     "down": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose -f docker-compose.dev.yml down",
+        "command": "docker compose -f docker-compose.dev.yml down",
         "cwd": "apps/tup-cms"
       }
     },


### PR DESCRIPTION
## Overview

- Do **not** use deprecated `docker-compose `command.
- **Do** use Docker Compose v2+ command, `docker compose`.

> [!IMPORTANT]
> Command `docker-compose` **fails** in latest versions of Docker Compose.

## Related

- [WP-602](https://tacc-main.atlassian.net/browse/WP-602)
- https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/

## Changes

- **replaced** `docker-compose ` with `docker compose`

## Testing

### Newer Docker Compose

0. Have Docker-Compose v2 (latest or relatively new).
1. Run any `npx nx serve …` command.
2. Verify no error about `docker-compose` command.

### Older Docker Compose

0. Have Docker-Compose v2 (older version).
1. Run any `npx nx serve …` command.
2. Verify no error about `docker-compose` command.

## UI

Skipped.