### PR TITLE
WP-1304: Add MFA banner to TUP

### DIFF
--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:d918bc67
+FROM taccwma/core-cms:v4.39.1
 
 WORKDIR /code
 

--- a/apps/tup-cms/Dockerfile
+++ b/apps/tup-cms/Dockerfile
@@ -7,7 +7,7 @@ COPY . /code/
 RUN npx nx build tup-ui
 RUN npx nx build tup-cms-react
 
-FROM taccwma/core-cms:v4.39.1
+FROM taccwma/core-cms:d918bc67
 
 WORKDIR /code
 

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
@@ -39,10 +39,18 @@
 .panels > :nth-child(2) { grid-area: systems; }
 .panels > :nth-child(3) { grid-area: projects_tickets; }
 
+.mfa-banner {
+  margin-bottom: 1.5rem;
+  font-size: var(--global-font-size--medium);
+}
+
+.dashboard-title {
+  margin-top: 2.5rem;
+}
 
 .section {
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto auto 1fr;
   padding: var(--global-space--section)
 }
 

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.module.css
@@ -40,7 +40,6 @@
 .panels > :nth-child(3) { grid-area: projects_tickets; }
 
 .mfa-banner {
-  margin-bottom: 1.5rem;
   font-size: var(--global-font-size--medium);
 }
 
@@ -50,8 +49,12 @@
 
 .section {
   display: grid;
-  grid-template-rows: auto auto 1fr;
+  grid-template-rows: auto 1fr;
   padding: var(--global-space--section)
+}
+
+.section:has(.mfa-banner) {
+  grid-template-rows: auto auto 1fr;
 }
 
 

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
@@ -8,7 +8,6 @@ import {
   UserNews,
 } from '@tacc/tup-components';
 
-import '@tacc/core-styles/dist/components/c-message.css';
 import './Dashboard.css';
 import styles from './Dashboard.module.css';
 import { Outlet } from 'react-router-dom';
