### PR TITLE
feat: tup-706 support news on other sites

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/settings_custom.py
+++ b/apps/tup-cms/src/taccsite_cms/settings_custom.py
@@ -46,6 +46,8 @@ STORAGES = {
 CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),
+
+    ('bare.html', 'Bare'), # for TACC/Core-CMS-Plugin-Remote-Content
 )
 
 CMS_PERMISSIONS = True

--- a/apps/tup-cms/src/taccsite_cms/templates/bare.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/bare.html
@@ -1,0 +1,3 @@
+{# TODO: Remove template after TUP's Core-CMS image has TACC/Core-CMS#868 #}
+{# https://github.com/TACC/Core-CMS/pull/868 #}
+{% extends "raw.html" %}


### PR DESCRIPTION
## Overview

Add a CMS template to support loading TACC news HTML on other sites.

## Status

- [ ] Get a name better than "Bare" ([I ask H.P.](https://tacc-team.slack.com/archives/C02GF2X2AS3/p1748371671590119?thread_ts=1748371412.012539&cid=C02GF2X2AS3))

## Related

- [TUP-706](https://tacc-main.atlassian.net/browse/TUP-706)
- supports https://github.com/TACC/Core-CMS/pull/868

## Changes

- **added** a template `bare.html`
- **added** `CMS_TEMPLATES` entry

## Testing

1. Open https://dev.tup.tacc.utexas.edu/news/latest-news/?template=bare.html
2. Verify page loads News content but:
    - no header nor footer
    - no global assets (e.g. styles, scripts)
3. (Optional) Verify page template "Bare" is available to editors.
    <sup>Editors should **not** use this, but it must be available to support `?template=`.</sup>

## UI

| New Feature | Regular View
| - | - |
| <img width="960" alt="dev tup news bare" src="https://github.com/user-attachments/assets/cebcec65-65fb-4cee-9893-2fc5224394ef" /> | <img width="960" alt="dev tup news normal" src="https://github.com/user-attachments/assets/2f4192f0-fc0d-42d0-9009-697109e0efff" /> |

<details><summary>Testing Step 3 (Optional)</summary>

| a "Side Effect" |
| - |
| <img width="960" alt="dev bare template option" src="https://github.com/user-attachments/assets/b3953312-fdab-442a-b8de-0fdfb637b0da" /> |

</details>

## Notes

I manually made these changes on prod (to test https://github.com/TACC/Core-CMS/pull/868 loading news via prod) — _because prod is (likely) allowed as cross-origin resource (pre-prod is not)_ — but server restart (which I will not do) is required to enable the change, so wasted effort.