### PR TITLE
fix: a11y issues, round 2

### DIFF
--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/styles.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/styles.html
@@ -1,7 +1,7 @@
 {% if has_markup_content %}
 <style>
 /* To prevent inline styling within raw API content */
-article > div.has-markup [style] {
+article > div.has-markup [style]:not(a) {
   all: unset !important; /* !important needed to override style attribute */
 }
 </style>

--- a/apps/tup-cms/src/apps/user_news/templates/user_news/includes/styles.html
+++ b/apps/tup-cms/src/apps/user_news/templates/user_news/includes/styles.html
@@ -1,7 +1,10 @@
 {% if has_markup_content %}
 <style>
 /* To prevent inline styling within raw API content */
-article > div.has-markup [style]:not(a) {
+article > div.has-markup [style]:not(
+  a,
+  [style=""]
+) {
   all: unset !important; /* !important needed to override style attribute */
 }
 </style>

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-ad-hoc-styles.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-ad-hoc-styles.html
@@ -13,3 +13,6 @@ Many <link>s is faster than one <link> with many '@import's.
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/c-feed-list-tweaks.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/navbar-width-horz-scrollbar.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/tagged-news-uppercase-tag.css" rel="stylesheet" />
+
+{# TODO: Delete when Core-CMS loads TACC/Core-Styles@1009035e #}
+<style>@layer project { figcaption, p.caption { opacity: 0.75; } }</style>

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-ad-hoc-styles.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-ad-hoc-styles.html
@@ -8,7 +8,7 @@ Many <link>s is faster than one <link> with many '@import's.
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/spacing-fixes.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@2d38b978/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/podcast-embeds.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/scrolling-fixes.css" rel="stylesheet" />
-<link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@982e4461/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/global-a11y.css" rel="stylesheet" />
+<link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@20981794/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/global-a11y.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/tup-730-drop-cap-and-fix-has-blog-tag-no-drop-cap.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/c-feed-list-tweaks.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/navbar-width-horz-scrollbar.css" rel="stylesheet" />

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/global-a11y.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/global-a11y.css
@@ -13,6 +13,7 @@
 }
 
 /* 3. Unset color that is so light it makes links in a lead undistinguishable */
+/* TODO: Delete this after TUP-CMS uses Core-CMS since TACC/Core-CMS#1141 */
 :is(:is(.blog-list) article) .blog-lead {
   color: unset;
 }

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/global-a11y.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/global-a11y.css
@@ -11,3 +11,8 @@
 .navbar-dark .navbar-toggler {
     border-color: var(--global-color-primary--normal);
 }
+
+/* 3. Unset color that is so light it makes links in a lead undistinguishable */
+:is(:is(.blog-list) article) .blog-lead {
+  color: unset;
+}


### PR DESCRIPTION
## Overview

Accessibility patches.

## Related

- continues #537
- references https://github.com/TACC/Core-CMS/pull/1141
- references https://github.com/TACC/Core-Styles/commit/1009035e

## Changes

1. [fix: links indistinguishable on news article leads](https://github.com/TACC/tup-ui/commit/2098179447412d4adc4163e63adbc8e71b413aab)
    These links are usually only hidden external article links, but Monsido/Acquia is still finding them.
2. [fix: unstyled link on a User Update](https://github.com/TACC/tup-ui/pull/546/commits/f949040db6baf62416123e40c2996348111da524) + 19935c9
    A link had a `style` attribute (why?!), which triggered de-styling. I've [added code to ignore] `style=""` to prevent this edge case. bug
3. [fix(a11y): increase figure caption opacity](https://github.com/TACC/tup-ui/pull/546/commits/cc11815ec814255314a426967fba054564d637a3)
   In fixing captions on dark backgrounds (during [#537](https://github.com/TACC/tup-ui/pull/537)), I broke captions on light backgrounds. Both fixed now.

## Testing

I tested —

- I ran accessibility scans to confirm the snippet fixes.
- The others, I live-edited HTML to achieve the same result.

— and after #537 (and friends) I've no will to further document tiny a11y fixes.

## UI

Skipped.