### PR TITLE
fix: TUP-736 inconsistent sys/res opts

### DIFF
--- a/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
+++ b/libs/tup-components/src/tickets/TicketCreateModal/TicketCreateForm.tsx
@@ -112,9 +112,10 @@ export const TicketCreateForm: React.FC = () => {
             <option>Vislab (stallion.tacc.utexas.edu)</option>
             <option>Cyclone (cyclone.tacc.utexas.edu)</option>
             <option>Cloud and Interactive Computing (Tapis API)</option>
+            <option>Cloud and Interactive Computing (Abaco API)</option>
             <option>Cloud and Interactive Computing (JupyterHub)</option>
             <option>Cloud and Interactive Computing (Other)</option>
-            <option>Other</option>
+            <option>Other / None</option>
           </FormikSelect>
           <FormikInput name="subject" label="Subject" required description="" />
           <FormikTextarea


### PR DESCRIPTION
## Overview

Updated **System/Resource** field options in new ticket form.

## Status

- Pending direction from JS, AJ, or SB ([private inquiry](https://tacc-team.slack.com/archives/C08UGV89TC4/p1748463684638919), [internal inquiry](https://tacc-team.slack.com/archives/CKB616RB8/p1748463358131659)).

## Related

- [TUP-736](https://tacc-main.atlassian.net/browse/TUP-736)

## Changes

- **added** option
- **changed** option

## Testing

1. Open `/portal/tickets`.
2. Click [+ New Ticket].
3. Open "System/Resource" menu.
4. Verify options match those of [help page](https://tacc.utexas.edu/about/help/) form.

## UI

Skipped.