### PR TITLE
chore(cms): snippet, no extra space for #page-acsc

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/css-ad-hoc-styles.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/css-ad-hoc-styles.html
@@ -5,7 +5,7 @@ Many <link>s is faster than one <link> with many '@import's.
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/fix-news-hr-behind-offset-image.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/hide-svg-icons.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/trumps-has-decal.css" rel="stylesheet" />
-<link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@ebe64890/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/spacing-fixes.css" rel="stylesheet" />
+<link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@a2898caa/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/spacing-fixes.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@2d38b978/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/podcast-embeds.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/scrolling-fixes.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/tup-ui@20981794/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/global-a11y.css" rel="stylesheet" />

--- a/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/spacing-fixes.css
+++ b/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/spacing-fixes.css
@@ -12,6 +12,7 @@
   #page-training *, /* 2025-04-02 *//* /use-tacc/training/ */
   #page-about-tours *, /* 2026-03-16 *//* /about/tours/ */
   #page-request-tour * /* 2026-03-16 *//* /about/tours/request/ */
+  #page-acsc *, /* 2026-04-21 *//* /education/undergraduates-graduates/acsc/ */
 ),
 .col:not(
   [class*="col-"],


### PR DESCRIPTION
## Overview

Saving a snippet change.

## Related

- similar to #553

## Notes

To not add extra space beneath columns on [/education/undergraduates-graduates/acsc/](https://tacc.utexas.edu/education/undergraduates-graduates/acsc/).