### PR TITLE
fix(cms): 500 error because of outdated plain.html

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/plain.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/plain.html
@@ -1,0 +1,3 @@
+{# TODO: Remove template after TUP's Core-CMS image has TACC/Core-CMS#868 #}
+{# https://github.com/TACC/Core-CMS/pull/868 #}
+{% extends "raw.html" %}

--- a/apps/tup-cms/src/taccsite_cms/templates/plain.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/plain.html
@@ -1,3 +1,5 @@
 {# TODO: Remove template after TUP's Core-CMS image has TACC/Core-CMS#868 #}
 {# https://github.com/TACC/Core-CMS/pull/868 #}
 {% extends "raw.html" %}
+
+{# test #}

--- a/apps/tup-cms/src/taccsite_cms/templates/plain.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/plain.html
@@ -1,5 +1,3 @@
 {# TODO: Remove template after TUP's Core-CMS image has TACC/Core-CMS#868 #}
 {# https://github.com/TACC/Core-CMS/pull/868 #}
 {% extends "raw.html" %}
-
-{# test #}

--- a/apps/tup-cms/src/taccsite_cms/templates/plain.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/plain.html
@@ -1,3 +1,0 @@
-{# TODO: Remove template after TUP's Core-CMS image has TACC/Core-CMS#868 #}
-{# https://github.com/TACC/Core-CMS/pull/868 #}
-{% extends "raw.html" %}


### PR DESCRIPTION
## Overview

Remove TUP-CMS `plain.html`, so app uses [Core-CMS `plain.html`](https://github.com/TACC/Core-CMS/blob/v4.39.1/taccsite_cms/templates/plain.html).

<sup>Fixes 500 error. (Server has bandaid fix, that will be removed [by deploying this].)</sup>

## Related

- fixes bug caused by #537

## Changes

- **deletes** file

## Testing

### Feature

Verify any URL appended with `?template=plain.html` removes header, footer, and styles.

### Deploy

1. [Deploy `d746460` to `dev`.](https://jenkins.portals.tacc.utexas.edu/job/TUP%20CMS%20deploy/121/console)
2. Access `tup_cms` container.
3. Verify `/code/taccsite_cms/templates/plain.html` has [content from `d746460`](https://github.com/TACC/tup-ui/blob/d746460/apps/tup-cms/src/taccsite_cms/templates/plain.html).
4. Verify https://dev.tup.tacc.utexas.edu/news/latest-news/?template=plain.html returns 500.
5. [Deploy `6273a72` to `dev`.](https://jenkins.portals.tacc.utexas.edu/job/TUP%20CMS%20deploy/122/parameters/)
6. Access `tup_cms` container.
7. Verify `/code/taccsite_cms/templates/plain.html` has [content of Core-CMS](https://github.com/TACC/Core-CMS/blob/v4.39.1/taccsite_cms/templates/plain.html).
8. Verify https://dev.tup.tacc.utexas.edu/news/latest-news/?template=plain.html returns un-styled content.

## UI

<img width="900" height="470" alt="unstyled content" src="https://github.com/user-attachments/assets/31065693-5721-4863-bfdd-64866f59cf39" />
