### PR TITLE
refactor(cms): pin snippet to @tacc/sortable-table npm package

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/research-projects-assets.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/research-projects-assets.html
@@ -2,42 +2,16 @@
 {# https://tickets.tacc.utexas.edu/Ticket/Display.html?id=42216 #}
 {# https://github.com/TACC/Core-CMS/pull/1178 #}
 
-{# https://github.com/TACC/Core-CMS/blob/b13909f4/taccsite_cms/templates/includes/sortable_table_filter_templates.html #}
-<template id="sortable-table-filters">
-  <fieldset class="js-sortable-filter-list sortable-filter-list">
-    <legend class="sr-only">Results in the table update as you type or select filters</legend>
-
-    <label class="sortable-filter mr-auto">
-      <i
-        class="icon icon-search icon-md sortable-filter__icon"
-        aria-label="Search"
-      >Search</i>
-      <input
-        type="search"
-        class="sortable-filter__input"
-        placeholder="Search…"
-      />
-      <output class="js-sortable-total text-truncate" aria-atomic="true"></output>
-    </label>
-
-    <label class="sortable-filter">
-      <span class="sortable-filter__label"></span>
-      <select class="sortable-filter__input">
-        <option value="">any</option>
-      </select>
-    </label>
-  </fieldset>
-</template>
-
 <link
   rel="stylesheet"
   id="research-projects-assets-alert-css"
   href="https://cdn.jsdelivr.net/gh/TACC/Core-Styles@v2.57.0/dist/bootstrap4/components/alert.css"
 />
+{# @tacc/sortable-table: wesleyboar/sortable-table@df4d78b8 until 0.1.0 release #}
 <link
   rel="stylesheet"
   id="research-projects-assets-table-css"
-  href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS@v4.40.0-rc6/taccsite_cms/static/site_cms/css/modules/sortableTable.css"
+  href="https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@df4d78b8/src/sortableTable.css"
 />
 <script
   src="https://cdn.jsdelivr.net/npm/list.js@2.3.1/dist/list.min.js"
@@ -48,8 +22,7 @@
   type="module"
   id="research-projects-assets-table-js"
 >
-  {# sortableTable.js: Core-CMS@b13909f4 until release after https://github.com/TACC/Core-CMS/pull/1178 #}
-  import sortableTable from 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS@b13909f4/taccsite_cms/static/site_cms/js/modules/sortableTable.js';
+  import sortableTable from 'https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@df4d78b8/src/sortableTable.js';
 
   sortableTable({
     scopeElement: document.getElementById('cms-content'),

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/research-projects-assets.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/research-projects-assets.html
@@ -27,5 +27,7 @@
   sortableTable({
     scopeElement: document.getElementById('cms-content'),
     buttonClass: 'btn btn-link',
+    searchIconClass: 'icon icon-search icon-md',
+    countClass: 'text-truncate',
   });
 </script>

--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/research-projects-assets.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/research-projects-assets.html
@@ -7,11 +7,11 @@
   id="research-projects-assets-alert-css"
   href="https://cdn.jsdelivr.net/gh/TACC/Core-Styles@v2.57.0/dist/bootstrap4/components/alert.css"
 />
-{# @tacc/sortable-table: wesleyboar/sortable-table@df4d78b8 until 0.1.0 release #}
+{# @tacc/sortable-table: wesleyboar/sortable-table@fb956d9f until 0.1.0 release #}
 <link
   rel="stylesheet"
   id="research-projects-assets-table-css"
-  href="https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@df4d78b8/src/sortableTable.css"
+  href="https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@fb956d9f/src/sortableTable.css"
 />
 <script
   src="https://cdn.jsdelivr.net/npm/list.js@2.3.1/dist/list.min.js"
@@ -22,7 +22,7 @@
   type="module"
   id="research-projects-assets-table-js"
 >
-  import sortableTable from 'https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@df4d78b8/src/sortableTable.js';
+  import sortableTable from 'https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@fb956d9f/src/sortableTable.js';
 
   sortableTable({
     scopeElement: document.getElementById('cms-content'),


### PR DESCRIPTION
## Overview

Updates research-projects snippet to use new [`@tacc/sortable-table`](https://github.com/wesleyboar/sortable-table) instead of Core-CMS files.

## Related

- [`wesleyboar/sortable-table`](https://github.com/wesleyboar/sortable-table) (the new package)
- updates #558
- mimics https://github.com/TACC/Core-CMS#1202

## Changes

- **updated** `research-projects-assets.html`
- **deleted** `<template>` cuz package self-injects it now

## Notes

> [!IMPORTANT]
> jsDelivr SHA pin (`df4d78b8`) will be updated to a versioned npm URL after `@tacc/sortable-table@0.1.0` is published.