### PR TITLE
deps: cms v4.20 & core-styles v2.37

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.19.0
+FROM taccwma/core-cms:v4.19.1
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.18.0
+FROM taccwma/core-cms:v4.19.0
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.19.1
+FROM taccwma/core-cms:v4.20.0
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.17.1
+FROM taccwma/core-cms:v4.18.0
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.20.0
+FROM taccwma/core-cms:v4.20.1
 
 WORKDIR /code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nx/vite": "17.2.8",
         "@nx/web": "17.2.8",
         "@nx/workspace": "17.2.8",
-        "@tacc/core-styles": "^2.33.1",
+        "@tacc/core-styles": "^2.35.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -6463,10 +6463,11 @@
       "dev": true
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.33.1.tgz",
-      "integrity": "sha512-1YRY9Tj13lqOOrVXVStXtUK7c6/QIfm3UuWfGMkuP96YN0lyBDDaeobMs8LV432p/4cpVydlQHEhPD+JHh3Ycw==",
+      "version": "2.35.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.35.1.tgz",
+      "integrity": "sha512-5iF+pZsS0yAFo7C+fKGPtD4BiINWX6AzYX2BR3A7nwviMB4O9RAHrsXKkfm4R/ERAwUWOSA7UoeLlgI6Jp1yFA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nx/vite": "17.2.8",
         "@nx/web": "17.2.8",
         "@nx/workspace": "17.2.8",
-        "@tacc/core-styles": "^2.35.1",
+        "@tacc/core-styles": "^2.36.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -6463,9 +6463,9 @@
       "dev": true
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.35.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.35.1.tgz",
-      "integrity": "sha512-5iF+pZsS0yAFo7C+fKGPtD4BiINWX6AzYX2BR3A7nwviMB4O9RAHrsXKkfm4R/ERAwUWOSA7UoeLlgI6Jp1yFA==",
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.36.0.tgz",
+      "integrity": "sha512-4BgC6bWj5pJbaGTK5xMASrRGLhQcFUDDywRnrB3YbPitTg1DzVi6A8mYoPyKsWh2ZPKUr5aLDlnexVHsOfJrKQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nx/vite": "17.2.8",
         "@nx/web": "17.2.8",
         "@nx/workspace": "17.2.8",
-        "@tacc/core-styles": "^2.36.0",
+        "@tacc/core-styles": "^2.37.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -6463,9 +6463,9 @@
       "dev": true
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.36.0.tgz",
-      "integrity": "sha512-4BgC6bWj5pJbaGTK5xMASrRGLhQcFUDDywRnrB3YbPitTg1DzVi6A8mYoPyKsWh2ZPKUr5aLDlnexVHsOfJrKQ==",
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.37.0.tgz",
+      "integrity": "sha512-PaaRrIVNQ4yo8bSBC1vJWeTCQyKHs9MA1K2Jlgdyj0xMJqV8zxhiSWk1L2cM5C5RV9yEwWvyGBQtQ4zATQZw3Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nx/vite": "17.2.8",
         "@nx/web": "17.2.8",
         "@nx/workspace": "17.2.8",
-        "@tacc/core-styles": "^2.37.0",
+        "@tacc/core-styles": "^2.37.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -6463,9 +6463,9 @@
       "dev": true
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.37.0.tgz",
-      "integrity": "sha512-PaaRrIVNQ4yo8bSBC1vJWeTCQyKHs9MA1K2Jlgdyj0xMJqV8zxhiSWk1L2cM5C5RV9yEwWvyGBQtQ4zATQZw3Q==",
+      "version": "2.37.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.37.2.tgz",
+      "integrity": "sha512-Mj47VU6WBUrkaT48OWHgKBPeWgUS1vkKuGupXmUjH4SjeKj1nXAAXdCUP5WpVfKccsyWmESyprMuCOlVqIDEQA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nx/vite": "17.2.8",
     "@nx/web": "17.2.8",
     "@nx/workspace": "17.2.8",
-    "@tacc/core-styles": "^2.35.1",
+    "@tacc/core-styles": "^2.36.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nx/vite": "17.2.8",
     "@nx/web": "17.2.8",
     "@nx/workspace": "17.2.8",
-    "@tacc/core-styles": "^2.33.1",
+    "@tacc/core-styles": "^2.35.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nx/vite": "17.2.8",
     "@nx/web": "17.2.8",
     "@nx/workspace": "17.2.8",
-    "@tacc/core-styles": "^2.37.0",
+    "@tacc/core-styles": "^2.37.2",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nx/vite": "17.2.8",
     "@nx/web": "17.2.8",
     "@nx/workspace": "17.2.8",
-    "@tacc/core-styles": "^2.36.0",
+    "@tacc/core-styles": "^2.37.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## Overview

**Fix styles bugs. Add styles features.** Get some no-op, coat-tailing updates.

