### PR TITLE
enhance: WI-154 show field labels not keys

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -44,6 +44,13 @@ def submit_ticket(form_data):
 
 
 def send_confirmation_email(form_name, form_data):
+
+    tour_receipt = ""
+    if form_name == "Tour Request Form":
+        tour_receipt = "<p>A copy of your tour request is provided below for your records:</p>\n"
+        for key in form_data:
+            tour_receipt += f"<p>{key}: {form_data[key]}</p>\n"
+
     email_body = f"""
             <p>Greetings,</p>
             <p>
@@ -51,11 +58,12 @@ def send_confirmation_email(form_name, form_data):
             </p>
             <p>
                 <ul>
-                    <li>For training registration requests, you will be contacted within one week to confirm registration. For additional help please contact Lauren Bruce (lbruce@tacc.utexas.edu).</li>
+                    <li>For information about training opportunities, please visit the <a href="https://tacc.utexas.edu/use-tacc/training/">Training page</a>, or contact Tabish Khan (tkhan@tacc.utexas.edu).</li>
                     <li>For tour requests, a tour coordinator will contact you within two business days to complete your reservation. For additional assistance please reach out to info@tacc.utexas.edu.</li>
-                    <li>For all other issues, a TACC support person will be in contact shortly. For additional assistance please reach out to info@tacc.utexas.edu.</li>
+                    <li>For additional assistance please reach out to info@tacc.utexas.edu.</li>
                 </ul>
             </p>
+            {tour_receipt}
             <p>
             Thank you for your time,<br>
             TACC Support

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -50,7 +50,7 @@ def send_confirmation_email(form_name, form_data):
         tour_receipt = "<p>A copy of your tour request is provided below for your records:</p>\n"
         for key in form_data:
             if not key.startswith('recaptcha_'):
-                tour_receipt += f"<p>{key}: {form_data[key]}</p>\n"
+                tour_receipt += f"<p>{form_data[key][label]}: {form_data[key]}</p>\n"
 
     email_body = f"""
             <p>Greetings,</p>

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -49,7 +49,7 @@ def send_confirmation_email(form_name, form_data):
     if form_name == "Tour Request Form":
         tour_receipt = "<p>A copy of your tour request is provided below for your records:</p>\n"
         for key in form_data:
-            if not key.startswith('recaptcha_'):
+            if not key.startswith('recaptcha_') and key != 'form_id':
                 label = reverse_slugify(key)
                 value = form_data[key]
                 tour_receipt += f"<p>{label}: {value}</p>\n"

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -51,7 +51,8 @@ def send_confirmation_email(form_name, form_data):
         for key in form_data:
             if not key.startswith('recaptcha_'):
                 label = reverse_slugify(key) if key != 'form_id' else 'Form ID'
-                tour_receipt += f"<p>{label}: {form_data[key]}</p>\n"
+                value = form_data[key]
+                tour_receipt += f"<p>{label}: {value}</p>\n"
 
     email_body = f"""
             <p>Greetings,</p>

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -49,7 +49,8 @@ def send_confirmation_email(form_name, form_data):
     if form_name == "Tour Request Form":
         tour_receipt = "<p>A copy of your tour request is provided below for your records:</p>\n"
         for key in form_data:
-            tour_receipt += f"<p>{key}: {form_data[key]}</p>\n"
+            if not key.startswith('recaptcha_'):
+                tour_receipt += f"<p>{key}: {form_data[key]}</p>\n"
 
     email_body = f"""
             <p>Greetings,</p>

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -51,8 +51,7 @@ def send_confirmation_email(form_name, form_data):
         for key in form_data:
             if not key.startswith('recaptcha_'):
                 label = reverse_slugify(key) if key != 'form_id' else 'Form ID'
