### PR TITLE
fix(cms): a11y for form validation UI

### DIFF
--- a/apps/tup-cms/src/taccsite_cms/templates/snippets/js-ad-hoc-scripts.html
+++ b/apps/tup-cms/src/taccsite_cms/templates/snippets/js-ad-hoc-scripts.html
@@ -4,7 +4,5 @@ One <script> that loads script with many 'import's is faster than many <script>s
 
 <script src="https://cdn.jsdelivr.net/gh/TACC/tup-ui@460405e9/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/js/ad-hoc.js" type="module"></script>
 
-{% comment %}
-If this works, delete `js-prevent-ugly-urls`:
-https://tacc.utexas.edu/admin/djangocms_snippet/snippet/150/change/
-{% endcomment %}
+{# To make form validation UI accessible #}
+<script id="search-form-a11y-fix" src="https://cdn.jsdelivr.net/gh/oliverjam/learn-form-validation@main/solution/index.html"></script>


### PR DESCRIPTION
## Overview

Add script so our form validation UI is accessible.

> [!CAUTION]
> Script alone does nothing. Requires markup changes ([example](https://github.com/oliverjam/learn-form-validation/blob/1994297/README.md?plain=1#L50-L60)).

## Related

- [TACC Website Accessibility Issue Reported by Acquia](https://new.monsido.com/25546/domains/79221/accessibility/issues)
    > Are input errors described in text?
    > <sup>652 pages found</sup>

## Changes

- **added** a global script

## Testing

0. Visit https://tacc.utexas.edu/.
1. Open browser's Developer Tools' Elements panel.
2. In that panel:
    1. Turn on Accessibility Tree.
    2. Scroll to top of the tree.
3. In the webpage, focus on search form.
4. Submit form with invalid content.\
    <sup>(blank **or** less than three characters)</sup>
5. **Verify** Accessibility Tree shows `alert`.
6. Change how the content is invalid.
7. **Verify** Accessibility Tree `alert` changes.

## UI

…

## Notes

https://oliverjam.com/articles/better-native-form-validation