@@ -28,7 +27,7 @@ const Layout: React.FC = () => {
     <RequireAuth>
       <section className={`c-page ${styles.section}`}>
         <SectionMessage
-          className={`c-message c-message--scope-section c-message--type-warning ${styles['mfa-banner']}`}
+          className={styles['mfa-banner']}
           type="warning"
           canDismiss
         >
@@ -37,7 +36,7 @@ const Layout: React.FC = () => {
           <a
             href="https://docs.tacc.utexas.edu/basics/mfa/"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener"
           >
             set up your MFA
           </a>{' '}

--- a/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/tup-ui/src/pages/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { SectionHeader } from '@tacc/core-components';
+import { SectionHeader, SectionMessage } from '@tacc/core-components';
 import {
   RequireAuth,
   SystemMonitor,
@@ -8,6 +8,7 @@ import {
   UserNews,
 } from '@tacc/tup-components';
 
+import '@tacc/core-styles/dist/components/c-message.css';
 import './Dashboard.css';
 import styles from './Dashboard.module.css';
 import { Outlet } from 'react-router-dom';
@@ -26,7 +27,25 @@ const Layout: React.FC = () => {
   return (
     <RequireAuth>
       <section className={`c-page ${styles.section}`}>
-        <SectionHeader>Dashboard</SectionHeader>
+        <SectionMessage
+          className={`c-message c-message--scope-section c-message--type-warning ${styles['mfa-banner']}`}
+          type="warning"
+          canDismiss
+        >
+          The portal will require Multi-Factor Authentication (MFA) beginning{' '}
+          <strong>August 18, 2026</strong>. Please{' '}
+          <a
+            href="https://docs.tacc.utexas.edu/basics/mfa/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            set up your MFA
+          </a>{' '}
+          to avoid disruption in access.
+        </SectionMessage>
+        <SectionHeader className={styles['dashboard-title']}>
+          Dashboard
+        </SectionHeader>
         <main className={styles.panels}>
           <UserNews />
           <SystemMonitor />

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
@@ -9,6 +9,12 @@
   display: unset;
 }
 
+.mfa-banner {
+  box-sizing: border-box;
+  width: 100%;
+  margin-bottom: 2rem;
+}
+
 /* When (the only known) error would wrap, move all lines to one line */
 @media screen and (max-width: 435px) {
   .root :global(.c-form-errors) br { content: ""; } /* to remove new line */

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.module.css
@@ -10,8 +10,7 @@
 }
 
 .mfa-banner {
-  box-sizing: border-box;
-  width: 100%;
+  composes: c-message c-message--type-warning c-message--scope-section from '@tacc/core-styles/dist/components/c-message.css';
   margin-bottom: 2rem;
 }
 

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.spec.tsx
@@ -97,20 +97,24 @@ describe('LoginComponent', () => {
     const { getByText, getAllByRole } = testRender(<LoginComponent />);
     await waitFor(() => getAllByRole('link'));
     const links: HTMLElement[] = getAllByRole('link');
-    expect(getByText('Create Account')).toBeDefined();
+    expect(getByText('set up your MFA')).toBeDefined();
     expect(links[0].getAttribute('href')).toEqual(
+      'https://docs.tacc.utexas.edu/basics/mfa/'
+    );
+    expect(getByText('Create Account')).toBeDefined();
+    expect(links[1].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/register'
     );
     expect(getByText('Account Help')).toBeDefined();
-    expect(links[1].getAttribute('href')).toEqual(
+    expect(links[2].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/login_support'
     );
     expect(getByText('Forgot Password')).toBeDefined();
-    expect(links[2].getAttribute('href')).toEqual(
+    expect(links[3].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/forgot_password'
     );
     expect(getByText('Recover Username')).toBeDefined();
-    expect(links[3].getAttribute('href')).toEqual(
+    expect(links[4].getAttribute('href')).toEqual(
       'https://accounts.tacc.utexas.edu/forgot_username'
     );
   });

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@tacc/tup-hooks';
 import { Formik, Form } from 'formik';
 import { FormikInput } from '@tacc/core-wrappers';
 import { Button } from '@tacc/core-components';
+import '@tacc/core-styles/dist/components/c-message.css';
 import styles from './LoginComponent.module.css';
 import { blackLogo } from '../../../assets';
 import { AxiosError } from 'axios';
@@ -133,6 +134,23 @@ const ForgotUsernameLink = () => (
   </a>
 );
 
+const MfaBanner = () => (
+  <div
+    className={`c-message c-message--scope-section c-message--type-warning ${styles['mfa-banner']}`}
+  >
+    The portal will require Multi-Factor Authentication (MFA) beginning{' '}
+    <strong>August 18, 2026</strong>. Please{' '}
+    <a
+      href="https://docs.tacc.utexas.edu/basics/mfa/"
+      target="_blank"
+      rel="noreferrer"
+    >
+      set up your MFA
+    </a>{' '}
+    to avoid disruption in access.
+  </div>
+);
+
 const LoginComponent: React.FC<LoginProps> = ({ className }) => {
   const location = useLocation();
   const [searchParams] = useSearchParams();
@@ -182,6 +200,7 @@ const LoginComponent: React.FC<LoginProps> = ({ className }) => {
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form className="c-form">
           <LoginError status={status} isError={isError} />
+          <MfaBanner />
           <FormikInput
             name="username"
             label="Username or Email"

--- a/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
+++ b/libs/tup-components/src/auth/LoginComponent/LoginComponent.tsx
@@ -4,7 +4,6 @@ import { useAuth } from '@tacc/tup-hooks';
 import { Formik, Form } from 'formik';
 import { FormikInput } from '@tacc/core-wrappers';
 import { Button } from '@tacc/core-components';
-import '@tacc/core-styles/dist/components/c-message.css';
 import styles from './LoginComponent.module.css';
 import { blackLogo } from '../../../assets';
 import { AxiosError } from 'axios';
@@ -135,15 +134,13 @@ const ForgotUsernameLink = () => (
 );
 
 const MfaBanner = () => (
-  <div
-    className={`c-message c-message--scope-section c-message--type-warning ${styles['mfa-banner']}`}
-  >
+  <div className={styles['mfa-banner']}>
     The portal will require Multi-Factor Authentication (MFA) beginning{' '}
     <strong>August 18, 2026</strong>. Please{' '}
     <a
       href="https://docs.tacc.utexas.edu/basics/mfa/"
       target="_blank"
-      rel="noreferrer"
+      rel="noopener"
     >
       set up your MFA
     </a>{' '}


### PR DESCRIPTION
## Overview
Add banner on TUP Login page announcing turning on MFA on Aug 18

## Related

- [WP-1304](https://tacc-main.atlassian.net/browse/WP-1304)

## Changes

## Testing

1. Verify the Log In page shows the MFA message
2. Verify the link on the Log In page works
3. Once logged in, verify the banner shows above the Dashboard. 
4. Verify the link works. 
5. Verify the banner is dismissible. 


## 

UI
<img width="501" height="334" alt="Screen Shot 2026-06-18 at 2 07 21 PM" src="https://github.com/user-attachments/assets/60219a5d-2925-4284-9cda-4ec0250bb294" />
<img width="985" height="131" alt="Screen Shot 2026-06-18 at 2 07 37 PM" src="https://github.com/user-attachments/assets/6af1c705-3850-42db-be13-ed9ea8b568e2" />

## Notes
