### PR TITLE
feat(cms): support confirmation email for new form

### DIFF
--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -49,9 +49,8 @@ def send_confirmation_email(form_name, form_data):
 
     tour_receipt = ""
     if form_name in (
-      "Tour Request Form",
-      "Request to Film Form")
-    :
+            "Tour Request Form",
+            "Request to Film Form"):
         tour_receipt = "<p>A copy of your request is provided below for your records:</p>\n"
         for key in form_data:
             if not key.startswith('recaptcha_'):

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -52,7 +52,6 @@ def submit_ticket(form_data):
 def send_confirmation_email(form_name, form_data):
     form_display_name = FORM_DISPLAY_NAMES.get(form_name, form_name)
 
-
     tour_receipt = ""
     if form_name in (
             "Tour Request Form",

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -15,7 +15,7 @@ if settings.DEBUG:
 hetdex_allocation = 66657
 
 FORM_DISPLAY_NAMES = {
-    "film-request-form": "Request to Film Form",
+    "film-request-form": "Request to Film form",
 }
 
 QUEUE_MAP = {

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -48,8 +48,11 @@ def submit_ticket(form_data):
 def send_confirmation_email(form_name, form_data):
 
     tour_receipt = ""
-    if form_name == "Tour Request Form":
-        tour_receipt = "<p>A copy of your tour request is provided below for your records:</p>\n"
+    if form_name in (
+      "Tour Request Form",
+      "Request to Film Form")
+    :
+        tour_receipt = "<p>A copy of your request is provided below for your records:</p>\n"
         for key in form_data:
             if not key.startswith('recaptcha_'):
                 label = reverse_slugify(key) if key != 'form_id' else 'Form ID'

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -14,6 +14,10 @@ if settings.DEBUG:
     service_url = service_url.replace("localhost", "host.docker.internal")
 hetdex_allocation = 66657
 
+FORM_DISPLAY_NAMES = {
+    "film-request-form": "Request to Film Form",
+}
+
 QUEUE_MAP = {
     "Allocations": "Allocations",
     "Login Issues": "Accounts",
@@ -46,6 +50,8 @@ def submit_ticket(form_data):
 
 
 def send_confirmation_email(form_name, form_data):
+    form_display_name = FORM_DISPLAY_NAMES.get(form_name, form_name)
+
 
     tour_receipt = ""
     if form_name in (
@@ -61,7 +67,7 @@ def send_confirmation_email(form_name, form_data):
     email_body = f"""
             <p>Greetings,</p>
             <p>
-                Thank you for reaching out to TACC and completing the {form_name}.
+                Thank you for reaching out to TACC and completing the {form_display_name}.
             </p>
             <p>
                 <ul>
@@ -77,7 +83,7 @@ def send_confirmation_email(form_name, form_data):
             </p>
             """
     send_mail(
-    f"TACC Form Submission Received: {form_name}",
+    f"TACC Form Submission Received: {form_display_name}",
     email_body,
     settings.DEFAULT_FROM_EMAIL,
     [form_data["email"]],

--- a/apps/tup-cms/src/apps/portal/apps.py
+++ b/apps/tup-cms/src/apps/portal/apps.py
@@ -50,7 +50,7 @@ def send_confirmation_email(form_name, form_data):
     tour_receipt = ""
     if form_name in (
             "Tour Request Form",
-            "Request to Film Form"):
+            "film-request-form"):
         tour_receipt = "<p>A copy of your request is provided below for your records:</p>\n"
         for key in form_data:
             if not key.startswith('recaptcha_'):


### PR DESCRIPTION
## Overview

Adds data to form submission confirmation email for new `film-request-form`.

## Related

- [RT #42100](https://tickets.tacc.utexas.edu/Ticket/Display.html?id=42100)

## Changes

- **adds** `tour_receipt` for `film-request-form`

## Testing

> [!IMPORTANT]
> The form must be created in the CMS admin with the exact name `film-request-form`.

> [!TIP]
> I tested with [a form on dev site](https://dev.tup.tacc.utexas.edu/test/form/film-request-form/).

1. Create/Open a form named `film-request-form`.
2. Enter a valid email address in a field `email`.
3. Verify a receipt email arrives at that address.
4. Verify receipt email has "Request to Film form" as display name.

## UI

### What _They_ Get

<img width="900" height="470" alt="Confirmation Email" src="https://github.com/user-attachments/assets/77ed0f02-952f-4254-af46-2faaf20ed14c" />

### What _We_ Get

<img width="900" height="260" alt="Internal Submission" src="https://github.com/user-attachments/assets/d0015260-963d-440a-b3a0-8128cbafa171" />