### PR TITLE
refactor(cms): sortableTable, use data-* attrs API

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/research-projects-assets.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/research-projects-assets.html
@@ -7,11 +7,11 @@
   id="research-projects-assets-alert-css"
   href="https://cdn.jsdelivr.net/gh/TACC/Core-Styles@v2.57.0/dist/bootstrap4/components/alert.css"
 />
-{# @tacc/sortable-table: wesleyboar/sortable-table@fb956d9f until 0.1.0 release #}
+{# @tacc/sort-table: wesleyboar/sort-table@e63f5427 until 0.1.0 release #}
 <link
   rel="stylesheet"
   id="research-projects-assets-table-css"
-  href="https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@fb956d9f/src/sortableTable.css"
+  href="https://cdn.jsdelivr.net/gh/wesleyboar/sort-table@e63f5427/src/sortableTable.css"
 />
 <script
   src="https://cdn.jsdelivr.net/npm/list.js@2.3.1/dist/list.min.js"
@@ -22,7 +22,7 @@
   type="module"
   id="research-projects-assets-table-js"
 >
-  import sortableTable from 'https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@fb956d9f/src/sortableTable.js';
+  import sortableTable from 'https://cdn.jsdelivr.net/gh/wesleyboar/sort-table@e63f5427/src/sortableTable.js';
 
   sortableTable({
     scopeElement: document.getElementById('cms-content'),


### PR DESCRIPTION
## Overview

Updates snippet to use the new `data-sortable-search` / `data-sortable-select-cols` attribute API and bumps the CDN pin to `wesleyboar/sort-table@e63f5427`.

## Related

- updates #558
- mimics https://github.com/TACC/Core-CMS/pull/1203
- requires https://github.com/wesleyboar/sort-table/pull/3

## Changes

- **updated** comment and CDN pin from `wesleyboar/sortable-table@fb956d9f` to `wesleyboar/sort-table@e63f5427`

## Notes

> [!IMPORTANT]
> jsDelivr SHA pin will be updated to a versioned npm URL after `@tacc/sort-table@0.1.0` is published.
> The CMS page's `data-sortable-filters` attribute must be updated manually in WYSIWYG to use the new `data-sortable-search` / `data-sortable-select-cols` attrs.