### PR TITLE
task/WP-allow-hetdex-email-list

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -89,7 +89,6 @@ def add_user_hetdex_allocation(form_data, request):
                            headers=headers,
                            json=data,
                            params=admin_params)
-    
     email_body = f"""
             <p>Greetings,</p>
             <p>
@@ -104,7 +103,6 @@ def add_user_hetdex_allocation(form_data, request):
             label = reverse_slugify(key) if key != 'form_id' else 'Form ID'
             value = form_data[key]
             email_body += f"<p><b>{label}</b>: {value}</p>\n"
-    
     if response.status_code != 200:
         # Add error information to the email body
         email_body += f"""
@@ -112,20 +110,19 @@ def add_user_hetdex_allocation(form_data, request):
             <p>Status Code: {response.status_code}</p>
             <p>Response Text: {response.text}</p>
             """
-        
         # Send email with "ATTENTION REQUIRED" subject line
         send_mail(
             f"ATTENTION REQUIRED: HETDEX JupyterHub Access Request Failed",
             email_body,
             settings.DEFAULT_FROM_EMAIL,
-            [settings.HETDEX_ADMIN_EMAIL],
+            settings.HETDEX_ADMIN_EMAIL,
             html_message=email_body)
     else:
         send_mail(
             f"HETDEX JupyterHub Access Request Successful",
             email_body,
             settings.DEFAULT_FROM_EMAIL,
-            [settings.HETDEX_ADMIN_EMAIL],
+            settings.HETDEX_ADMIN_EMAIL,
             html_message=email_body)
 
 def callback(form, cleaned_data, request, **kwargs):


### PR DESCRIPTION
## Overview

## Related



## Changes
Remove brackets from settings.HETDEX_EMAIL to allow for a list of emails.

## Testing

1. In apps/tup_cms/taccsite_cms/secrets.py, add a list of emails that you can check to verify the email was sent.
2. Create a page with form in CMS called "hetdex-request-form" and submit
3. Navigate to your dashboard -> Projects and Allocations
4. Check that you are added to the project
5. CMS can email the list of emails the form fields and submission data

## UI
<img width="1280" height="775" alt="image" src="https://github.com/user-attachments/assets/5cc846a0-a90b-48c7-92d2-5c949621c6c1" />

## Notes
