### PR TITLE
fix: missing "Security Incident" category

### DIFF
--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -90,7 +90,13 @@ export const TicketCreateForm: React.FC = () => {
     >
       {({ isValid }) => (
         <Form className={styles['ticket-create-form']} id="ticket-create-form">
-          <FormikSelect name="category" label="Category" required>
+          <FormikSelect
+            name="category"
+            label="Category"
+            required
+            description='For issues with MFA or CoC, choose "Multi-factor
+            Authentication" or "Other" respectively'
+          >
             <option value="">Please Choose One</option>
             <option>Allocations</option>
             <option>Running Jobs or Using TACC Resources</option>

--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -97,6 +97,7 @@ export const TicketCreateForm: React.FC = () => {
             <option>Login Issues</option>
             <option>Multi-factor Authentication</option>
             <option>Arecibo Data</option>
+            <option>Security Incident</option>
             <option>Other</option>
           </FormikSelect>
           <FormikSelect name="resource" label="System/Resource" required>


### PR DESCRIPTION
## Overview

<details><summary>The Category field in Ticket form is missing "Security Incident".</summary>

1. N.M. reported this to H.P. for CMS form.
2. I updated [CMS help page](https://tacc.utexas.edu/about/help/) form.
3. I checked this form, which is also missing it.
4. I failed to find in Git history when it was lost.
5. J.R. reveals change caused by [TUP-539](https://tacc-main.atlassian.net/browse/TUP-539).

</details>

## Related

- revert [TUP-539](https://tacc-main.atlassian.net/browse/TUP-539)

## Changes

- **added** `<option>` to a form field
- **added** help text to that form field

## Testing

1. Open portal.
2. Open modal to create a ticket.
3. View "Category" field.
4. Verify "Security Option" is present.
5. Verify help text is
    > For issues with MFA or CoC, choose "Multi-factor Authentication" or "Other" respectively.

## UI

<img width="960" alt="screenshot" src="https://github.com/user-attachments/assets/822ea6b3-e6c4-4552-9ab8-baffa11ea5d3" />

## Notes

Matches changes made to [CMS help page](https://tacc.utexas.edu/about/help/) form.