### PR TITLE
fix: embeds too short for podcasts from new source

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-podcast-embeds.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-podcast-embeds.html
@@ -1,5 +1,6 @@
 <style id="css-podcast-embeds">
 iframe[href*="rss.com"] {
-    height: 200px;
+    /* FAQ: for wide screen, 200px; for narrow screen, 202px */
+    height: 202px;
 }
 </style>

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-podcast-embeds.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-podcast-embeds.html
@@ -1,0 +1,5 @@
+<style id="css-podcast-embeds">
+iframe[href*="rss.com"] {
+    height: 200px;
+}
+</style>


### PR DESCRIPTION
> [!IMPORTANT]
> Closed in favor of #514.

## Overview

Embeds for podcasts are too short, since we migrated to RSS.com for podcasts.

## Related

- would be replaced by #514

## Changes

- **added** a snippet (saved in CMS today)

## Testing

1. Open https://tacc.utexas.edu/news/latest-news/2025/06/05/How-Public-Investment-in-HPC-Sparked-AI-Boom/?edit.
2. Scroll to podcast, purple audio embed (if not visible).
3. Verify podcast embed does **not** have a scrollbar.

## UI

| before | after |
| - | - |
| <img width="960" alt="before" src="https://github.com/user-attachments/assets/2884ebc9-279d-481a-843e-75adc8259ff8" /> | <img width="960" alt="after" src="https://github.com/user-attachments/assets/ecbe96c5-06fe-4ff4-aa59-b4339c6e62ae" /> |