### PR TITLE
chore(tup-cms): save new snippets (added today)

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-fix-padding-on-plain-cards-with-lists-after-paragraph.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-fix-padding-on-plain-cards-with-lists-after-paragraph.html
@@ -1,0 +1,5 @@
+<style id="css-page-reu-research-projects">
+    .card--plain p:has(+ :is(ul,ol)) {
+        margin-bottom: 5px;
+    }
+</style>

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-remove-padding-between-section-h3-and-paragraph.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-remove-padding-between-section-h3-and-paragraph.html
@@ -1,0 +1,5 @@
+<style id="css-remove-padding-between-section-h3-and-paragraph">
+[class*="section--"] > h3:has(+ p) {
+    margin-bottom: 0;
+}
+</style>

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-spacing-fixes.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-spacing-fixes.html
@@ -9,10 +9,12 @@
   #page-scivis-gallery *,
   #page-all-systems *,
   #page-stampede2 *, /* IMPORTANT: Added on 2023-10-13 */
-  :has(h1:only-child) /* /research/tacc-software/, /use-tacc/software-list/ */
+  :has(h1:only-child), /* /research/tacc-software/, /use-tacc/software-list/ */
+  #page-weteachcs * /* 2024-10-03 *//* /education/educators/weteachcs/ */
 ),
 .col:not(
   [class*="col-"],
+  [class*="banner-cell"], /* homepage banner */
   :last-child
 ) {
   margin-bottom: 4rem;


### PR DESCRIPTION
## Overview & Changes

Add 2 new snippets. Update 1 old snippet.

## Testing & UI

N/A. Just saving code that is now or has been live.

## Notes

The new snippets are used on these pages (as of today):
- https://tacc.utexas.edu/education/undergraduates-graduates/reu/research-projects/
- https://tacc.utexas.edu/education/undergraduates-graduates/reu/research-projects/archive/

> [!NOTE]
> One day I'll implement a non-snippet way to add TUP-specific CSS, but not today.
> <details><summary>Ideas</summary>
>
> 1. I could load stylesheets via CMS setting `PORTAL_STYLES`; and load even more this way after enhancements from https://github.com/TACC/Core-CMS/pull/880.
> 2. I could load one stylesheet (in any manner) from a URL that is always live, never cached. CDN's appear to have those, but there is still cache; but JSDelivr's cache for such URLs can take time to clear if URL is accessed (e.g. via TACC website page load) before I presss clear cache button for the URL. 
>
> </details>