### PR TITLE
style: add space before open parens

### DIFF
--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -102,15 +102,15 @@ export const TicketCreateForm: React.FC = () => {
           <FormikSelect name="resource" label="System/Resource" required>
             <option value="">Please Choose One</option>
             <option>Corral (corral-login.tacc.utexas.edu)</option>
-            <option>Corral-Protected(corral-protected.tacc.utexas.edu)</option>
-            <option>Frontera(frontera.tacc.utexas.edu)</option>
-            <option>Jetstream(jetstream.tacc.utexas.edu)</option>
-            <option>Lonestar6(lonestar6.tacc.utexas.edu)</option>
-            <option>Ranch(ranch.tacc.utexas.edu)</option>
-            <option>Stampede3(stampede3.tacc.utexas.edu)</option>
-            <option>Vista(vista.tacc.utexas.edu)</option>
-            <option>Vislab(stallion.tacc.utexas.edu)</option>
-            <option>Cyclone(cyclone.tacc.utexas.edu)</option>
+            <option>Corral-Protected (corral-protected.tacc.utexas.edu)</option>
+            <option>Frontera (frontera.tacc.utexas.edu)</option>
+            <option>Jetstream (jetstream.tacc.utexas.edu)</option>
+            <option>Lonestar6 (lonestar6.tacc.utexas.edu)</option>
+            <option>Ranch (ranch.tacc.utexas.edu)</option>
+            <option>Stampede3 (stampede3.tacc.utexas.edu)</option>
+            <option>Vista (vista.tacc.utexas.edu)</option>
+            <option>Vislab (stallion.tacc.utexas.edu)</option>
+            <option>Cyclone (cyclone.tacc.utexas.edu)</option>
             <option>Cloud and Interactive Computing (Tapis API)</option>
             <option>Cloud and Interactive Computing (JupyterHub)</option>
             <option>Cloud and Interactive Computing (Other)</option>


### PR DESCRIPTION
## Overview

Add space before "(…)" in System dropdown.

_Already changed on [CMS help page](https://tacc.utexas.edu/about/help/) form._

## Related

None.

## Changes

- **added** space to user-facing text

## Testing

1. Open portal.
2. Begin to create ticket.
3. View "System/Resource" field options.
4. Verify open parentheses is always preceded by a space.

## UI

Skipped, because option value is just used as a string for a string:
* [portal form](https://github.com/TACC/tup-ui/blob/v1.1.13/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx#L63)
* [cms form](https://github.com/TACC/tup-ui/blob/v1.1.13/apps/tup-cms/src/apps/portal/apps.py#L32C52-L32C66)