### PR TITLE
feat: CMD-147 enable BlueSky share

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -132,7 +132,7 @@ PORTAL_NAV_WIDTH = 'lg'
 # TACC: SOCIAL MEDIA
 ########################
 
-PORTAL_SOCIAL_SHARE_PLATFORMS = ['linkedin', 'facebook', 'email']
+PORTAL_SOCIAL_SHARE_PLATFORMS = ['linkedin', 'bluesky', 'facebook', 'email']
 
 ########################
 # DJANGOCMS_BLOG


### PR DESCRIPTION
## Overview / Changes

**Enable** BlueSky social media service to News share buttons.

## Related

**Enables** feature from:
- [CMD-147](https://tacc-main.atlassian.net/browse/CMD-147)
- https://github.com/TACC/Core-CMS/pull/832

## Testing

1. Build/Start CMS on this branch.
    <sup>Deployed to [dev](https://dev.tup.tacc.utexas.edu/news/latest-news/2024/02/01/nsf-selects-tacc-supercomputers-for-national-ai-research-resource-nairr-pilot/).</sup>
2. Create/Open a news article.
    <sup>E.g. [(dev) NSF Selects TACC Supercomputers for National AI Research Resource Pilot](https://dev.tup.tacc.utexas.edu/news/latest-news/2024/02/01/nsf-selects-tacc-supercomputers-for-national-ai-research-resource-nairr-pilot/).</sup>
3. Verify BlueSky icon is present in share options.
4. Click BlueSky icon.
5. Verify new tab appears that lets user share link on BlueSky.
6. Verify article image loads.

## UI

### CMS Feature Works on Dev

https://github.com/user-attachments/assets/a6d7e2f7-6fd8-40de-be01-973c2efd5778

### BlueSky Feature Works With Prod URL

https://github.com/user-attachments/assets/c4d39c8b-63f3-47cb-bd04-9d082146c4c8