### PR TITLE
Quick: Fix haystack error on publish

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -67,6 +67,7 @@ RECAPTCHA_PUBLIC_KEY = ''
 # ELASTICSEARCH
 ########################
 
+PORTAL_SEARCH_INDEX_IS_AUTOMATIC = False
 HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.BaseSignalProcessor'
 
 ########################


### PR DESCRIPTION
## Overview
The updated core-cms image requires `PORTAL_SEARCH_INDEX_IS_AUTOMATIC = False` to be configured in settings, otherwise our existing haystack config isn't respected.

## Related

- required since https://github.com/TACC/Core-CMS/pull/857