-                value = form_data[key]
-                tour_receipt += f"<p>{label}: {value}</p>\n"
+                tour_receipt += f"<p>{label}: {form_data[key]}</p>\n"
 
     email_body = f"""
             <p>Greetings,</p>

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -49,8 +49,8 @@ def send_confirmation_email(form_name, form_data):
     if form_name == "Tour Request Form":
         tour_receipt = "<p>A copy of your tour request is provided below for your records:</p>\n"
         for key in form_data:
-            if not key.startswith('recaptcha_') and key != 'form_id':
-                label = reverse_slugify(key)
+            if not key.startswith('recaptcha_'):
+                label = reverse_slugify(key) if key != 'form_id' else 'Form ID'
                 value = form_data[key]
                 tour_receipt += f"<p>{label}: {value}</p>\n"
 

--- a/apps/tup-cms/src/apps/portal/utils.py
+++ b/apps/tup-cms/src/apps/portal/utils.py
@@ -5,7 +5,7 @@ import re
 def reverse_slugify(slug):
     """
 
-    :param str slug: A name that is lowercase and uses hyphens instead of spaces
+    :param str slug: A name that is title-cased and uses hyphens instead of spaces
     :rtype: str
 
     ..note:: Usage:
@@ -18,12 +18,7 @@ def reverse_slugify(slug):
 
     words_to_exclude = {'a', 'is', 'to', 'of', 'for', 'and', 'or', 'in'}
     words = slug.split('-')
-    words_capitalized = [
-      word.capitalize()
-      if word not in words_to_exclude
-      else word
-      for word in words
-    ]
-    text = ' '.join(words_capitalized).capitalize()
+    words_for_title = [ word if word.lower() in words_to_exclude else word.capitalize() for word in words ]
+    text = words_for_title.join(' ')
 
     return text

--- a/apps/tup-cms/src/apps/portal/utils.py
+++ b/apps/tup-cms/src/apps/portal/utils.py
@@ -19,6 +19,6 @@ def reverse_slugify(slug):
     words_to_exclude = {'a', 'is', 'to', 'of', 'for', 'and', 'or', 'in'}
     words = slug.split('-')
     words_for_title = [ word if word.lower() in words_to_exclude else word.capitalize() for word in words ]
-    text = words_for_title.join(' ')
+    text = ' '.join(words_for_title)
 
     return text

--- a/apps/tup-cms/src/apps/portal/utils.py
+++ b/apps/tup-cms/src/apps/portal/utils.py
@@ -1,11 +1,10 @@
 """Utilities for Portal
 """
-import re
 
 def reverse_slugify(slug):
     """
 
-    :param str slug: A name that is title-cased and uses hyphens instead of spaces
+    :param str slug: A name that is lowercase and uses hyphens instead of spaces
     :rtype: str
 
     ..note:: Usage:


### PR DESCRIPTION
## Overview

In "Tour Request Form" response:
- **do** show field labels
    <sup>which are for users</sup>
- **not** field name keys
    <sup>which are for code</sup>

## Related

- [WI-154](https://tacc-main.atlassian.net/browse/WI-154)
- enhances https://github.com/TACC/tup-ui/pull/480
- includes #481

## Changes

- **changed** field value name shown to user in e-mail
- **removed** recaptcha field value

## Testing

0. Have a form called "Tour Request Form".
1. Submit form.
2. Verify auto-reply:
    - does **not** show reCAPTCHA value
    - shows "First Name" **not** `first-name`
    - shows "Name of Your Organization" **not** `name-of-your-organization`
    - et cetera

## UI

| Before | After |
| - | - |
| <img width="960" alt="WI-154 Email Top (BEFORE)" src="https://github.com/user-attachments/assets/46934533-a13a-4100-b112-46425d06658f"> | <img width="960" alt="WI-154 Email Top (AFTER)" src="https://github.com/user-attachments/assets/de74bfc1-6aec-4239-b3a0-c9413d40f921"> |
| <img width="960" alt="WI-154 Email End (BEFORE)" src="https://github.com/user-attachments/assets/f5601652-c63b-42d4-8b21-cd206aee74b6"> | <img width="960" alt="WI-154 Email End (AFTER)" src="https://github.com/user-attachments/assets/8f181ccd-145b-4dcf-9834-a730363b5c22"> |