### PR TITLE
task/wp-918-Adjust System Listings in Allocations

### DIFF
--- a/libs/tup-components/src/projects/ProjectsListing/ProjectsListingAllocationTable.tsx
+++ b/libs/tup-components/src/projects/ProjectsListing/ProjectsListingAllocationTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo, useState} from 'react';
 import { ProjectsRawSystem } from '@tacc/tup-hooks';
 import styles from './ProjectsListing.module.css';
 
@@ -10,7 +10,20 @@ const formatDate = (datestring: string): string => {
 export const ProjectsListingAllocationTable: React.FC<{
   project: ProjectsRawSystem;
 }> = ({ project }) => {
-  const allocations = project.allocations || [];
+
+  const sortedAllocationSystems = useMemo(() => {
+      const allocations = project.allocations || [];
+      return allocations.sort((a, b) => {
+        if ((!a?.end) || typeof a.end !== 'string') return -1; 
+        if ((!b?.end)|| typeof b.end !== 'string') return 1;
+        
+        return new Date(a?.end).getTime() - new Date(b?.end).getTime() 
+      });
+    }, [project.allocations]);
+
+    const filteredAllocationSystems = sortedAllocationSystems
+      ?.filter(allocation => allocation.status && typeof allocation.status == 'string' && allocation?.status?.toLowerCase() === 'active')
+
 
   return (
     <table className={styles['allocations-table']}>
@@ -24,7 +37,7 @@ export const ProjectsListingAllocationTable: React.FC<{
         </tr>
       </thead>
       <tbody>
-        {allocations.map((allocation) => (
+        {filteredAllocationSystems.map((allocation) => (
           <tr key={allocation.id}>
             <td>{allocation.resource}</td>
             <td>{allocation.total} SU</td>


### PR DESCRIPTION

## Overview
- Filter and sort systems by date

## Related

- [TUP-918](https://tacc-main.atlassian.net/browse/TUP-918)

## Changes
Adds filter by status and sorting by end date for systems in an allocations in projects menu

## Testing

1. [http://localhost:8000/portal/projects](http://localhost:8000/portal/projects) Check that systems no longer show if they are inactive 
2. Check that systems are sorted by date oldest to newest (ones set to expire soonest

## UI
![Screenshot 2025-04-17 at 3 27 20 PM](https://github.com/user-attachments/assets/b99ccfee-228c-4166-aa43-4dad2557ba8e)


## Notes
