### PR TITLE
Quick: Change login redirect param from 'from' to 'next' to match CMS config

### DIFF
--- a/apps/tup-cms/src/apps/portal/decorators.py
+++ b/apps/tup-cms/src/apps/portal/decorators.py
@@ -16,7 +16,7 @@ def tup_login_required(login_url="/portal/login"):
 
             if user is None:
                 from_path = urllib.parse.quote(request.get_full_path())
-                return redirect(f'{login_url}?from={from_path}')
+                return redirect(f'{login_url}?next={from_path}')
 
             login(request, user)
             return view_func(request, *args, **kwargs)

--- a/apps/tup-cms/src/apps/portal/views.py
+++ b/apps/tup-cms/src/apps/portal/views.py
@@ -15,7 +15,7 @@ def LoginView(request):
     user = authenticate(request)
     if user:
         login(request, user)
-        return redirect(request.GET.get('from', '/portal'))
+        return redirect(request.GET.get('next', '/portal'))
 
     if settings.DEBUG:
         template = loader.get_template('portal/portal.debug.html')

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -112,7 +112,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
   // parameter, 3) dashboard base route
   let from = (location.state as { from?: Location })?.from?.pathname ?? '';
   if (!from) {
-    from = searchParams.get('from') ?? '/portal';
+    from = searchParams.get('next') ?? '/portal';
   } else from = `/portal${from}`;
 
   const authCallback = useCallback(() => {


### PR DESCRIPTION
## Overview
Fix redirect for CMS pages where login is required (e.g. planned allocation form)

Testing directions: For testing purposes I've changed the "citing TACC" page to require lgin. Go to https://dev.tup.tacc.utexas.edu/about/citing-tacc/ while logged out, and check that you get redirected to the "citing tacc" page after login