> [!IMPORTANT]
> After deploy to prod, delete [snippet #158](https://tacc.utexas.edu/admin/djangocms_snippet/snippet/158/change/).

## Related

- requires https://github.com/TACC/Core-CMS/releases/tag/v4.20.0
- requires https://github.com/TACC/Core-Styles/releases/tag/v2.37.0

## Changes

- **updated** Core-Styles & Core-CMS

## Testing & UI

### ✅ Core-CMS v4.18 / Core-Styles v2.35

1. Visit https://tacc.utexas.edu/systems/all/.
2. See **extra** space to the right of all images in cards. 🫢
3. Visit https://dev.tup.tacc.utexas.edu/systems/all/.
4. See **no** such space. 😏

| Before | After |
| - | - |
| <img width="920" alt="before" src="https://github.com/user-attachments/assets/d7e1653a-f6d4-4f6e-9f13-9709468ee369"> | <img width="920" alt="after" src="https://github.com/user-attachments/assets/41a08b9c-5a96-4111-bc31-4dddba6b535a"> |

### ✅ Core-CMS v4.19 / Core-Styles v2.36

1. Create a Bootstrap column.
2. Choose "Column dark"
3. Verify in that column;
    - background becomes dark
    - text becomes light
    - primary Button becomes lighter
    - Cards adapt as if in a dark Section

| Before | After |
| - | - |
| <img width="845" alt="Screenshot 2024-10-25 at 7 27 16 PM" src="https://github.com/user-attachments/assets/fa5b3fd8-8924-4ab3-bafa-e16beef1d899"> | <img width="845" alt="Screenshot 2024-10-25 at 7 26 16 PM" src="https://github.com/user-attachments/assets/edb905a9-1118-4e19-96b4-8643cb2b01d5"> |

### ✅ Core-CMS v4.20

1. Create a "Section (…)".
    <sup>i.e. `o-section`</sup>
2. Verify a `<div class="o-section">` is created.
3. Verify it does **not** have `container` class.

| Plugin | Render |
| - | - |
| <img width="919" alt="Plugin" src="https://github.com/user-attachments/assets/d03b7047-0bc4-46a8-a17f-cb2ab374e81f"> | <img width="919" alt="Render" src="https://github.com/user-attachments/assets/0280e22b-0a0d-4928-b010-93b3968f5fc9"> |

### ✅ ⚠️ Core-Styles v2.37

A new feature has a minor bug. Otherwise, all good.

1. <details><summary>Create/Find a <code>c-card--plain</code> that has an image.</summary>

    1. Create a "Style" block.
    3. Choose `c-card--plain`.
    4. Save block.
    5. Add "Picture/Image" block inside.
    6. Add "Text" block inside (with an `<h3>` and a paragraph).

    </details>

2. Edit the "Picture/Image": Add a link (internal or external).
3. Save block.
4. Verify card layout does not change.
5. Verify image in card has hover and click state.
6. Verify hover and click state are visible around image.

<details open><summary>After 533ae38</summary>

Tested with v2.39.0 via https://github.com/TACC/tup-ui/pull/499.

- ⚠️ Image crop changes.
- ⚠️ Hover state border is absent.

| before | after |
| - | - |
| <img width="960" alt="before" src="https://github.com/user-attachments/assets/c72eeead-3019-49de-b4a2-acf357276a65" /> | <img width="960" alt="after" src="https://github.com/user-attachments/assets/1d6abe81-33eb-4256-a0e1-ff486dc84d45" /> |
| <img width="960" alt="before - HTML" src="https://github.com/user-attachments/assets/3fb3b6fb-30df-4678-803a-877a8dc9db9c" /> | <img width="960" alt="after - HTML" src="https://github.com/user-attachments/assets/de8a097e-a8a6-4817-8b12-156209b5a975" /> |

https://github.com/user-attachments/assets/21f0c1a7-6594-4a65-8f85-691362ab954d

</details>

<details><summary>Before 533ae38</summary>

- ⚠️ Image crop changes.
- ⚠️ Hover state border is only on 1 side of a `card--right` image.

https://github.com/user-attachments/assets/f57a9460-292c-4525-b63e-f56bf86bdbad

| Before | After | After (Hover) | After (Click)
| - | - | - | - |
| <img width="485" alt="before" src="https://github.com/user-attachments/assets/618407e1-97b0-4371-8b15-f08899b00ce0"> | <img width="485" alt="after" src="https://github.com/user-attachments/assets/e6698fab-e083-43a4-907b-4515213df46a"> | <img width="485" alt="after - hover" src="https://github.com/user-attachments/assets/c0591579-db5d-4d34-ba1a-2818c03d0d8a"> | <img width="485" alt="after - active" src="https://github.com/user-attachments/assets/57da2a16-5ad0-48b0-a7b3-b2d5dab77812"> |

</details>