### PR TITLE
enhance(tup-comp…): username label also say email

### DIFF
--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
@@ -27,7 +27,7 @@ describe('LoginComponent', () => {
       value: { replace: mockNavigate },
     });
     const { getByLabelText, getByRole } = testRender(<LoginComponent />);
-    const username = getByLabelText(/Username/);
+    const username = getByLabelText(/Username or Email/);
     const password = getByLabelText(/Password/);
     const submit = getByRole('button');
     await act(async () => {

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -155,9 +155,9 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
           <LoginError status={status} isError={isError} />
           <FormikInput
             name="username"
-            label="Username"
+            label="Username or Email"
             type="text"
-            autoComplete="username"
+            autoComplete="username email"
             required
           />
           <FormikInput


### PR DESCRIPTION
## Overview / Changes

Label "Username" also as "Username and Email".

## Related

- [internal request](https://tacc-team.slack.com/archives/CKB616RB8/p1729697761158459)

## Testing

1. Run tests on tup-components. Verify LoginComponent passes.
2. Load tup-ui at login screen. Verify label is "Username and Email".

## UI

Skipped.