### PR TITLE
fix: fresh CMS migrate (i.e. Core-CMS v4.24 to v4.28)

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.24.2
+FROM taccwma/core-cms:v4.28.2
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Update CMS just enough to fix error during [migration](https://github.com/TACC/Core-CMS/blob/v4.24.2/taccsite_cms/migrations/0001_add_groups.py?rgh-link-date=2025-08-12T19%3A41%3A25Z) that [has become noop](https://github.com/TACC/Core-CMS/pull/932).

## Related

- from https://github.com/TACC/Core-CMS/releases/tag/v4.23.0
- to https://github.com/TACC/Core-CMS/releases/tag/v4.28.2

## Changes / Testing

- [v4.24.3](https://github.com/TACC/Core-CMS/releases/tag/v4.24.3), [v4.25.2](https://github.com/TACC/Core-CMS/releases/tag/v4.25.2): test portal nav — on CMS page, and in Portal
- [v4.25.0](https://github.com/TACC/Core-CMS/releases/tag/v4.25.0), [v4.25.1](https://github.com/TACC/Core-CMS/releases/tag/v4.25.1), [v4.26.1](https://github.com/TACC/Core-CMS/releases/tag/v4.26.1): test header UI — **font change**, otherwise zero or negligible changes
- [v4.25.3](https://github.com/TACC/Core-CMS/releases/tag/v4.25.3), [v4.25.4](https://github.com/TACC/Core-CMS/releases/tag/v4.25.4): test pagination on News — expect less space between "Page 1 of NN" and "Next >"
- [v4.27.1](https://github.com/TACC/Core-CMS/releases/tag/v4.27.1): ~~find and test .c-card-list — layout might change~~
    <sup>`people-grid` created before and used instead, at [/education/k-12-students/#meet-the-team](https://tacc.utexas.edu/education/k-12-students/#meet-the-team)</sup>
- [v4.28.2](https://github.com/TACC/Core-CMS/releases/tag/v4.28.2): test fresh migrate

## UI

Skipped, but tested expected changes. Differences are as expected.