### PR TITLE
chore(cms): delete hotjar script

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/assets_custom.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/assets_custom.html
@@ -18,18 +18,6 @@
 
 {# NEW CODE #}
 
-<!-- Hotjar Tracking Code for TACC -->
-<script id="js-hotjar-tracking">
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:3319380,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
-
 <!-- TUP CMS UX Scripts -->
 <script src="{% static 'tup_cms/js/modules/breadcrumbs.js' %}" type="module"></script>
 


### PR DESCRIPTION
## Overview

Delete Hotjar. We are not using it.

## Related

- we do not renew paid service

## Changes

- **deletes** a script

## Testing

1. Verify code (e.g. `js-hotjar-tracking`) is not present.

## UI

Skipped.