### PR TITLE
fix: TUP-731 software table missing stampede3 & vista

### DIFF
--- a/libs/tup-components/src/software/SoftwareTable.tsx
+++ b/libs/tup-components/src/software/SoftwareTable.tsx
@@ -190,7 +190,8 @@ const SoftwareTable: React.FC = () => {
             <option value="">any</option>
             <option>Frontera</option>
             <option>Lonestar6</option>
-            <option>Stampede2</option>
+            <option>Stampede3</option>
+            <option>Vista</option>
           </select>
         </label>
       </form>


### PR DESCRIPTION
## Overview / Changes

Add "Stampede3". Add "Vista". Remove "Stampede 2".

## Related

- [TUP-731](https://tacc-main.atlassian.net/browse/TUP-731)

## Testing

1. Open https://dev.tup.tacc.utexas.edu/use-tacc/software-list/.
2. Open "System" dropdown.
3. See "Stampede 3", "Vista", but not "Stampede2".
4. Select these two new options.
5. Verify table updates appropriately.

## UI

https://github.com/user-attachments/assets/865b6786-8e59-4b12-af76-4ce327f930da