### PR TITLE
chore(cms): delete snippet (already deleted from prod)

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-fix-padding-on-plain-cards-with-lists-after-paragraph.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-fix-padding-on-plain-cards-with-lists-after-paragraph.html
@@ -1,5 +1,0 @@
-<style id="css-page-reu-research-projects">
-    .card--plain p:has(+ :is(ul,ol)) {
-        margin-bottom: 5px;
-    }
-</style>


### PR DESCRIPTION
## Overview

Deleted on prod.

## Testing

https://tacc.utexas.edu/education/undergraduates-graduates/reu/research-projects/

Tested. Only used on one page.

## UI

Was causing weird spacing.

## Notes

Newer CMS & Styles since that snippet fixed (the right way) the problem it fixed (the bandaid way).