### PR TITLE
feat: allow up to two Allocation Managers per project and update rela…

### DIFF
--- a/libs/tup-components/src/projects/details/ProjectDetails.tsx
+++ b/libs/tup-components/src/projects/details/ProjectDetails.tsx
@@ -143,8 +143,8 @@ const ProjectDetails: React.FC<{ projectId: number }> = ({ projectId }) => {
       >
         {canManage && (
           <span>
-            To set an Allocation Manager, please select a user in the menu to
-            the left.
+            To set Allocation Managers, please select a user in the menu to the
+            left. Up to two Allocation Managers may be assigned per project.
             <br />
             <br />
           </span>

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -21,9 +21,17 @@ const UserRoleSelector: React.FC<{ projectId: number; user: ProjectUser }> = ({
 }) => {
   const currentUserRole = useRoleForCurrentUser(projectId) ?? '';
   const { mutate: mutateSetDelegate } = useSetProjectDelegate(projectId);
-  const { mutate: mutateRemoveDelegate } = useRemoveProjectDelegate(projectId);
+  const { mutate: mutateRemoveDelegate } = useRemoveProjectDelegate(
+    projectId,
+    user.username
+  );
   const { data: project, isLoading: isLoadingProject } = useProject(projectId);
+  const { data: projectUsers } = useProjectUsers(projectId);
   const isAccess = project?.chargeCode.startsWith('TG-');
+  const delegateCount =
+    projectUsers?.filter((projectUser) => projectUser.role === 'Delegate')
+      .length ?? 0;
+  const canPromoteToDelegate = user.role === 'Delegate' || delegateCount < 2;
 
   const [selectedUserRole, setSelectedUserRole] = useState<string>(
     user.role ?? ''
@@ -66,7 +74,9 @@ const UserRoleSelector: React.FC<{ projectId: number; user: ProjectUser }> = ({
         id="user-role-select"
       >
         <option value={'Standard'}>Standard User</option>
-        <option value={'Delegate'}>Allocation Manager</option>
+        <option value={'Delegate'} disabled={!canPromoteToDelegate}>
+          Allocation Manager
+        </option>
       </select>{' '}
       {selectedUserRole !== user.role && (
         <Button className={styles['link-button']} type="link" attr="submit">

--- a/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
+++ b/libs/tup-components/src/projects/users/UserDetail/UserDetail.tsx
@@ -75,7 +75,9 @@ const UserRoleSelector: React.FC<{ projectId: number; user: ProjectUser }> = ({
       >
         <option value={'Standard'}>Standard User</option>
         <option value={'Delegate'} disabled={!canPromoteToDelegate}>
-          Allocation Manager
+          {canPromoteToDelegate
+            ? 'Allocation Manager'
+            : 'Allocation Manager (remove an existing manager to add another)'}
         </option>
       </select>{' '}
       {selectedUserRole !== user.role && (

--- a/libs/tup-components/src/projects/users/UserList/UserList.tsx
+++ b/libs/tup-components/src/projects/users/UserList/UserList.tsx
@@ -9,7 +9,7 @@ const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
   const projectUsers = useProjectUsers(projectId);
   const data = projectUsers.data ?? [];
   const pi = data.find((user) => user.role === 'PI');
-  const delegate = data.find((user) => user.role === 'Delegate');
+  const delegates = data.filter((user) => user.role === 'Delegate');
 
   if (projectUsers.isLoading)
     return (
@@ -38,11 +38,12 @@ const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
           </span>
         </NavItem>
       )}
-      {delegate && (
+      {delegates.map((delegate) => (
         <NavItem
           to={`/projects/${projectId}/${delegate?.username}`}
           end
           className={styles['user-navitem']}
+          key={`delegate-${delegate.username}`}
         >
           <span style={{ fontWeight: 'normal' }}>Allocation Manager</span>
           <h4>
@@ -54,7 +55,7 @@ const UserList: React.FC<{ projectId: number }> = ({ projectId }) => {
             ({delegate.username})
           </span>
         </NavItem>
-      )}
+      ))}
       <div className={styles['separator']}></div>
       {data.map((user) => (
         <NavItem

--- a/libs/tup-hooks/src/projects/useProjects.ts
+++ b/libs/tup-hooks/src/projects/useProjects.ts
@@ -60,10 +60,10 @@ export const useSetProjectDelegate = (projectId: number) => {
   return mutation;
 };
 
-export const useRemoveProjectDelegate = (projectId: number) => {
+export const useRemoveProjectDelegate = (projectId: number, username: string) => {
   const queryClient = useQueryClient();
   const mutation = useDelete<string>({
-    endpoint: `/projects/${projectId}/delegate`,
+    endpoint: `/projects/${projectId}/delegate/${username}`,
     options: {
       onSuccess: () => {
         queryClient.invalidateQueries(['projects']);

--- a/libs/tup-hooks/src/projects/useProjects.ts
+++ b/libs/tup-hooks/src/projects/useProjects.ts
@@ -60,7 +60,10 @@ export const useSetProjectDelegate = (projectId: number) => {
   return mutation;
 };
 
-export const useRemoveProjectDelegate = (projectId: number, username: string) => {
+export const useRemoveProjectDelegate = (
+  projectId: number,
+  username: string
+) => {
   const queryClient = useQueryClient();
   const mutation = useDelete<string>({
     endpoint: `/projects/${projectId}/delegate/${username}`,


### PR DESCRIPTION
## Overview:
Allow up to 2 Allocations Managers per project on TUP. 

## Related Github Issues:

- [WP-1023](https://jira.tacc.utexas.edu/browse/WP-1023)

## Summary of Changes:
UI/hooks to display/manage up to 2 managers.
Calls to the correct backend endpoint for demotion.

## Testing Steps:

1. Go to Projects & Allocations
2. Select an Allocation
3. Verify that you can add another Allocation Manager
4. With 2 Allocation Managers, verify no more can be added
5. Remove an Allocation Manager, verify 1 Allocation Manager is acceptable. 

## UI

https://github.com/user-attachments/assets/63b04cf2-e780-49d5-9a3c-733ffe8b76eb
<img width="617" height="511" alt="Screen Shot 2026-05-13 at 1 02 52 PM" src="https://github.com/user-attachments/assets/79dc772f-c066-4afe-8f68-f90cae857a2a" />

## Notes
Related to: https://github.com/TACC/tup-services/pull/57 